### PR TITLE
chore: DI Integration Cleanup

### DIFF
--- a/core/locale/testing/build.gradle.kts
+++ b/core/locale/testing/build.gradle.kts
@@ -2,11 +2,17 @@ plugins {
     alias(libs.plugins.app.kmp)
 }
 
+scaffold {
+    useMetro()
+}
+
 kotlin {
     sourceSets {
         commonMain {
             dependencies {
+                implementation(projects.core.base)
                 implementation(projects.core.locale.api)
+                implementation(projects.core.locale.implementation)
                 implementation(libs.coroutines.core)
             }
         }

--- a/core/locale/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/locale/testing/FakeLocaleProvider.kt
+++ b/core/locale/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/locale/testing/FakeLocaleProvider.kt
@@ -1,10 +1,18 @@
 package com.thomaskioko.tvmaniac.locale.testing
 
 import com.thomaskioko.tvmaniac.locale.api.LocaleProvider
+import com.thomaskioko.tvmaniac.locale.implementation.DefaultLocaleProvider
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, replaces = [DefaultLocaleProvider::class])
 public class FakeLocaleProvider(
     private val supportedLanguages: List<String> = listOf("en"),
 ) : LocaleProvider {

--- a/core/logger/testing/build.gradle.kts
+++ b/core/logger/testing/build.gradle.kts
@@ -2,10 +2,16 @@ plugins {
     alias(libs.plugins.app.kmp)
 }
 
+scaffold {
+    useMetro()
+}
+
 kotlin {
     sourceSets {
         commonMain.dependencies {
+            implementation(projects.core.base)
             implementation(projects.core.logger.api)
+            implementation(projects.core.logger.implementation)
         }
     }
 }

--- a/core/logger/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/fixture/FakeCrashReporter.kt
+++ b/core/logger/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/fixture/FakeCrashReporter.kt
@@ -1,7 +1,15 @@
 package com.thomaskioko.tvmaniac.core.logger.fixture
 
 import com.thomaskioko.tvmaniac.core.logger.CrashReporter
+import com.thomaskioko.tvmaniac.core.logger.FirebaseCrashLogger
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, replaces = [FirebaseCrashLogger::class])
 public class FakeCrashReporter : CrashReporter {
     override fun setCollectionEnabled(enabled: Boolean) {}
     override fun recordException(throwable: Throwable) {}

--- a/core/logger/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/fixture/FakeLogger.kt
+++ b/core/logger/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/fixture/FakeLogger.kt
@@ -1,7 +1,19 @@
 package com.thomaskioko.tvmaniac.core.logger.fixture
 
+import com.thomaskioko.tvmaniac.core.logger.CompositeLogger
+import com.thomaskioko.tvmaniac.core.logger.KermitLogger
 import com.thomaskioko.tvmaniac.core.logger.Logger
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(
+    AppScope::class,
+    replaces = [CompositeLogger::class, KermitLogger::class],
+)
 public class FakeLogger : Logger {
     override fun setup(debugMode: Boolean) {}
 

--- a/core/notifications/testing/build.gradle.kts
+++ b/core/notifications/testing/build.gradle.kts
@@ -2,10 +2,15 @@ plugins {
     alias(libs.plugins.app.kmp)
 }
 
+scaffold {
+    useMetro()
+}
+
 kotlin {
     sourceSets {
         commonMain {
             dependencies {
+                implementation(projects.core.base)
                 api(projects.core.notifications.api)
             }
         }

--- a/core/notifications/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/notifications/testing/FakeNotificationManager.kt
+++ b/core/notifications/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/notifications/testing/FakeNotificationManager.kt
@@ -2,7 +2,14 @@ package com.thomaskioko.tvmaniac.core.notifications.testing
 
 import com.thomaskioko.tvmaniac.core.notifications.api.EpisodeNotification
 import com.thomaskioko.tvmaniac.core.notifications.api.NotificationManager
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
 public class FakeNotificationManager : NotificationManager {
     private val scheduledNotifications = mutableMapOf<Long, EpisodeNotification>()
 

--- a/core/tasks/testing/build.gradle.kts
+++ b/core/tasks/testing/build.gradle.kts
@@ -2,9 +2,14 @@ plugins {
     alias(libs.plugins.app.kmp)
 }
 
+scaffold {
+    useMetro()
+}
+
 kotlin {
     sourceSets {
         commonMain.dependencies {
+            implementation(projects.core.base)
             implementation(projects.core.tasks.api)
         }
     }

--- a/core/tasks/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/tasks/testing/FakeBackgroundTaskScheduler.kt
+++ b/core/tasks/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/tasks/testing/FakeBackgroundTaskScheduler.kt
@@ -2,7 +2,14 @@ package com.thomaskioko.tvmaniac.core.tasks.testing
 
 import com.thomaskioko.tvmaniac.core.tasks.api.BackgroundTaskScheduler
 import com.thomaskioko.tvmaniac.core.tasks.api.PeriodicTaskRequest
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
 public class FakeBackgroundTaskScheduler : BackgroundTaskScheduler {
     override fun schedulePeriodic(request: PeriodicTaskRequest) {}
     override fun scheduleAndExecute(request: PeriodicTaskRequest) {}

--- a/core/testing/di/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testing/di/FakeAppBindings.kt
+++ b/core/testing/di/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testing/di/FakeAppBindings.kt
@@ -7,8 +7,6 @@ import com.arkivanov.decompose.router.slot.dismiss
 import com.arkivanov.decompose.router.stack.StackNavigation
 import com.thomaskioko.root.nav.NotificationRationale
 import com.thomaskioko.tvmaniac.appconfig.ApplicationInfo
-import com.thomaskioko.tvmaniac.appconfig.DefaultTmdbConfig
-import com.thomaskioko.tvmaniac.appconfig.DefaultTraktConfig
 import com.thomaskioko.tvmaniac.appconfig.Platform
 import com.thomaskioko.tvmaniac.core.base.ComputationCoroutineScope
 import com.thomaskioko.tvmaniac.core.base.IoCoroutineScope
@@ -17,22 +15,6 @@ import com.thomaskioko.tvmaniac.core.base.TmdbApi
 import com.thomaskioko.tvmaniac.core.base.TraktApi
 import com.thomaskioko.tvmaniac.core.base.di.BaseBindingContainer
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
-import com.thomaskioko.tvmaniac.core.logger.CompositeLogger
-import com.thomaskioko.tvmaniac.core.logger.CrashReporter
-import com.thomaskioko.tvmaniac.core.logger.FirebaseCrashLogger
-import com.thomaskioko.tvmaniac.core.logger.KermitLogger
-import com.thomaskioko.tvmaniac.core.logger.Logger
-import com.thomaskioko.tvmaniac.core.logger.fixture.FakeCrashReporter
-import com.thomaskioko.tvmaniac.core.logger.fixture.FakeLogger
-import com.thomaskioko.tvmaniac.core.notifications.api.NotificationManager
-import com.thomaskioko.tvmaniac.core.tasks.api.BackgroundTaskScheduler
-import com.thomaskioko.tvmaniac.core.tasks.testing.FakeBackgroundTaskScheduler
-import com.thomaskioko.tvmaniac.data.user.api.UserRepository
-import com.thomaskioko.tvmaniac.data.user.implementation.DefaultUserRepository
-import com.thomaskioko.tvmaniac.data.user.testing.FakeUserRepository
-import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
-import com.thomaskioko.tvmaniac.datastore.implementation.DefaultDatastoreRepository
-import com.thomaskioko.tvmaniac.datastore.testing.FakeDatastoreRepository
 import com.thomaskioko.tvmaniac.discover.nav.DiscoverNavigator
 import com.thomaskioko.tvmaniac.discover.presenter.di.DefaultDiscoverNavigator
 import com.thomaskioko.tvmaniac.domain.library.LibrarySyncWorker
@@ -42,8 +24,6 @@ import com.thomaskioko.tvmaniac.espisodedetails.nav.model.EpisodeSheetConfig
 import com.thomaskioko.tvmaniac.genreshows.nav.GenreShowsRoute
 import com.thomaskioko.tvmaniac.home.nav.HomeTabNavigator
 import com.thomaskioko.tvmaniac.home.nav.di.model.HomeConfig
-import com.thomaskioko.tvmaniac.locale.api.LocaleProvider
-import com.thomaskioko.tvmaniac.locale.testing.FakeLocaleProvider
 import com.thomaskioko.tvmaniac.navigation.DefaultNavRouteSerializer
 import com.thomaskioko.tvmaniac.navigation.DefaultNavigator
 import com.thomaskioko.tvmaniac.navigation.DefaultSheetConfigSerializer
@@ -64,26 +44,8 @@ import com.thomaskioko.tvmaniac.presenter.root.DefaultRootPresenter
 import com.thomaskioko.tvmaniac.presenter.root.RootPresenter
 import com.thomaskioko.tvmaniac.presenter.root.di.DefaultNotificationRationale
 import com.thomaskioko.tvmaniac.presenter.root.di.DefaultSheetNavigator
-import com.thomaskioko.tvmaniac.requestmanager.testing.FakeRequestManagerRepository
-import com.thomaskioko.tvmaniac.resourcemanager.api.RequestManagerRepository
-import com.thomaskioko.tvmaniac.resourcemanager.implementation.DefaultRequestManagerRepository
-import com.thomaskioko.tvmaniac.syncactivity.api.TraktActivityRepository
-import com.thomaskioko.tvmaniac.syncactivity.implementation.DefaultTraktActivityRepository
-import com.thomaskioko.tvmaniac.syncactivity.testing.FakeTraktActivityRepository
-import com.thomaskioko.tvmaniac.tmdb.api.TmdbConfig
-import com.thomaskioko.tvmaniac.trakt.api.TraktConfig
-import com.thomaskioko.tvmaniac.traktauth.api.TraktAuthManager
-import com.thomaskioko.tvmaniac.traktauth.api.TraktAuthRepository
-import com.thomaskioko.tvmaniac.traktauth.implementation.DefaultTraktAuthRepository
 import com.thomaskioko.tvmaniac.traktauth.implementation.TokenRefreshWorker
-import com.thomaskioko.tvmaniac.traktauth.testing.FakeTraktAuthManager
-import com.thomaskioko.tvmaniac.traktauth.testing.FakeTraktAuthRepository
-import com.thomaskioko.tvmaniac.traktlists.api.TraktListRepository
-import com.thomaskioko.tvmaniac.traktlists.implementation.DefaultTraktListRepository
-import com.thomaskioko.tvmaniac.traktlists.testing.FakeTraktListRepository
 import com.thomaskioko.tvmaniac.util.api.AppUtils
-import com.thomaskioko.tvmaniac.util.api.FormatterUtil
-import com.thomaskioko.tvmaniac.util.testing.FakeFormatterUtil
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
@@ -103,17 +65,6 @@ import kotlinx.coroutines.flow.flowOf
     AppScope::class,
     replaces = [
         BaseBindingContainer::class,
-        DefaultDatastoreRepository::class,
-        DefaultUserRepository::class,
-        DefaultRequestManagerRepository::class,
-        DefaultTmdbConfig::class,
-        DefaultTraktActivityRepository::class,
-        DefaultTraktAuthRepository::class,
-        DefaultTraktConfig::class,
-        DefaultTraktListRepository::class,
-        CompositeLogger::class,
-        KermitLogger::class,
-        FirebaseCrashLogger::class,
         EpisodeNotificationWorker::class,
         LibrarySyncWorker::class,
         TokenRefreshWorker::class,
@@ -125,47 +76,15 @@ import kotlinx.coroutines.flow.flowOf
     ],
 )
 public object FakeAppBindings {
-    @Provides
-    @SingleIn(AppScope::class)
-    public fun provideDatastoreRepository(): DatastoreRepository = FakeDatastoreRepository()
-
-    @Provides
-    @SingleIn(AppScope::class)
-    public fun provideTraktAuthManager(): TraktAuthManager = FakeTraktAuthManager()
-
-    @Provides
-    @SingleIn(AppScope::class)
-    public fun provideTraktAuthRepository(): TraktAuthRepository = FakeTraktAuthRepository()
-
-    @Provides
-    @SingleIn(AppScope::class)
-    public fun provideLogger(): Logger = FakeLogger()
-
-    @Provides
-    @SingleIn(AppScope::class)
-    public fun provideUserRepository(): UserRepository = FakeUserRepository()
-
-    @Provides
-    @SingleIn(AppScope::class)
-    public fun provideTraktListRepository(): TraktListRepository = FakeTraktListRepository()
-
-    @Provides
-    @SingleIn(AppScope::class)
-    public fun provideRequestManagerRepository(): RequestManagerRepository = FakeRequestManagerRepository()
-
-    @Provides
-    @SingleIn(AppScope::class)
-    public fun provideTraktActivityRepository(): TraktActivityRepository =
-        FakeTraktActivityRepository()
 
     @Provides
     @SingleIn(AppScope::class)
     public fun provideAppCoroutineDispatchers(): AppCoroutineDispatchers = AppCoroutineDispatchers(
-        io = Dispatchers.Default,
-        computation = Dispatchers.Default,
-        databaseWrite = Dispatchers.Default,
-        databaseRead = Dispatchers.Default,
-        main = Dispatchers.Default,
+        io = Dispatchers.Main,
+        computation = Dispatchers.Main,
+        databaseWrite = Dispatchers.Main,
+        databaseRead = Dispatchers.Main,
+        main = Dispatchers.Main,
     )
 
     @Provides
@@ -203,20 +122,6 @@ public object FakeAppBindings {
 
     @Provides
     @SingleIn(AppScope::class)
-    public fun provideTmdbConfig(): TmdbConfig = object : TmdbConfig {
-        override val apiKey: String = "fake-tmdb-api-key"
-    }
-
-    @Provides
-    @SingleIn(AppScope::class)
-    public fun provideTraktConfig(): TraktConfig = object : TraktConfig {
-        override val clientId: String = "fake-trakt-client-id"
-        override val clientSecret: String = "fake-trakt-client-secret"
-        override val redirectUri: String = "tvmaniac://auth"
-    }
-
-    @Provides
-    @SingleIn(AppScope::class)
     @TmdbApi
     public fun provideTmdbHttpClientEngine(): io.ktor.client.engine.HttpClientEngine =
         MockEngine { respond("{}", HttpStatusCode.OK) }
@@ -228,31 +133,10 @@ public object FakeAppBindings {
         MockEngine { respond("{}", HttpStatusCode.OK) }
 
     @Provides
-    @SingleIn(AppScope::class)
-    public fun provideNotificationManager(): NotificationManager =
-        com.thomaskioko.tvmaniac.core.notifications.testing.FakeNotificationManager()
-
-    @Provides
-    @SingleIn(AppScope::class)
-    public fun provideLocaleProvider(): LocaleProvider = FakeLocaleProvider()
-
-    @Provides
-    @SingleIn(AppScope::class)
-    public fun provideCrashReporter(): CrashReporter = FakeCrashReporter()
-
-    @Provides
-    @SingleIn(AppScope::class)
-    public fun provideBackgroundTaskScheduler(): BackgroundTaskScheduler = FakeBackgroundTaskScheduler()
-
-    @Provides
     public fun provideAppUtils(): AppUtils = object : AppUtils {
         override fun isYoutubePlayerInstalled(): Flow<Boolean> =
             flowOf(false)
     }
-
-    @Provides
-    public fun provideFormatterUtil(): FormatterUtil =
-        FakeFormatterUtil()
 
     @Provides
     @SingleIn(AppScope::class)

--- a/core/testing/di/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testing/di/FakeAppConfigBindings.kt
+++ b/core/testing/di/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testing/di/FakeAppConfigBindings.kt
@@ -1,0 +1,36 @@
+package com.thomaskioko.tvmaniac.testing.di
+
+import com.thomaskioko.tvmaniac.appconfig.DefaultTmdbConfig
+import com.thomaskioko.tvmaniac.appconfig.DefaultTraktConfig
+import com.thomaskioko.tvmaniac.tmdb.api.TmdbConfig
+import com.thomaskioko.tvmaniac.trakt.api.TraktConfig
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+
+@BindingContainer
+@ContributesTo(
+    AppScope::class,
+    replaces = [
+        DefaultTmdbConfig::class,
+        DefaultTraktConfig::class,
+    ],
+)
+public object FakeAppConfigBindings {
+
+    @Provides
+    @SingleIn(AppScope::class)
+    public fun provideTmdbConfig(): TmdbConfig = object : TmdbConfig {
+        override val apiKey: String = "fake-tmdb-api-key"
+    }
+
+    @Provides
+    @SingleIn(AppScope::class)
+    public fun provideTraktConfig(): TraktConfig = object : TraktConfig {
+        override val clientId: String = "fake-trakt-client-id"
+        override val clientSecret: String = "fake-trakt-client-secret"
+        override val redirectUri: String = "tvmaniac://auth"
+    }
+}

--- a/core/testing/di/src/iosMain/kotlin/com/thomaskioko/tvmaniac/testing/di/RunTestWithGraph.kt
+++ b/core/testing/di/src/iosMain/kotlin/com/thomaskioko/tvmaniac/testing/di/RunTestWithGraph.kt
@@ -1,0 +1,29 @@
+package com.thomaskioko.tvmaniac.testing.di
+
+import dev.zacsweers.metro.createGraphFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestResult
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+
+/**
+ * iOS variant of [runTestWithGraph]. See the JVM declaration in `jvmMain` for
+ * the contract and motivation; the two share their shape but live in separate
+ * source sets because Metro materializes `@DependencyGraph.Factory` per target.
+ */
+public fun runTestWithGraph(
+    testDispatcher: TestDispatcher = StandardTestDispatcher(),
+    testBody: suspend TestScope.(TestGraph) -> Unit,
+): TestResult = runTest(testDispatcher) {
+    Dispatchers.setMain(testDispatcher)
+    try {
+        val graph = createGraphFactory<TestGraph.Factory>().create()
+        testBody(graph)
+    } finally {
+        Dispatchers.resetMain()
+    }
+}

--- a/core/testing/di/src/iosMain/kotlin/com/thomaskioko/tvmaniac/testing/di/TestGraph.kt
+++ b/core/testing/di/src/iosMain/kotlin/com/thomaskioko/tvmaniac/testing/di/TestGraph.kt
@@ -10,7 +10,7 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.DependencyGraph
 
 @DependencyGraph(AppScope::class)
-public interface TestJvmGraph {
+public interface TestGraph {
     public val datastoreRepository: DatastoreRepository
     public val traktAuthManager: TraktAuthManager
     public val navigator: Navigator
@@ -20,6 +20,6 @@ public interface TestJvmGraph {
 
     @DependencyGraph.Factory
     public fun interface Factory {
-        public fun create(): TestJvmGraph
+        public fun create(): TestGraph
     }
 }

--- a/core/testing/di/src/jvmMain/kotlin/com/thomaskioko/tvmaniac/testing/di/RunTestWithGraph.kt
+++ b/core/testing/di/src/jvmMain/kotlin/com/thomaskioko/tvmaniac/testing/di/RunTestWithGraph.kt
@@ -1,0 +1,48 @@
+package com.thomaskioko.tvmaniac.testing.di
+
+import dev.zacsweers.metro.createGraphFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestResult
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+
+/**
+ * Runs [testBody] inside [runTest] with a fresh [TestGraph] and a test
+ * dispatcher installed as `Dispatchers.Main`.
+ *
+ * Collapses the per-test boilerplate of manually calling `Dispatchers.setMain`,
+ * `createGraphFactory<TestGraph.Factory>().create()`, and the matching
+ * `resetMain` in a teardown. The resulting test body reads:
+ *
+ * ```kotlin
+ * @Test
+ * fun `should provide fake DatastoreRepository`() = runTestWithGraph { graph ->
+ *     graph.datastoreRepository.shouldBeInstanceOf<FakeDatastoreRepository>()
+ * }
+ * ```
+ *
+ * [testDispatcher] defaults to [StandardTestDispatcher] so that any `delay` /
+ * `.debounce` inside presenters under test is explicitly driven by
+ * `advanceTimeBy(...)` or `advanceUntilIdle()` — rather than eagerly executed
+ * and masking ordering bugs.
+ *
+ * Per-platform declaration: Metro's `@DependencyGraph.Factory` is materialized
+ * per Kotlin target, so the JVM and iOS variants of this helper must live in
+ * their respective source sets.
+ */
+public fun runTestWithGraph(
+    testDispatcher: TestDispatcher = StandardTestDispatcher(),
+    testBody: suspend TestScope.(TestGraph) -> Unit,
+): TestResult = runTest(testDispatcher) {
+    Dispatchers.setMain(testDispatcher)
+    try {
+        val graph = createGraphFactory<TestGraph.Factory>().create()
+        testBody(graph)
+    } finally {
+        Dispatchers.resetMain()
+    }
+}

--- a/core/testing/di/src/jvmMain/kotlin/com/thomaskioko/tvmaniac/testing/di/TestGraph.kt
+++ b/core/testing/di/src/jvmMain/kotlin/com/thomaskioko/tvmaniac/testing/di/TestGraph.kt
@@ -10,7 +10,7 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.DependencyGraph
 
 @DependencyGraph(AppScope::class)
-public interface TestIosGraph {
+public interface TestGraph {
     public val datastoreRepository: DatastoreRepository
     public val traktAuthManager: TraktAuthManager
     public val navigator: Navigator
@@ -20,6 +20,6 @@ public interface TestIosGraph {
 
     @DependencyGraph.Factory
     public fun interface Factory {
-        public fun create(): TestIosGraph
+        public fun create(): TestGraph
     }
 }

--- a/core/testing/di/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/testing/di/TestJvmGraphTest.kt
+++ b/core/testing/di/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/testing/di/TestJvmGraphTest.kt
@@ -2,59 +2,44 @@ package com.thomaskioko.tvmaniac.testing.di
 
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.destroy
 import com.arkivanov.essenty.lifecycle.resume
 import com.thomaskioko.tvmaniac.datastore.testing.FakeDatastoreRepository
 import com.thomaskioko.tvmaniac.presenter.root.RootPresenter
 import com.thomaskioko.tvmaniac.traktauth.testing.FakeTraktAuthManager
-import dev.zacsweers.metro.createGraphFactory
 import io.kotest.matchers.types.shouldBeInstanceOf
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlin.test.Test
 
 internal class TestJvmGraphTest {
-    private val lifecycle = LifecycleRegistry()
-    private val testDispatcher = StandardTestDispatcher()
 
-    private val component: TestJvmGraph by lazy {
-        createGraphFactory<TestJvmGraph.Factory>().create()
-    }
-
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-        lifecycle.resume()
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
+    @Test
+    fun `should provide fake DatastoreRepository`() = runTestWithGraph { graph ->
+        graph.datastoreRepository.shouldBeInstanceOf<FakeDatastoreRepository>()
     }
 
     @Test
-    fun `should provide fake DatastoreRepository`() {
-        component.datastoreRepository.shouldBeInstanceOf<FakeDatastoreRepository>()
+    fun `should provide fake TraktAuthManager`() = runTestWithGraph { graph ->
+        graph.traktAuthManager.shouldBeInstanceOf<FakeTraktAuthManager>()
     }
 
     @Test
-    fun `should provide fake TraktAuthManager`() {
-        component.traktAuthManager.shouldBeInstanceOf<FakeTraktAuthManager>()
-    }
-
-    @Test
-    fun `should resolve RootPresenter factory`() {
+    fun `should resolve RootPresenter factory`() = runTestWithGraph { graph ->
+        val lifecycle = LifecycleRegistry().apply { resume() }
         val componentContext = DefaultComponentContext(lifecycle = lifecycle)
-        val presenter = component.rootPresenterFactory(componentContext)
+        val presenter = graph.rootPresenterFactory(componentContext)
 
         presenter.shouldBeInstanceOf<RootPresenter>()
+
+        // Tear down the lifecycle before the test exits so presenter-internal
+        // coroutines that were launched on `Dispatchers.Main` complete before
+        // `runTestWithGraph`'s `Dispatchers.resetMain()` fires.
+        lifecycle.destroy()
+        advanceUntilIdle()
     }
 
     @Test
-    fun `should resolve NavDestinations set`() {
-        component.navDestinations.shouldBeInstanceOf<Set<*>>()
+    fun `should resolve NavDestinations set`() = runTestWithGraph { graph ->
+        graph.navDestinations.shouldBeInstanceOf<Set<*>>()
     }
 }

--- a/core/util/testing/build.gradle.kts
+++ b/core/util/testing/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
     alias(libs.plugins.app.kmp)
 }
 
+scaffold {
+    useMetro()
+}
+
 kotlin {
     sourceSets {
         commonMain {
@@ -9,6 +13,7 @@ kotlin {
                 api(projects.core.appconfig.api)
                 api(projects.core.util.api)
                 implementation(projects.core.base)
+                implementation(projects.core.util.implementation)
             }
         }
     }

--- a/core/util/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/util/testing/FakeDateTimeProvider.kt
+++ b/core/util/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/util/testing/FakeDateTimeProvider.kt
@@ -1,6 +1,11 @@
 package com.thomaskioko.tvmaniac.util.testing
 
+import com.thomaskioko.tvmaniac.util.DefaultDateTimeProvider
 import com.thomaskioko.tvmaniac.util.api.DateTimeProvider
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
@@ -8,6 +13,9 @@ import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Clock
 import kotlin.time.Instant
 
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, replaces = [DefaultDateTimeProvider::class])
 public class FakeDateTimeProvider(
     private var currentTime: Instant = Clock.System.now(),
 ) : DateTimeProvider {

--- a/core/util/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/util/testing/FakeFormatterUtil.kt
+++ b/core/util/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/util/testing/FakeFormatterUtil.kt
@@ -1,7 +1,14 @@
 package com.thomaskioko.tvmaniac.util.testing
 
 import com.thomaskioko.tvmaniac.util.api.FormatterUtil
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
 public class FakeFormatterUtil : FormatterUtil {
     private var formattedDateTime: String = ""
 

--- a/data/datastore/testing/build.gradle.kts
+++ b/data/datastore/testing/build.gradle.kts
@@ -2,11 +2,17 @@ plugins {
     alias(libs.plugins.app.kmp)
 }
 
+scaffold {
+    useMetro()
+}
+
 kotlin {
     sourceSets {
         commonMain {
             dependencies {
+                implementation(projects.core.base)
                 implementation(projects.data.datastore.api)
+                implementation(projects.data.datastore.implementation)
                 implementation(libs.coroutines.core)
             }
         }

--- a/data/datastore/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/datastore/testing/FakeDatastoreRepository.kt
+++ b/data/datastore/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/datastore/testing/FakeDatastoreRepository.kt
@@ -4,12 +4,20 @@ import com.thomaskioko.tvmaniac.datastore.api.AppTheme
 import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
 import com.thomaskioko.tvmaniac.datastore.api.ImageQuality
 import com.thomaskioko.tvmaniac.datastore.api.ListStyle
+import com.thomaskioko.tvmaniac.datastore.implementation.DefaultDatastoreRepository
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, replaces = [DefaultDatastoreRepository::class])
 public class FakeDatastoreRepository : DatastoreRepository {
 
     private val appThemeFlow = MutableStateFlow(AppTheme.SYSTEM_THEME)

--- a/data/request-manager/testing/build.gradle.kts
+++ b/data/request-manager/testing/build.gradle.kts
@@ -2,10 +2,16 @@ plugins {
     alias(libs.plugins.app.kmp)
 }
 
+scaffold {
+    useMetro()
+}
+
 kotlin {
     sourceSets {
         commonMain.dependencies {
+            implementation(projects.core.base)
             implementation(projects.data.requestManager.api)
+            implementation(projects.data.requestManager.implementation)
             implementation(libs.coroutines.core)
         }
     }

--- a/data/request-manager/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/requestmanager/testing/FakeRequestManagerRepository.kt
+++ b/data/request-manager/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/requestmanager/testing/FakeRequestManagerRepository.kt
@@ -1,9 +1,17 @@
 package com.thomaskioko.tvmaniac.requestmanager.testing
 
 import com.thomaskioko.tvmaniac.resourcemanager.api.RequestManagerRepository
+import com.thomaskioko.tvmaniac.resourcemanager.implementation.DefaultRequestManagerRepository
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import kotlin.time.Duration
 import kotlin.time.Instant
 
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, replaces = [DefaultRequestManagerRepository::class])
 public class FakeRequestManagerRepository : RequestManagerRepository {
     public var requestValid: Boolean = true
     public var upsertCalled: Boolean = false

--- a/data/sync-activity/testing/build.gradle.kts
+++ b/data/sync-activity/testing/build.gradle.kts
@@ -2,12 +2,18 @@ plugins {
     alias(libs.plugins.app.kmp)
 }
 
+scaffold {
+    useMetro()
+}
+
 kotlin {
     sourceSets {
         commonMain {
             dependencies {
                 api(projects.data.syncActivity.api)
 
+                implementation(projects.core.base)
+                implementation(projects.data.syncActivity.implementation)
                 implementation(projects.data.database.sqldelight)
                 implementation(libs.coroutines.core)
                 implementation(libs.sqldelight.extensions)

--- a/data/sync-activity/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/syncactivity/testing/FakeTraktActivityRepository.kt
+++ b/data/sync-activity/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/syncactivity/testing/FakeTraktActivityRepository.kt
@@ -2,7 +2,15 @@ package com.thomaskioko.tvmaniac.syncactivity.testing
 
 import com.thomaskioko.tvmaniac.syncactivity.api.TraktActivityRepository
 import com.thomaskioko.tvmaniac.syncactivity.api.model.ActivityType
+import com.thomaskioko.tvmaniac.syncactivity.implementation.DefaultTraktActivityRepository
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, replaces = [DefaultTraktActivityRepository::class])
 public class FakeTraktActivityRepository : TraktActivityRepository {
 
     private val changedActivities = mutableSetOf<ActivityType>()

--- a/data/traktauth/testing/build.gradle.kts
+++ b/data/traktauth/testing/build.gradle.kts
@@ -2,4 +2,18 @@ plugins {
     alias(libs.plugins.app.kmp)
 }
 
-kotlin { sourceSets { commonMain { dependencies { implementation(projects.data.traktauth.api) } } } }
+scaffold {
+    useMetro()
+}
+
+kotlin {
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation(projects.core.base)
+                implementation(projects.data.traktauth.api)
+                implementation(projects.data.traktauth.implementation)
+            }
+        }
+    }
+}

--- a/data/traktauth/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/testing/FakeTraktAuthManager.kt
+++ b/data/traktauth/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/testing/FakeTraktAuthManager.kt
@@ -1,7 +1,14 @@
 package com.thomaskioko.tvmaniac.traktauth.testing
 
 import com.thomaskioko.tvmaniac.traktauth.api.TraktAuthManager
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
 public class FakeTraktAuthManager : TraktAuthManager {
     override fun launchWebView() {
     }

--- a/data/traktauth/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/testing/FakeTraktAuthRepository.kt
+++ b/data/traktauth/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/testing/FakeTraktAuthRepository.kt
@@ -5,10 +5,18 @@ import com.thomaskioko.tvmaniac.traktauth.api.AuthState
 import com.thomaskioko.tvmaniac.traktauth.api.TokenRefreshResult
 import com.thomaskioko.tvmaniac.traktauth.api.TraktAuthRepository
 import com.thomaskioko.tvmaniac.traktauth.api.TraktAuthState
+import com.thomaskioko.tvmaniac.traktauth.implementation.DefaultTraktAuthRepository
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, replaces = [DefaultTraktAuthRepository::class])
 public class FakeTraktAuthRepository : TraktAuthRepository {
 
     private val _state = MutableStateFlow(TraktAuthState.LOGGED_OUT)

--- a/data/traktlists/testing/build.gradle.kts
+++ b/data/traktlists/testing/build.gradle.kts
@@ -2,12 +2,18 @@ plugins {
     alias(libs.plugins.app.kmp)
 }
 
+scaffold {
+    useMetro()
+}
+
 kotlin {
     sourceSets {
         commonMain {
             dependencies {
                 api(projects.data.traktlists.api)
 
+                implementation(projects.core.base)
+                implementation(projects.data.traktlists.implementation)
                 implementation(libs.coroutines.core)
             }
         }

--- a/data/traktlists/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/testing/FakeTraktListRepository.kt
+++ b/data/traktlists/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/testing/FakeTraktListRepository.kt
@@ -3,10 +3,18 @@ package com.thomaskioko.tvmaniac.traktlists.testing
 import com.thomaskioko.tvmaniac.traktlists.api.TraktList
 import com.thomaskioko.tvmaniac.traktlists.api.TraktListEntity
 import com.thomaskioko.tvmaniac.traktlists.api.TraktListRepository
+import com.thomaskioko.tvmaniac.traktlists.implementation.DefaultTraktListRepository
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, replaces = [DefaultTraktListRepository::class])
 public class FakeTraktListRepository : TraktListRepository {
 
     private val listsFlow = MutableStateFlow<List<TraktListEntity>>(emptyList())

--- a/data/user/testing/build.gradle.kts
+++ b/data/user/testing/build.gradle.kts
@@ -2,11 +2,16 @@ plugins {
     alias(libs.plugins.app.kmp)
 }
 
+scaffold {
+    useMetro()
+}
+
 kotlin {
     sourceSets {
         commonMain {
             dependencies {
                 implementation(projects.data.user.api)
+                implementation(projects.data.user.implementation)
                 implementation(projects.core.base)
             }
         }

--- a/data/user/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/user/testing/FakeUserRepository.kt
+++ b/data/user/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/user/testing/FakeUserRepository.kt
@@ -3,9 +3,17 @@ package com.thomaskioko.tvmaniac.data.user.testing
 import com.thomaskioko.tvmaniac.data.user.api.UserRepository
 import com.thomaskioko.tvmaniac.data.user.api.model.UserProfile
 import com.thomaskioko.tvmaniac.data.user.api.model.UserProfileStats
+import com.thomaskioko.tvmaniac.data.user.implementation.DefaultUserRepository
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, replaces = [DefaultUserRepository::class])
 public class FakeUserRepository(
     userProfile: UserProfile? = createTestProfile(),
 ) : UserRepository {

--- a/features/home/presenter/src/iosTest/kotlin/com/thomaskioko/tvmaniac/presenter/home/HomePresenterIosTest.kt
+++ b/features/home/presenter/src/iosTest/kotlin/com/thomaskioko/tvmaniac/presenter/home/HomePresenterIosTest.kt
@@ -1,12 +1,12 @@
 package com.thomaskioko.tvmaniac.presenter.home
 
 import com.arkivanov.decompose.ComponentContext
-import com.thomaskioko.tvmaniac.testing.di.TestIosGraph
+import com.thomaskioko.tvmaniac.testing.di.TestGraph
 import dev.zacsweers.metro.createGraphFactory
 
 internal class HomePresenterIosTest : HomePresenterTest() {
-    private val testGraph: TestIosGraph by lazy {
-        createGraphFactory<TestIosGraph.Factory>().create()
+    private val testGraph: TestGraph by lazy {
+        createGraphFactory<TestGraph.Factory>().create()
     }
 
     override fun createHomePresenter(componentContext: ComponentContext): HomePresenter =

--- a/features/home/presenter/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/presenter/home/HomePresenterJvmTest.kt
+++ b/features/home/presenter/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/presenter/home/HomePresenterJvmTest.kt
@@ -1,12 +1,12 @@
 package com.thomaskioko.tvmaniac.presenter.home
 
 import com.arkivanov.decompose.ComponentContext
-import com.thomaskioko.tvmaniac.testing.di.TestJvmGraph
+import com.thomaskioko.tvmaniac.testing.di.TestGraph
 import dev.zacsweers.metro.createGraphFactory
 
 internal class HomePresenterJvmTest : HomePresenterTest() {
-    private val testComponent: TestJvmGraph =
-        createGraphFactory<TestJvmGraph.Factory>().create()
+    private val testComponent: TestGraph =
+        createGraphFactory<TestGraph.Factory>().create()
 
     override fun createHomePresenter(componentContext: ComponentContext): HomePresenter =
         testComponent.homeScreenGraphFactory.createHomeGraph(componentContext).homePresenter

--- a/features/root/presenter/src/iosTest/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenterIosTest.kt
+++ b/features/root/presenter/src/iosTest/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenterIosTest.kt
@@ -3,12 +3,12 @@ package com.thomaskioko.tvmaniac.presenter.root
 import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
 import com.thomaskioko.tvmaniac.navigation.Navigator
 import com.thomaskioko.tvmaniac.presenter.root.RootPresenter
-import com.thomaskioko.tvmaniac.testing.di.TestIosGraph
+import com.thomaskioko.tvmaniac.testing.di.TestGraph
 import dev.zacsweers.metro.createGraphFactory
 
 internal class DefaultRootPresenterIosTest : DefaultRootPresenterTest() {
-    private val testGraph: TestIosGraph by lazy {
-        createGraphFactory<TestIosGraph.Factory>().create()
+    private val testGraph: TestGraph by lazy {
+        createGraphFactory<TestGraph.Factory>().create()
     }
 
     override val rootPresenterFactory: RootPresenter.Factory

--- a/features/root/presenter/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenterJvmTest.kt
+++ b/features/root/presenter/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenterJvmTest.kt
@@ -3,12 +3,12 @@ package com.thomaskioko.tvmaniac.presenter.root
 import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
 import com.thomaskioko.tvmaniac.navigation.Navigator
 import com.thomaskioko.tvmaniac.presenter.root.RootPresenter
-import com.thomaskioko.tvmaniac.testing.di.TestJvmGraph
+import com.thomaskioko.tvmaniac.testing.di.TestGraph
 import dev.zacsweers.metro.createGraphFactory
 
 internal class DefaultRootPresenterJvmTest : DefaultRootPresenterTest() {
-    private val testComponent: TestJvmGraph by lazy {
-        createGraphFactory<TestJvmGraph.Factory>().create()
+    private val testComponent: TestGraph by lazy {
+        createGraphFactory<TestGraph.Factory>().create()
     }
 
     override val rootPresenterFactory: RootPresenter.Factory

--- a/i18n/testing/build.gradle.kts
+++ b/i18n/testing/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 scaffold {
     addAndroidTarget()
+    useMetro()
 }
 
 kotlin {
@@ -17,7 +18,9 @@ kotlin {
 
         commonMain {
             dependencies {
+                implementation(projects.core.base)
                 implementation(projects.i18n.api)
+                implementation(projects.i18n.implementation)
                 implementation(libs.coroutines.core)
                 implementation(libs.moko.resources)
             }

--- a/i18n/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/i18n/testing/FakeLocalizer.kt
+++ b/i18n/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/i18n/testing/FakeLocalizer.kt
@@ -1,11 +1,19 @@
 package com.thomaskioko.tvmaniac.i18n.testing
 
+import com.thomaskioko.tvmaniac.i18n.MokoResourcesLocalizer
 import com.thomaskioko.tvmaniac.i18n.PluralsResourceKey
 import com.thomaskioko.tvmaniac.i18n.StringResourceKey
 import com.thomaskioko.tvmaniac.i18n.api.Localizer
 import com.thomaskioko.tvmaniac.i18n.testing.util.getPlural
 import com.thomaskioko.tvmaniac.i18n.testing.util.getString
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, replaces = [MokoResourcesLocalizer::class])
 public class FakeLocalizer : Localizer {
 
     override fun getString(key: StringResourceKey): String = key.getString()


### PR DESCRIPTION
## Description
This PR refactors the `core/testing/di` module by moving Metro `@ContributesBinding(replaces = [...])` annotations from the monolithic `FakeAppBindings` onto the fake classes themselves, so the replacement contract lives where the
fake is defined instead of two layers away in a central container. It also fixes a scheduler-mismatch bug in the
JVM/iOS test-graph dispatcher wiring and adds a `runTestWithGraph` helper to cut the `@Before`/`@After` boilerplate out of per-test setup.

This is an experiment and I might revert it back. The downside to this is fake modules have a dependency to the implementation module. The up side is the `FakeAppBindings` has less fake bindings.