### PR TITLE
Update navigation module structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ This is my playground for learning Kotlin Multiplatform. With that said, I'm sur
 ### Opening iOS Project
 - Navigate to the ios directory & open `.xcodeproj`
 
+## Architecture Overview
+- [ ] TODO: Add detail architecture
+
+![TvManiac Architecture](https://github.com/thomaskioko/tv-maniac/assets/841885/a5a9bfc9-6caf-4b4a-a8be-c8b0d7331543)
+
+
 ### Android Screenshots
 
 <table>
@@ -91,8 +97,6 @@ This is my playground for learning Kotlin Multiplatform. With that said, I'm sur
   </td>
 </tr>
 </table>
-
-
 
 ## Libraries Used
 ### Android

--- a/README.md
+++ b/README.md
@@ -11,26 +11,21 @@ TvManiac
 ## 🚧 Under Heavy Development 🚧
 This is my playground for learning Kotlin Multiplatform. With that said, I'm sure it's filled with bugs crawling everywhere, and I'm probably doing a couple of things wrong. So a lot is changing, but that shouldn't stop you from checking it out.
 
-| Android | iOS | 
-| -- | -- | 
+| Android | iOS |
+| -- | -- |
 | <video src="https://github.com/thomaskioko/tv-maniac/assets/841885/a9991256-27a8-4a99-87f3-0f071c7cbc68" width=350/> | <video src="https://github.com/thomaskioko/tv-maniac/assets/841885/45fa6cd7-6bca-4baa-ad71-93339986ef12" width=350/> |
+
+
+> [!IMPORTANT]
+>  To fetch data, you will need to [create a TMDB API app](https://www.themoviedb.org/settings/api) and generate an API key if you don't have one.  Once you have your keys, add them to `config.yaml`. If the file is unavailable, navigate to the root dir and create a symlink.
+> `$ ln -s core/util/src/commonMain/resources/config.yaml config.yaml`, then add the API keys.
 
 ## 🖥 Project Setup & Environment
 
 #### Requirements
 - [Zulu Java 17](https://www.azul.com/downloads/?package=jdk#zulu)
 - You require the latest [Android Studio](https://developer.android.com/studio/preview) release to be able to build the app.
-- Install KMP Plugin. Checkout [this setup guide](https://kotlinlang.org/docs/multiplatform-mobile-setup.html).
-
-### API Keys
-To use the TMDB API, you'll need to [create a new API app](https://www.themoviedb.org/settings/api) and generate an API key if you don't have one.
-Once you have your keys, add them to `config.yaml`. If the file is unavailable, navigate to the root dir and create a symlink.
-
-`ln -s core/util/src/commonMain/resources/config.yaml config.yaml`
-
-```
-tmdbApiKey: "PUT_API_KEY_HERE"
-```
+- Install KMM Plugin. Checkout [this setup guide](https://kotlinlang.org/docs/multiplatform-mobile-setup.html).
 
 ### Opening iOS Project
 - Navigate to the ios directory & open `.xcodeproj`
@@ -108,7 +103,7 @@ tmdbApiKey: "PUT_API_KEY_HERE"
 * [AppAuth](https://openid.github.io/AppAuth-Android/) - AppAuth for Android is a client SDK for communicating with OAuth 2.0 and OpenID Connect providers.
 * [Compose Lints](https://slackhq.github.io/compose-lints/) - Custom lint checks for Jetpack Compose.
 * [Jetpack Compose](https://developer.android.com/jetpack/compose)
-    * [Coil](https://coil-kt.github.io/coil/compose/) - Image loading
+  * [Coil](https://coil-kt.github.io/coil/compose/) - Image loading
 * [KenBurnsView](https://github.com/flavioarfaria/KenBurnsView) - Immersive image.
 * [Leakcanary](https://github.com/square/leakcanary) - Memory leak detection.
 
@@ -124,7 +119,7 @@ tmdbApiKey: "PUT_API_KEY_HERE"
 * [Kotest Assertions](https://kotest.io/docs/assertions/assertions.html) - Testing
 * [Multiplatform Paging](https://github.com/cashapp/multiplatform-paging) A library that adds additional Kotlin/Multiplatform targets to AndroidX Paging, and provides UI components to use Paging on iOS.
 * [SQLDelight](https://github.com/cashapp/sqldelight/) - Local storage
-    - [Coroutines Extensions](https://cashapp.github.io/sqldelight/js_sqlite/coroutines/) Consume queries as Flow
+  - [Coroutines Extensions](https://cashapp.github.io/sqldelight/js_sqlite/coroutines/) Consume queries as Flow
 
 
 ### iOS
@@ -159,6 +154,7 @@ iOS
 - [x] Implement trakt auth & sign in
 - [x] Update show detail UI
 - [x] Add Seasons Detail UI
+- [ ] Implement Paging
 - [ ] Add Episode detail screen
 - [ ] Add Watchlist
 - [ ] Implement Search

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -26,6 +26,14 @@ android {
 
 dependencies {
   implementation(projects.android.designsystem)
+  implementation(projects.android.feature.discover)
+  implementation(projects.android.feature.library)
+  implementation(projects.android.feature.moreShows)
+  implementation(projects.android.feature.search)
+  implementation(projects.android.feature.seasonDetails)
+  implementation(projects.android.feature.settings)
+  implementation(projects.android.feature.showDetails)
+  implementation(projects.android.feature.trailers)
   implementation(projects.shared)
   implementation(projects.core.base)
   implementation(projects.core.traktAuth.api)

--- a/android/app/src/main/kotlin/com/thomaskioko/tvmaniac/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/thomaskioko/tvmaniac/MainActivity.kt
@@ -59,7 +59,7 @@ class MainActivity : ComponentActivity() {
         onDispose {}
       }
 
-      TvManiacTheme(darkTheme = darkTheme) { component.rootScreen() }
+      TvManiacTheme(darkTheme = darkTheme) { RootScreen(presenter = component.presenter) }
     }
   }
 }

--- a/android/app/src/main/kotlin/com/thomaskioko/tvmaniac/RootScreen.kt
+++ b/android/app/src/main/kotlin/com/thomaskioko/tvmaniac/RootScreen.kt
@@ -1,4 +1,4 @@
-package com.thomaskioko.tvmaniac.navigation
+package com.thomaskioko.tvmaniac
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
@@ -32,17 +32,15 @@ import com.thomaskioko.tvmaniac.compose.components.TvManiacNavigationBar
 import com.thomaskioko.tvmaniac.discover.DiscoverScreen
 import com.thomaskioko.tvmaniac.feature.moreshows.MoreShowsScreen
 import com.thomaskioko.tvmaniac.library.LibraryScreen
+import com.thomaskioko.tvmaniac.navigation.RootNavigationPresenter
 import com.thomaskioko.tvmaniac.navigation.RootNavigationPresenter.Config
+import com.thomaskioko.tvmaniac.navigation.Screen
 import com.thomaskioko.tvmaniac.resources.R
 import com.thomaskioko.tvmaniac.search.SearchScreen
 import com.thomaskioko.tvmaniac.seasondetails.SeasonDetailsScreen
 import com.thomaskioko.tvmaniac.settings.SettingsScreen
 import com.thomaskioko.tvmaniac.videoplayer.TrailersScreen
-import me.tatarka.inject.annotations.Inject
 
-typealias RootScreen = @Composable () -> Unit
-
-@Inject
 @Composable
 fun RootScreen(presenter: RootNavigationPresenter, modifier: Modifier = Modifier) {
   Surface(modifier = modifier, color = MaterialTheme.colorScheme.background) {

--- a/android/app/src/main/kotlin/com/thomaskioko/tvmaniac/inject/ActivityComponent.kt
+++ b/android/app/src/main/kotlin/com/thomaskioko/tvmaniac/inject/ActivityComponent.kt
@@ -5,7 +5,6 @@ import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.defaultComponentContext
 import com.thomaskioko.tvmaniac.core.base.annotations.ActivityScope
 import com.thomaskioko.tvmaniac.navigation.RootNavigationPresenter
-import com.thomaskioko.tvmaniac.navigation.RootScreen
 import com.thomaskioko.tvmaniac.traktauth.api.TraktAuthManager
 import com.thomaskioko.tvmaniac.traktauth.implementation.TraktAuthManagerComponent
 import me.tatarka.inject.annotations.Component
@@ -22,7 +21,6 @@ abstract class ActivityComponent(
 ) : TraktAuthManagerComponent {
   abstract val traktAuthManager: TraktAuthManager
   abstract val presenter: RootNavigationPresenter
-  abstract val rootScreen: RootScreen
 
   companion object
 }

--- a/navigation/build.gradle.kts
+++ b/navigation/build.gradle.kts
@@ -1,28 +1,10 @@
 plugins {
-  id("plugin.tvmaniac.kotlin.android")
   id("plugin.tvmaniac.multiplatform")
   alias(libs.plugins.serialization)
 }
 
 kotlin {
   sourceSets {
-    androidMain.dependencies {
-      implementation(projects.android.designsystem)
-      implementation(projects.android.resources)
-
-      implementation(projects.android.feature.discover)
-      implementation(projects.android.feature.library)
-      implementation(projects.android.feature.moreShows)
-      implementation(projects.android.feature.search)
-      implementation(projects.android.feature.seasonDetails)
-      implementation(projects.android.feature.settings)
-      implementation(projects.android.feature.showDetails)
-      implementation(projects.android.feature.trailers)
-
-      implementation(libs.androidx.compose.material3)
-      implementation(libs.decompose.extensions.compose)
-    }
-
     commonMain.dependencies {
       implementation(projects.core.base)
       implementation(projects.core.traktAuth.api)
@@ -64,17 +46,4 @@ kotlin {
       implementation(libs.bundles.unittest)
     }
   }
-}
-
-android {
-  namespace = "com.thomaskioko.tvmaniac.navigation"
-
-  buildFeatures { compose = true }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-  }
-
-  composeOptions { kotlinCompilerExtensionVersion = libs.versions.composecompiler.get() }
 }


### PR DESCRIPTION
## Description
This small change moves the `RootScreen` to the Android App module. This leaves the navigation module with navigation logic and no screen composables.