### PR TITLE
fix: Background jobs improvement

### DIFF
--- a/core/base/build.gradle.kts
+++ b/core/base/build.gradle.kts
@@ -18,8 +18,13 @@ kotlin {
         commonMain.dependencies {
             api(projects.core.view)
 
+            implementation(projects.core.logger.api)
             implementation(libs.coroutines.core)
             implementation(libs.decompose.decompose)
+        }
+
+        commonTest.dependencies {
+            implementation(libs.bundles.unittest)
         }
     }
 }

--- a/core/base/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/base/coroutines/AppScopeLauncher.kt
+++ b/core/base/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/base/coroutines/AppScopeLauncher.kt
@@ -1,0 +1,27 @@
+package com.thomaskioko.tvmaniac.core.base.coroutines
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+
+/**
+ * Launches work that must outlive the caller's coroutine scope.
+ *
+ * Use this for follow-up sync work triggered by a user action (writing through to the
+ * network, refreshing caches) that should still complete if the user navigates away
+ * before the launched block finishes. The block runs on a process-scoped supervisor,
+ * so cancelling the caller does not cancel the launched job.
+ *
+ * Process-scoped, not OS-scheduled. The job dies with the process. For work that must
+ * survive process death, use the OS-managed scheduler in `core/tasks` instead.
+ *
+ * The launcher catches any failure inside the block and logs it under the supplied
+ * tag. CancellationException is rethrown (never logged), so structured cancellation
+ * during process shutdown still works.
+ */
+public interface AppScopeLauncher {
+
+    public fun launch(
+        tag: String,
+        block: suspend CoroutineScope.() -> Unit,
+    ): Job
+}

--- a/core/base/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/base/coroutines/DefaultAppScopeLauncher.kt
+++ b/core/base/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/base/coroutines/DefaultAppScopeLauncher.kt
@@ -1,0 +1,32 @@
+package com.thomaskioko.tvmaniac.core.base.coroutines
+
+import com.thomaskioko.tvmaniac.core.base.IoCoroutineScope
+import com.thomaskioko.tvmaniac.core.logger.Logger
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+public class DefaultAppScopeLauncher(
+    @IoCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val logger: Logger,
+) : AppScopeLauncher {
+
+    override fun launch(
+        tag: String,
+        block: suspend CoroutineScope.() -> Unit,
+    ): Job = appCoroutineScope.launch {
+        try {
+            block()
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (throwable: Throwable) {
+            logger.error(tag, "Background job failed", throwable)
+        }
+    }
+}

--- a/core/base/src/commonTest/kotlin/com/thomaskioko/tvmaniac/core/base/coroutines/AppScopeLauncherTest.kt
+++ b/core/base/src/commonTest/kotlin/com/thomaskioko/tvmaniac/core/base/coroutines/AppScopeLauncherTest.kt
@@ -1,0 +1,55 @@
+package com.thomaskioko.tvmaniac.core.base.coroutines
+
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+internal class AppScopeLauncherTest {
+
+    private val logger = RecordingLogger()
+
+    @Test
+    fun `should run block on injected scope`() = runTest {
+        val launcher = DefaultAppScopeLauncher(backgroundScope, logger)
+        var ran = false
+
+        launcher.launch("Test") { ran = true }
+        runCurrent()
+
+        ran shouldBe true
+        logger.errors shouldHaveSize 0
+    }
+
+    @Test
+    fun `should log error with throwable when block fails`() = runTest {
+        val launcher = DefaultAppScopeLauncher(backgroundScope, logger)
+        val cause = IllegalStateException("boom")
+
+        launcher.launch("FollowShowInteractor") { throw cause }
+        runCurrent()
+
+        logger.errors shouldBe listOf(
+            LoggedError(
+                tag = "FollowShowInteractor",
+                message = "Background job failed",
+                throwable = cause,
+            ),
+        )
+    }
+
+    @Test
+    fun `should not log when block is cancelled`() = runTest {
+        val launcher = DefaultAppScopeLauncher(backgroundScope, logger)
+
+        val job = launcher.launch("Test") {
+            throw CancellationException("caller went away")
+        }
+        runCurrent()
+
+        job.isCancelled shouldBe true
+        logger.errors shouldHaveSize 0
+    }
+}

--- a/core/base/src/commonTest/kotlin/com/thomaskioko/tvmaniac/core/base/coroutines/LoggedError.kt
+++ b/core/base/src/commonTest/kotlin/com/thomaskioko/tvmaniac/core/base/coroutines/LoggedError.kt
@@ -1,0 +1,7 @@
+package com.thomaskioko.tvmaniac.core.base.coroutines
+
+internal data class LoggedError(
+    val tag: String?,
+    val message: String,
+    val throwable: Throwable?,
+)

--- a/core/base/src/commonTest/kotlin/com/thomaskioko/tvmaniac/core/base/coroutines/RecordingLogger.kt
+++ b/core/base/src/commonTest/kotlin/com/thomaskioko/tvmaniac/core/base/coroutines/RecordingLogger.kt
@@ -1,0 +1,23 @@
+package com.thomaskioko.tvmaniac.core.base.coroutines
+
+import com.thomaskioko.tvmaniac.core.logger.Logger
+
+internal class RecordingLogger : Logger {
+
+    private val recorded = mutableListOf<LoggedError>()
+
+    val errors: List<LoggedError> get() = recorded.toList()
+
+    override fun error(message: String, throwable: Throwable) {
+        recorded += LoggedError(tag = null, message = message, throwable = throwable)
+    }
+
+    override fun error(tag: String, message: String) {
+        recorded += LoggedError(tag = tag, message = message, throwable = null)
+    }
+
+    override fun error(tag: String, message: String, throwable: Throwable) {
+        recorded += LoggedError(tag = tag, message = message, throwable = throwable)
+    }
+}
+

--- a/core/base/src/commonTest/kotlin/com/thomaskioko/tvmaniac/core/base/coroutines/RecordingLogger.kt
+++ b/core/base/src/commonTest/kotlin/com/thomaskioko/tvmaniac/core/base/coroutines/RecordingLogger.kt
@@ -20,4 +20,3 @@ internal class RecordingLogger : Logger {
         recorded += LoggedError(tag = tag, message = message, throwable = throwable)
     }
 }
-

--- a/core/base/testing/build.gradle.kts
+++ b/core/base/testing/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    alias(libs.plugins.app.kmp)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.core.base)
+
+            implementation(libs.coroutines.core)
+        }
+    }
+}

--- a/core/base/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/base/coroutines/FakeAppScopeLauncher.kt
+++ b/core/base/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/base/coroutines/FakeAppScopeLauncher.kt
@@ -1,0 +1,28 @@
+package com.thomaskioko.tvmaniac.core.base.coroutines
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+/**
+ * Test fake for [AppScopeLauncher] that runs launched blocks on a caller-supplied scope.
+ *
+ * Pass the test's `TestScope` as [scope] so launched work executes under the same
+ * scheduler as the test body and `runTest` can advance it to completion.
+ */
+public class FakeAppScopeLauncher(
+    private val scope: CoroutineScope,
+) : AppScopeLauncher {
+
+    private val recordedTags = mutableListOf<String>()
+
+    public val launches: List<String> get() = recordedTags.toList()
+
+    override fun launch(
+        tag: String,
+        block: suspend CoroutineScope.() -> Unit,
+    ): Job {
+        recordedTags += tag
+        return scope.launch { block() }
+    }
+}

--- a/core/logger/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/Logger.kt
+++ b/core/logger/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/Logger.kt
@@ -12,6 +12,8 @@ public interface Logger {
 
     public fun error(tag: String, message: String)
 
+    public fun error(tag: String, message: String, throwable: Throwable): Unit = Unit
+
     public fun info(message: String, throwable: Throwable): Unit = Unit
 
     public fun info(tag: String, message: String): Unit = Unit

--- a/core/logger/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/CompositeLogger.kt
+++ b/core/logger/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/CompositeLogger.kt
@@ -39,6 +39,10 @@ public class CompositeLogger(
         loggers.forEach { it.error(tag, message) }
     }
 
+    override fun error(tag: String, message: String, throwable: Throwable) {
+        loggers.forEach { it.error(tag, message, throwable) }
+    }
+
     override fun info(message: String, throwable: Throwable) {
         loggers.forEach { it.info(message, throwable) }
     }

--- a/core/logger/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/FirebaseCrashLogger.kt
+++ b/core/logger/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/FirebaseCrashLogger.kt
@@ -18,6 +18,11 @@ public class FirebaseCrashLogger(
         crashReporter.log("[$tag] $message")
     }
 
+    override fun error(tag: String, message: String, throwable: Throwable) {
+        crashReporter.log("[$tag] $message")
+        crashReporter.recordException(throwable, tag)
+    }
+
     override fun recordException(throwable: Throwable, tag: String) {
         if (tag.isEmpty()) {
             crashReporter.recordException(throwable)

--- a/core/logger/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/KermitLogger.kt
+++ b/core/logger/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/KermitLogger.kt
@@ -30,6 +30,10 @@ public class KermitLogger : Logger {
         KermitLogger.withTag(tag).e(message)
     }
 
+    override fun error(tag: String, message: String, throwable: Throwable) {
+        KermitLogger.withTag(tag).e(message, throwable)
+    }
+
     override fun info(message: String, throwable: Throwable) {
         KermitLogger.i(message, throwable)
     }

--- a/core/logger/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/fixture/FakeLogger.kt
+++ b/core/logger/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/fixture/FakeLogger.kt
@@ -13,6 +13,8 @@ public class FakeLogger : Logger {
 
     override fun error(tag: String, message: String) {}
 
+    override fun error(tag: String, message: String, throwable: Throwable) {}
+
     override fun info(message: String, throwable: Throwable) {}
 
     override fun info(tag: String, message: String) {}

--- a/core/tasks/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/tasks/implementation/DefaultWorkerFactory.kt
+++ b/core/tasks/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/tasks/implementation/DefaultWorkerFactory.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.core.tasks.implementation
 
+import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.core.tasks.api.BackgroundWorker
 import com.thomaskioko.tvmaniac.core.tasks.api.WorkerFactory
 import dev.zacsweers.metro.AppScope
@@ -10,8 +11,13 @@ import dev.zacsweers.metro.SingleIn
 @ContributesBinding(AppScope::class)
 public class DefaultWorkerFactory(
     workers: Set<BackgroundWorker>,
+    logger: Logger,
 ) : WorkerFactory {
     private val registry: Map<String, BackgroundWorker> = workers.associateBy { it.workerName }
+
+    init {
+        logger.debug("DefaultWorkerFactory", "Registered workers: ${registry.keys}")
+    }
 
     override val workerNames: Set<String> get() = registry.keys
 

--- a/core/tasks/implementation/src/iosMain/kotlin/com/thomaskioko/tvmaniac/core/tasks/implementation/IosTaskScheduler.kt
+++ b/core/tasks/implementation/src/iosMain/kotlin/com/thomaskioko/tvmaniac/core/tasks/implementation/IosTaskScheduler.kt
@@ -11,15 +11,24 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
 import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.ObjCObjectVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import platform.BackgroundTasks.BGAppRefreshTaskRequest
 import platform.BackgroundTasks.BGProcessingTaskRequest
 import platform.BackgroundTasks.BGTask
+import platform.BackgroundTasks.BGTaskRequest
 import platform.BackgroundTasks.BGTaskScheduler
 import platform.Foundation.NSDate
+import platform.Foundation.NSError
 import platform.Foundation.dateWithTimeIntervalSinceNow
 
 @SingleIn(AppScope::class)
@@ -31,18 +40,20 @@ public class IosTaskScheduler(
 ) : BackgroundTaskScheduler {
 
     private val scheduler = BGTaskScheduler.sharedScheduler
+    private val lock = reentrantLock()
     private val activeRequests = mutableMapOf<String, PeriodicTaskRequest>()
     private val registeredTaskIds = mutableSetOf<String>()
 
     init {
         val names = workerFactory.workerNames
         names.forEach { taskId -> ensureRegistered(taskId) }
-        logger.debug(TAG, "Eagerly registered ${names.size} background task handlers")
+        logger.debug(TAG, "Eagerly registered ${names.size} background task handlers: $names")
+        logPendingRequests(reason = "init")
     }
 
     override fun schedulePeriodic(request: PeriodicTaskRequest) {
         ensureRegistered(request.id)
-        activeRequests[request.id] = request
+        lock.withLock { activeRequests[request.id] = request }
         submitRequest(request)
     }
 
@@ -52,32 +63,63 @@ public class IosTaskScheduler(
     }
 
     override fun cancel(id: String) {
-        activeRequests.remove(id)
+        lock.withLock { activeRequests.remove(id) }
         scheduler.cancelTaskRequestWithIdentifier(id)
         logger.debug(TAG, "Cancelled task [$id]")
     }
 
     override fun cancelAll() {
-        activeRequests.clear()
+        lock.withLock { activeRequests.clear() }
         scheduler.cancelAllTaskRequests()
         logger.debug(TAG, "Cancelled all tasks")
     }
 
+    /**
+     * Resubmits any active requests that the system no longer has pending.
+     *
+     * The earlier implementation resubmitted every active request on every
+     * backgrounding event, which reset `earliestBeginDate` to `now + 5 minutes`
+     * each time and allowed rapid foreground/background cycles to push the
+     * begin date forward indefinitely.
+     */
     override fun rescheduleBackgroundTask() {
-        activeRequests.values.forEach { request ->
-            submitRequest(request)
+        scheduler.getPendingTaskRequestsWithCompletionHandler { array ->
+            val pendingIds = (array ?: emptyList<Any?>())
+                .filterIsInstance<BGTaskRequest>()
+                .map { it.identifier }
+                .toSet()
+            val snapshot = lock.withLock { activeRequests.values.toList() }
+            var resubmitted = 0
+            snapshot.forEach { request ->
+                if (request.id in pendingIds) {
+                    logger.debug(TAG, "Already pending, skipping resubmit [${request.id}]")
+                } else {
+                    submitRequest(request)
+                    resubmitted++
+                }
+            }
+            logger.debug(
+                TAG,
+                "Reschedule complete. pending=${pendingIds.size}, resubmitted=$resubmitted, active=${snapshot.size}",
+            )
         }
-        logger.debug(TAG, "Rescheduled ${activeRequests.size} tasks")
     }
 
     private fun ensureRegistered(taskId: String) {
-        if (taskId in registeredTaskIds) return
+        val needsRegister = lock.withLock {
+            if (taskId in registeredTaskIds) {
+                false
+            } else {
+                registeredTaskIds.add(taskId)
+                true
+            }
+        }
+        if (!needsRegister) return
         scheduler.registerForTaskWithIdentifier(
             identifier = taskId,
             usingQueue = null,
             launchHandler = ::handleTask,
         )
-        registeredTaskIds.add(taskId)
         logger.debug(TAG, "Registered background task [$taskId]")
     }
 
@@ -115,12 +157,20 @@ public class IosTaskScheduler(
             }
         }
 
-        try {
-            scheduler.submitTaskRequest(taskRequest = bgRequest, error = null)
-            val type = if (request.longRunning) "processing" else "refresh"
-            logger.debug(TAG, "Scheduled $type task [${request.id}] for $earliestBeginDate")
-        } catch (t: Throwable) {
-            logger.error(TAG, "Error scheduling task [${request.id}]: ${t.message}")
+        val type = if (request.longRunning) "processing" else "refresh"
+        memScoped {
+            val errorPtr = alloc<ObjCObjectVar<NSError?>>()
+            val ok = scheduler.submitTaskRequest(taskRequest = bgRequest, error = errorPtr.ptr)
+            if (ok) {
+                logger.debug(TAG, "Scheduled $type task [${request.id}] for $earliestBeginDate")
+            } else {
+                val error = errorPtr.value
+                logger.error(
+                    TAG,
+                    "Submit failed [${request.id}] type=$type code=${error?.code} " +
+                        "domain=${error?.domain} desc=${error?.localizedDescription}",
+                )
+            }
         }
     }
 
@@ -145,7 +195,8 @@ public class IosTaskScheduler(
 
     private fun handleTask(bgTask: BGTask?) {
         val taskId = bgTask?.identifier ?: return
-        val request = activeRequests[taskId]
+        val request = lock.withLock { activeRequests[taskId] }
+        logger.debug(TAG, "handleTask fired [$taskId] knownRequest=${request != null}")
 
         val worker = workerFactory.createWorker(taskId) ?: run {
             logger.error(TAG, "Received unknown task [$taskId]")
@@ -188,6 +239,22 @@ public class IosTaskScheduler(
             } catch (e: Throwable) {
                 completeTask(false)
                 logger.error(TAG, "Task [$taskId] failed: ${e.message}")
+            }
+        }
+    }
+
+    private fun logPendingRequests(reason: String) {
+        scheduler.getPendingTaskRequestsWithCompletionHandler { array ->
+            val requests = (array ?: emptyList<Any?>()).filterIsInstance<BGTaskRequest>()
+            if (requests.isEmpty()) {
+                logger.debug(TAG, "Pending dump [$reason]: empty")
+            } else {
+                requests.forEach { req ->
+                    logger.debug(
+                        TAG,
+                        "Pending dump [$reason]: id=${req.identifier} earliest=${req.earliestBeginDate}",
+                    )
+                }
             }
         }
     }

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeSyncRepository.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeSyncRepository.kt
@@ -2,5 +2,5 @@ package com.thomaskioko.tvmaniac.episodes.api
 
 public interface WatchedEpisodeSyncRepository {
     public suspend fun syncShowEpisodeWatches(showTraktId: Long, forceRefresh: Boolean = false)
-    public suspend fun uploadPendingEpisodes()
+    public suspend fun syncPendingEpisodes()
 }

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepository.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepository.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.episodes.implementation
 
+import com.thomaskioko.tvmaniac.core.base.coroutines.AppScopeLauncher
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.fresh
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.get
@@ -33,6 +34,7 @@ public class DefaultEpisodeRepository(
     private val episodesDao: EpisodesDao,
     private val dispatchers: AppCoroutineDispatchers,
     private val upcomingEpisodesStore: UpcomingEpisodesStore,
+    private val appScopeLauncher: AppScopeLauncher,
 ) : EpisodeRepository {
 
     override fun observeEpisodeById(episodeId: Long): Flow<EpisodeById?> =
@@ -52,13 +54,16 @@ public class DefaultEpisodeRepository(
             episodeNumber = episodeNumber,
             includeSpecials = includeSpecials,
         )
-        syncRepository.uploadPendingEpisodes()
 
-        upNextRepository.fetchUpNext(
-            showTraktId = showTraktId,
-            seasonNumber = seasonNumber,
-            episodeNumber = episodeNumber,
-        )
+        appScopeLauncher.launch(TAG) {
+            syncRepository.syncPendingEpisodes()
+
+            upNextRepository.fetchUpNext(
+                showTraktId = showTraktId,
+                seasonNumber = seasonNumber,
+                episodeNumber = episodeNumber,
+            )
+        }
     }
 
     override suspend fun markEpisodeAndPreviousEpisodesWatched(
@@ -75,7 +80,11 @@ public class DefaultEpisodeRepository(
             episodeNumber = episodeNumber,
             includeSpecials = includeSpecials,
         )
-        upNextRepository.updateUpNextForShow(showTraktId)
+
+        appScopeLauncher.launch(TAG) {
+            syncRepository.syncPendingEpisodes()
+            upNextRepository.updateUpNextForShow(showTraktId)
+        }
     }
 
     override suspend fun markEpisodeAsUnwatched(showTraktId: Long, episodeId: Long) {
@@ -85,7 +94,11 @@ public class DefaultEpisodeRepository(
             episodeId = episodeId,
             includeSpecials = includeSpecials,
         )
-        upNextRepository.updateUpNextForShow(showTraktId)
+
+        appScopeLauncher.launch(TAG) {
+            syncRepository.syncPendingEpisodes()
+            upNextRepository.updateUpNextForShow(showTraktId)
+        }
     }
 
     override fun observeSeasonWatchProgress(
@@ -115,7 +128,11 @@ public class DefaultEpisodeRepository(
             episodes = episodes,
             includeSpecials = includeSpecials,
         )
-        upNextRepository.updateUpNextForShow(showTraktId)
+
+        appScopeLauncher.launch(TAG) {
+            syncRepository.syncPendingEpisodes()
+            upNextRepository.updateUpNextForShow(showTraktId)
+        }
     }
 
     override suspend fun markSeasonAndPreviousSeasonsWatched(
@@ -128,13 +145,21 @@ public class DefaultEpisodeRepository(
             seasonNumber = seasonNumber,
             includeSpecials = includeSpecials,
         )
-        upNextRepository.updateUpNextForShow(showTraktId)
+
+        appScopeLauncher.launch(TAG) {
+            syncRepository.syncPendingEpisodes()
+            upNextRepository.updateUpNextForShow(showTraktId)
+        }
     }
 
     override suspend fun markSeasonUnwatched(showTraktId: Long, seasonNumber: Long) {
         val includeSpecials = getIncludeSpecials()
         watchedEpisodeDao.markSeasonAsUnwatched(showTraktId, seasonNumber, includeSpecials)
-        upNextRepository.updateUpNextForShow(showTraktId)
+
+        appScopeLauncher.launch(TAG) {
+            syncRepository.syncPendingEpisodes()
+            upNextRepository.updateUpNextForShow(showTraktId)
+        }
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -186,4 +211,8 @@ public class DefaultEpisodeRepository(
     }
 
     private suspend fun getIncludeSpecials(): Boolean = datastoreRepository.getIncludeSpecials()
+
+    private companion object {
+        private const val TAG = "EpisodeRepository"
+    }
 }

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepository.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepository.kt
@@ -28,11 +28,12 @@ public class DefaultWatchedEpisodeSyncRepository(
     private val logger: Logger,
 ) : WatchedEpisodeSyncRepository {
 
-    override suspend fun uploadPendingEpisodes() {
+    override suspend fun syncPendingEpisodes() {
         val authState = traktAuthRepository.getAuthState()
         if (authState == null || !authState.isAuthorized) return
 
         processPendingEpisodesToUploads()
+        processPendingEpisodesDeletes()
     }
 
     override suspend fun syncShowEpisodeWatches(showTraktId: Long, forceRefresh: Boolean) {

--- a/data/episode/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/testing/FakeWatchedEpisodeSyncRepository.kt
+++ b/data/episode/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/testing/FakeWatchedEpisodeSyncRepository.kt
@@ -20,6 +20,6 @@ public class FakeWatchedEpisodeSyncRepository : WatchedEpisodeSyncRepository {
         lastForceRefresh = forceRefresh
     }
 
-    override suspend fun uploadPendingEpisodes() {
+    override suspend fun syncPendingEpisodes() {
     }
 }

--- a/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TokenRefreshWorker.kt
+++ b/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TokenRefreshWorker.kt
@@ -43,6 +43,7 @@ public class TokenRefreshWorker(
             id = WORKER_NAME,
             intervalMs = FIVE_HOURS_MS,
             constraints = TaskConstraints(requiresNetwork = true),
+            longRunning = true,
         )
     }
 }

--- a/domain/showdetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/FollowShowInteractor.kt
+++ b/domain/showdetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/FollowShowInteractor.kt
@@ -1,45 +1,34 @@
 package com.thomaskioko.tvmaniac.domain.showdetails
 
+import com.thomaskioko.tvmaniac.core.base.coroutines.AppScopeLauncher
 import com.thomaskioko.tvmaniac.core.base.interactor.Interactor
-import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
-import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.followedshows.api.FollowedShowsRepository
 import com.thomaskioko.tvmaniac.upnext.api.UpNextRepository
 import dev.zacsweers.metro.Inject
-import kotlinx.coroutines.withContext
 
 @Inject
 public class FollowShowInteractor(
     private val followedShowsRepository: FollowedShowsRepository,
     private val showContentSyncInteractor: ShowContentSyncInteractor,
     private val upNextRepository: UpNextRepository,
-    private val dispatchers: AppCoroutineDispatchers,
-    private val logger: Logger,
+    private val appScopeLauncher: AppScopeLauncher,
 ) : Interactor<FollowShowInteractor.Param>() {
 
     override suspend fun doWork(params: Param) {
-        withContext(dispatchers.io) {
-            followedShowsRepository.addFollowedShow(params.traktId)
+        followedShowsRepository.addFollowedShow(params.traktId)
 
-            try {
-                showContentSyncInteractor.executeSync(
-                    ShowContentSyncInteractor.Param(
-                        traktId = params.traktId,
-                        forceRefresh = params.forceRefresh,
-                    ),
-                )
-            } catch (t: Throwable) {
-                logger.error("FollowShowInteractor", "Failed to sync content for show ${params.traktId}: ${t.message}")
-            }
-
-            try {
-                upNextRepository.updateUpNextForShow(
-                    showTraktId = params.traktId,
+        appScopeLauncher.launch(TAG) {
+            showContentSyncInteractor.executeSync(
+                ShowContentSyncInteractor.Param(
+                    traktId = params.traktId,
                     forceRefresh = params.forceRefresh,
-                )
-            } catch (t: Throwable) {
-                logger.error("FollowShowInteractor", "Failed to update up next for show ${params.traktId}: ${t.message}")
-            }
+                ),
+            )
+
+            upNextRepository.updateUpNextForShow(
+                showTraktId = params.traktId,
+                forceRefresh = params.forceRefresh,
+            )
         }
     }
 
@@ -47,4 +36,8 @@ public class FollowShowInteractor(
         val traktId: Long,
         val forceRefresh: Boolean = false,
     )
+
+    private companion object {
+        private const val TAG = "FollowShowInteractor"
+    }
 }

--- a/domain/showdetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/ShowContentSyncInteractor.kt
+++ b/domain/showdetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/ShowContentSyncInteractor.kt
@@ -7,6 +7,7 @@ import com.thomaskioko.tvmaniac.data.showdetails.api.ShowDetailsRepository
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeSyncRepository
 import com.thomaskioko.tvmaniac.seasondetails.api.SeasonDetailsRepository
 import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
 
 @Inject
@@ -35,8 +36,10 @@ public class ShowContentSyncInteractor(
                     showTraktId = params.traktId,
                     forceRefresh = params.forceRefresh,
                 )
-            } catch (t: Throwable) {
-                logger.error("Error while updating show seasons/episodes: ${params.traktId}", t)
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (throwable: Throwable) {
+                logger.error(TAG, "Failed to sync show ${params.traktId}", throwable)
             }
         }
     }
@@ -46,4 +49,8 @@ public class ShowContentSyncInteractor(
         val forceRefresh: Boolean = false,
         val isUserInitiated: Boolean = false,
     )
+
+    private companion object {
+        private const val TAG = "ShowContentSync"
+    }
 }

--- a/domain/upnext/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/upnext/UpNextSyncWorker.kt
+++ b/domain/upnext/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/upnext/UpNextSyncWorker.kt
@@ -51,6 +51,7 @@ public class UpNextSyncWorker(
             id = WORKER_NAME,
             intervalMs = SIX_HOURS_MS,
             constraints = TaskConstraints(requiresNetwork = true),
+            longRunning = true,
         )
     }
 }

--- a/features/debug/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/debug/presenter/DebugPresenter.kt
+++ b/features/debug/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/debug/presenter/DebugPresenter.kt
@@ -139,11 +139,23 @@ public class DebugPresenter(
         val formattedDate = lastTokenRefreshTimestamp?.let(dateTimeProvider::epochToDisplayDateTime)
             ?: return localizer.getString(StringResourceKey.LabelDebugNeverRefreshed)
 
-        val key = if (authState?.isAuthorized == true) {
-            StringResourceKey.LabelDebugTokenRefreshValid
+        val expiresAt = authState?.expiresAt
+        val remaining = expiresAt?.minus(dateTimeProvider.now())
+        return if (authState?.isAuthorized == true && remaining != null && remaining.isPositive()) {
+            localizer.getString(
+                StringResourceKey.LabelDebugTokenExpiresIn,
+                formattedDate,
+                formatRemaining(remaining),
+            )
         } else {
-            StringResourceKey.LabelDebugTokenRefreshExpired
+            localizer.getString(StringResourceKey.LabelDebugTokenExpired, formattedDate)
         }
-        return localizer.getString(key, formattedDate)
+    }
+
+    private fun formatRemaining(duration: Duration): String = when {
+        duration.inWholeDays >= 1 -> "${duration.inWholeDays}d ${duration.inWholeHours % 24}h"
+        duration.inWholeHours >= 1 -> "${duration.inWholeHours}h ${duration.inWholeMinutes % 60}m"
+        duration.inWholeMinutes >= 1 -> "${duration.inWholeMinutes}m"
+        else -> "${duration.inWholeSeconds.coerceAtLeast(0)}s"
     }
 }

--- a/features/debug/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/debug/presenter/DebugPresenterTest.kt
+++ b/features/debug/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/debug/presenter/DebugPresenterTest.kt
@@ -37,6 +37,8 @@ import kotlinx.coroutines.test.setMain
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class DebugPresenterTest {
@@ -74,13 +76,16 @@ class DebugPresenterTest {
     }
 
     @Test
-    fun `should return valid token status given logged in with authorized auth state`() = runTest {
+    fun `should return expires-in subtitle given logged in with future expiry`() = runTest {
+        val now = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+        dateTimeProvider.setCurrentTime(now)
         traktAuthRepository.setState(TraktAuthState.LOGGED_IN)
         traktAuthRepository.setAuthState(
             AuthState(
                 accessToken = "test-token",
                 refreshToken = "test-refresh",
                 isAuthorized = true,
+                expiresAt = now + 3.hours,
             ),
         )
         datastoreRepository.setLastTokenRefreshTimestamp(1_700_000_000_000L)
@@ -92,16 +97,16 @@ class DebugPresenterTest {
             advanceUntilIdle()
             val state = expectMostRecentItem()
 
-            val expectedDate = "Mar 22, 2026 at 10:00"
             state.tokenStatusSubtitle shouldBe localizer.getString(
-                StringResourceKey.LabelDebugTokenRefreshValid,
-                expectedDate,
+                StringResourceKey.LabelDebugTokenExpiresIn,
+                "Mar 22, 2026 at 10:00",
+                "3h 0m",
             )
         }
     }
 
     @Test
-    fun `should return expired token status given logged in with unauthorized auth state`() = runTest {
+    fun `should return expired subtitle given logged in with unauthorized auth state`() = runTest {
         traktAuthRepository.setState(TraktAuthState.LOGGED_IN)
         traktAuthRepository.setAuthState(
             AuthState(
@@ -119,10 +124,38 @@ class DebugPresenterTest {
             advanceUntilIdle()
             val state = expectMostRecentItem()
 
-            val expectedDate = "Mar 22, 2026 at 10:00"
             state.tokenStatusSubtitle shouldBe localizer.getString(
-                StringResourceKey.LabelDebugTokenRefreshExpired,
-                expectedDate,
+                StringResourceKey.LabelDebugTokenExpired,
+                "Mar 22, 2026 at 10:00",
+            )
+        }
+    }
+
+    @Test
+    fun `should return expired subtitle given logged in with past expiry`() = runTest {
+        val now = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+        dateTimeProvider.setCurrentTime(now)
+        traktAuthRepository.setState(TraktAuthState.LOGGED_IN)
+        traktAuthRepository.setAuthState(
+            AuthState(
+                accessToken = "test-token",
+                refreshToken = "test-refresh",
+                isAuthorized = true,
+                expiresAt = now - 1.hours,
+            ),
+        )
+        datastoreRepository.setLastTokenRefreshTimestamp(1_700_000_000_000L)
+        dateTimeProvider.setEpochToDisplayDateTimeResult("Mar 22, 2026 at 10:00")
+
+        val presenter = createPresenter()
+
+        presenter.state.test {
+            advanceUntilIdle()
+            val state = expectMostRecentItem()
+
+            state.tokenStatusSubtitle shouldBe localizer.getString(
+                StringResourceKey.LabelDebugTokenExpired,
+                "Mar 22, 2026 at 10:00",
             )
         }
     }

--- a/features/discover/presenter/build.gradle.kts
+++ b/features/discover/presenter/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
                 implementation(projects.domain.episode)
                 implementation(projects.domain.followedshows)
                 implementation(projects.domain.genre)
+                implementation(projects.domain.showdetails)
                 implementation(projects.domain.upnext)
                 implementation(projects.data.episode.api)
                 implementation(projects.data.followedshows.api)
@@ -41,6 +42,7 @@ kotlin {
 
         commonTest {
             dependencies {
+                implementation(projects.core.base.testing)
                 implementation(projects.core.logger.testing)
                 implementation(projects.data.episode.testing)
                 implementation(projects.data.upnext.testing)
@@ -48,6 +50,8 @@ kotlin {
                 implementation(projects.data.followedshows.testing)
                 implementation(projects.data.genre.testing)
                 implementation(projects.data.popularshows.testing)
+                implementation(projects.data.seasondetails.testing)
+                implementation(projects.data.showdetails.testing)
                 implementation(projects.data.topratedshows.testing)
                 implementation(projects.data.traktauth.testing)
                 implementation(projects.data.trendingshows.testing)

--- a/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/DiscoverShowsPresenter.kt
+++ b/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/DiscoverShowsPresenter.kt
@@ -23,7 +23,7 @@ import com.thomaskioko.tvmaniac.domain.episode.MarkEpisodeWatchedInteractor
 import com.thomaskioko.tvmaniac.domain.episode.MarkEpisodeWatchedParams
 import com.thomaskioko.tvmaniac.domain.followedshows.UnfollowShowInteractor
 import com.thomaskioko.tvmaniac.domain.genre.GenreShowsInteractor
-import com.thomaskioko.tvmaniac.followedshows.api.FollowedShowsRepository
+import com.thomaskioko.tvmaniac.domain.showdetails.FollowShowInteractor
 import com.thomaskioko.tvmaniac.home.nav.HomeRoute
 import com.thomaskioko.tvmaniac.home.nav.di.model.HomeConfig
 import com.thomaskioko.tvmaniac.shows.api.model.Category
@@ -50,7 +50,7 @@ public class DiscoverShowsPresenter(
     componentContext: ComponentContext,
     private val navigator: DiscoverNavigator,
     private val discoverShowsInteractor: DiscoverShowsInteractor,
-    private val followedShowsRepository: FollowedShowsRepository,
+    private val followShowInteractor: FollowShowInteractor,
     private val unfollowShowInteractor: UnfollowShowInteractor,
     private val featuredShowsInteractor: FeaturedShowsInteractor,
     private val topRatedShowsInteractor: TopRatedShowsInteractor,
@@ -171,7 +171,9 @@ public class DiscoverShowsPresenter(
                         if (action.inLibrary) {
                             unfollowShowInteractor.executeSync(action.traktId)
                         } else {
-                            followedShowsRepository.addFollowedShow(action.traktId)
+                            followShowInteractor.executeSync(
+                                FollowShowInteractor.Param(traktId = action.traktId),
+                            )
                         }
                     }
                 }

--- a/features/discover/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/discover/presenter/DiscoverShowsPresenterTest.kt
+++ b/features/discover/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/discover/presenter/DiscoverShowsPresenterTest.kt
@@ -5,6 +5,7 @@ import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.decompose.router.stack.StackNavigation
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
+import com.thomaskioko.tvmaniac.core.base.coroutines.FakeAppScopeLauncher
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.logger.fixture.FakeLogger
 import com.thomaskioko.tvmaniac.core.view.ErrorToStringMapper
@@ -12,6 +13,7 @@ import com.thomaskioko.tvmaniac.data.featuredshows.api.interactor.FeaturedShowsI
 import com.thomaskioko.tvmaniac.data.featuredshows.testing.FakeFeaturedShowsRepository
 import com.thomaskioko.tvmaniac.data.popularshows.api.PopularShowsInteractor
 import com.thomaskioko.tvmaniac.data.popularshows.testing.FakePopularShowsRepository
+import com.thomaskioko.tvmaniac.data.showdetails.testing.FakeShowDetailsRepository
 import com.thomaskioko.tvmaniac.data.topratedshows.testing.FakeTopRatedShowsRepository
 import com.thomaskioko.tvmaniac.data.trendingshows.testing.FakeTrendingShowsRepository
 import com.thomaskioko.tvmaniac.data.upcomingshows.api.UpcomingShowsInteractor
@@ -25,8 +27,11 @@ import com.thomaskioko.tvmaniac.domain.discover.DiscoverShowsInteractor
 import com.thomaskioko.tvmaniac.domain.episode.MarkEpisodeWatchedInteractor
 import com.thomaskioko.tvmaniac.domain.followedshows.UnfollowShowInteractor
 import com.thomaskioko.tvmaniac.domain.genre.GenreShowsInteractor
+import com.thomaskioko.tvmaniac.domain.showdetails.FollowShowInteractor
+import com.thomaskioko.tvmaniac.domain.showdetails.ShowContentSyncInteractor
 import com.thomaskioko.tvmaniac.domain.upnext.ObserveUpNextInteractor
 import com.thomaskioko.tvmaniac.episodes.testing.FakeEpisodeRepository
+import com.thomaskioko.tvmaniac.episodes.testing.FakeWatchedEpisodeSyncRepository
 import com.thomaskioko.tvmaniac.followedshows.testing.FakeFollowedShowsRepository
 import com.thomaskioko.tvmaniac.genre.FakeGenreRepository
 import com.thomaskioko.tvmaniac.home.nav.HomeTabNavigator
@@ -36,6 +41,7 @@ import com.thomaskioko.tvmaniac.navigation.testing.TestNavigator
 import com.thomaskioko.tvmaniac.navigation.testing.test
 import com.thomaskioko.tvmaniac.seasondetails.nav.SeasonDetailsRoute
 import com.thomaskioko.tvmaniac.seasondetails.nav.SeasonDetailsUiParam
+import com.thomaskioko.tvmaniac.seasondetails.testing.FakeSeasonDetailsRepository
 import com.thomaskioko.tvmaniac.shows.api.model.ShowEntity
 import com.thomaskioko.tvmaniac.topratedshows.data.api.TopRatedShowsInteractor
 import com.thomaskioko.tvmaniac.traktauth.testing.FakeTraktAuthRepository
@@ -45,7 +51,9 @@ import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldNotBeSameInstanceAs
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -57,8 +65,12 @@ import kotlin.test.Test
 class DiscoverShowsPresenterTest {
 
     private val testDispatcher = StandardTestDispatcher()
+    private val appCoroutineScope = CoroutineScope(testDispatcher + SupervisorJob())
 
     private val featuredShowsRepository = FakeFeaturedShowsRepository()
+    private val showDetailsRepository = FakeShowDetailsRepository()
+    private val seasonDetailsRepository = FakeSeasonDetailsRepository()
+    private val watchedEpisodeSyncRepository = FakeWatchedEpisodeSyncRepository()
     private val trendingShowsRepository = FakeTrendingShowsRepository()
     private val upcomingShowsRepository = FakeUpcomingShowsRepository()
     private val topRatedShowsRepository = FakeTopRatedShowsRepository()
@@ -306,7 +318,18 @@ class DiscoverShowsPresenterTest {
                 observeUpNextInteractor = observeUpNextInteractor,
                 dispatchers = coroutineDispatcher,
             ),
-            followedShowsRepository = followedShowsRepository,
+            followShowInteractor = FollowShowInteractor(
+                followedShowsRepository = followedShowsRepository,
+                showContentSyncInteractor = ShowContentSyncInteractor(
+                    showDetailsRepository = showDetailsRepository,
+                    seasonDetailsRepository = seasonDetailsRepository,
+                    watchedEpisodeSyncRepository = watchedEpisodeSyncRepository,
+                    dispatchers = coroutineDispatcher,
+                    logger = FakeLogger(),
+                ),
+                upNextRepository = upNextRepository,
+                appScopeLauncher = FakeAppScopeLauncher(scope = appCoroutineScope),
+            ),
             featuredShowsInteractor = FeaturedShowsInteractor(
                 featuredShowsRepository = featuredShowsRepository,
                 dispatchers = coroutineDispatcher,
@@ -462,7 +485,18 @@ class DiscoverShowsPresenterTest {
             observeUpNextInteractor = observeUpNextInteractor,
             dispatchers = coroutineDispatcher,
         ),
-        followedShowsRepository = followedShowsRepository,
+        followShowInteractor = FollowShowInteractor(
+            followedShowsRepository = followedShowsRepository,
+            showContentSyncInteractor = ShowContentSyncInteractor(
+                showDetailsRepository = showDetailsRepository,
+                seasonDetailsRepository = seasonDetailsRepository,
+                watchedEpisodeSyncRepository = watchedEpisodeSyncRepository,
+                dispatchers = coroutineDispatcher,
+                logger = FakeLogger(),
+            ),
+            upNextRepository = upNextRepository,
+            appScopeLauncher = FakeAppScopeLauncher(scope = appCoroutineScope),
+        ),
         featuredShowsInteractor = FeaturedShowsInteractor(
             featuredShowsRepository = featuredShowsRepository,
             dispatchers = coroutineDispatcher,

--- a/features/episode-sheet/presenter/build.gradle.kts
+++ b/features/episode-sheet/presenter/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
 
         commonTest {
             dependencies {
+                implementation(projects.core.base.testing)
                 implementation(projects.core.logger.testing)
                 implementation(projects.core.util.testing)
                 implementation(projects.data.episode.testing)

--- a/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenter.kt
+++ b/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenter.kt
@@ -3,6 +3,7 @@ package com.thomaskioko.tvmaniac.presentation.episodedetail
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.value.Value
 import com.thomaskioko.tvmaniac.core.base.ActivityScope
+import com.thomaskioko.tvmaniac.core.base.coroutines.AppScopeLauncher
 import com.thomaskioko.tvmaniac.core.base.extensions.asValue
 import com.thomaskioko.tvmaniac.core.base.extensions.coroutineScope
 import com.thomaskioko.tvmaniac.core.logger.Logger
@@ -51,6 +52,7 @@ public class EpisodeSheetPresenter(
     private val errorToStringMapper: ErrorToStringMapper,
     private val localizer: Localizer,
     private val logger: Logger,
+    private val appScopeLauncher: AppScopeLauncher,
 ) {
 
     private val coroutineScope = componentContext.coroutineScope()
@@ -90,7 +92,8 @@ public class EpisodeSheetPresenter(
 
     private fun toggleWatched() {
         val episode = currentEpisode ?: return
-        coroutineScope.launch {
+        sheetNavigator.dismiss()
+        appScopeLauncher.launch(TAG) {
             if (episode.is_watched != 0L) {
                 markEpisodeUnwatchedInteractor(
                     MarkEpisodeUnwatchedParams(
@@ -108,7 +111,6 @@ public class EpisodeSheetPresenter(
                     ),
                 ).collectStatus(actionLoadingState, logger, uiMessageManager, errorToStringMapper = errorToStringMapper)
             }
-            sheetNavigator.dismiss()
         }
     }
 
@@ -134,9 +136,9 @@ public class EpisodeSheetPresenter(
 
     private fun unfollowShow() {
         val episode = currentEpisode ?: return
-        coroutineScope.launch {
+        sheetNavigator.dismiss()
+        appScopeLauncher.launch(TAG) {
             unfollowShowInteractor.executeSync(episode.show_trakt_id.id)
-            sheetNavigator.dismiss()
         }
     }
 
@@ -149,5 +151,9 @@ public class EpisodeSheetPresenter(
     @AssistedFactory
     public fun interface Factory {
         public fun create(episodeId: Long, source: ScreenSource): EpisodeSheetPresenter
+    }
+
+    private companion object {
+        private const val TAG = "EpisodeSheetPresenter"
     }
 }

--- a/features/episode-sheet/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenterTest.kt
+++ b/features/episode-sheet/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenterTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.decompose.router.stack.StackNavigation
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.thomaskioko.tvmaniac.core.base.coroutines.FakeAppScopeLauncher
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.logger.fixture.FakeLogger
 import com.thomaskioko.tvmaniac.core.view.ErrorToStringMapper
@@ -28,7 +29,9 @@ import com.thomaskioko.tvmaniac.showdetails.nav.ShowDetailsRoute
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -41,6 +44,7 @@ internal class EpisodeSheetPresenterTest {
 
     private val lifecycle = LifecycleRegistry()
     private val testDispatcher = StandardTestDispatcher()
+    private val appCoroutineScope = CoroutineScope(testDispatcher + SupervisorJob())
     private val episodeRepository = FakeEpisodeRepository()
     private val followedShowsRepository = FakeFollowedShowsRepository()
     private val localizer = FakeLocalizer()
@@ -175,7 +179,8 @@ internal class EpisodeSheetPresenterTest {
     fun `should mark episode as watched given ToggleWatched is dispatched and episode is unwatched`() = runTest {
         episodeRepository.setEpisodeById(testEpisode(isWatched = false))
 
-        val presenter = createPresenter()
+        val sheetNavigator = FakeSheetNavigator()
+        val presenter = createPresenter(sheetNavigator = sheetNavigator)
 
         presenter.state.test {
             awaitItem()
@@ -193,6 +198,7 @@ internal class EpisodeSheetPresenterTest {
                 episodeNumber = 1L,
             )
             episodeRepository.lastMarkEpisodeUnwatchedCall.shouldBeNull()
+            sheetNavigator.dismissCount shouldBe 1
         }
     }
 
@@ -200,7 +206,8 @@ internal class EpisodeSheetPresenterTest {
     fun `should mark episode as unwatched given ToggleWatched is dispatched and episode is watched`() = runTest {
         episodeRepository.setEpisodeById(testEpisode(isWatched = true))
 
-        val presenter = createPresenter()
+        val sheetNavigator = FakeSheetNavigator()
+        val presenter = createPresenter(sheetNavigator = sheetNavigator)
 
         presenter.state.test {
             awaitItem()
@@ -215,6 +222,36 @@ internal class EpisodeSheetPresenterTest {
                 showTraktId = 100L,
                 episodeId = 1L,
             )
+            sheetNavigator.dismissCount shouldBe 1
+        }
+    }
+
+    @Test
+    fun `should dismiss sheet immediately given ToggleWatched is dispatched and before background work completes`() = runTest {
+        episodeRepository.setEpisodeById(testEpisode(isWatched = false))
+
+        val sheetNavigator = FakeSheetNavigator()
+        val presenter = createPresenter(sheetNavigator = sheetNavigator)
+
+        presenter.state.test {
+            awaitItem()
+            testDispatcher.scheduler.advanceUntilIdle()
+            awaitItem()
+
+            presenter.dispatch(EpisodeSheetAction.ToggleWatched)
+
+            sheetNavigator.dismissCount shouldBe 1
+            episodeRepository.lastMarkEpisodeWatchedCall.shouldBeNull()
+
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            episodeRepository.lastMarkEpisodeWatchedCall shouldBe
+                com.thomaskioko.tvmaniac.episodes.testing.MarkEpisodeWatchedCall(
+                    showTraktId = 100L,
+                    episodeId = 1L,
+                    seasonNumber = 1L,
+                    episodeNumber = 1L,
+                )
         }
     }
 
@@ -324,6 +361,7 @@ internal class EpisodeSheetPresenterTest {
     private fun createPresenter(
         source: ScreenSource = ScreenSource.DISCOVER,
         sheetNavigator: FakeSheetNavigator = FakeSheetNavigator(),
+        appScopeLauncher: FakeAppScopeLauncher = FakeAppScopeLauncher(appCoroutineScope),
     ): EpisodeSheetPresenter {
         navigatedToShowId = null
         navigatedToSeason = null
@@ -365,6 +403,7 @@ internal class EpisodeSheetPresenterTest {
             errorToStringMapper = ErrorToStringMapper { it.message ?: "Test error" },
             localizer = localizer,
             logger = logger,
+            appScopeLauncher = appScopeLauncher,
         )
     }
 

--- a/features/show-details/presenter/build.gradle.kts
+++ b/features/show-details/presenter/build.gradle.kts
@@ -47,6 +47,7 @@ kotlin {
 
         commonTest {
             dependencies {
+                implementation(projects.core.base.testing)
                 implementation(projects.core.logger.testing)
                 implementation(projects.core.util.testing)
                 implementation(projects.data.cast.testing)

--- a/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/ShowDetailsPresenterTest.kt
+++ b/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/ShowDetailsPresenterTest.kt
@@ -10,6 +10,7 @@ import com.arkivanov.decompose.router.stack.pushNew
 import com.arkivanov.decompose.router.stack.pushToFront
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.thomaskioko.root.nav.NotificationRationale
+import com.thomaskioko.tvmaniac.core.base.coroutines.FakeAppScopeLauncher
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.logger.fixture.FakeLogger
 import com.thomaskioko.tvmaniac.core.notifications.api.EpisodeNotification
@@ -72,7 +73,9 @@ import com.thomaskioko.tvmaniac.util.testing.FakeFormatterUtil
 import io.kotest.matchers.shouldBe
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -107,6 +110,7 @@ class ShowDetailsPresenterTest {
     private val fakeLogger = FakeLogger()
     private val fakeDateTimeProvider = FakeDateTimeProvider()
     private val testDispatcher = StandardTestDispatcher()
+    private val appCoroutineScope = CoroutineScope(testDispatcher + SupervisorJob())
     private val coroutineDispatcher = AppCoroutineDispatchers(
         main = testDispatcher,
         io = testDispatcher,
@@ -894,8 +898,7 @@ class ShowDetailsPresenterTest {
                     watchedEpisodeSyncRepository = watchedEpisodeSyncRepository,
                 ),
                 upNextRepository = upNextRepository,
-                dispatchers = coroutineDispatcher,
-                logger = fakeLogger,
+                appScopeLauncher = FakeAppScopeLauncher(scope = appCoroutineScope),
             ),
             showDetailsInteractor = ShowDetailsInteractor(
                 showDetailsRepository = showDetailsRepository,

--- a/i18n/generator/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/base/strings.xml
@@ -351,8 +351,8 @@
     <string name="label_debug_trigger_crash_title">Test Crash</string>
     <string name="label_debug_trigger_crash_description">Trigger a test crash for Crashlytics</string>
     <string name="label_debug_token_status_title">Token Status</string>
-    <string name="label_debug_token_refresh_valid">Last refreshed: %s · Token is valid</string>
-    <string name="label_debug_token_refresh_expired">Last refreshed: %s · Token has expired</string>
+    <string name="label_debug_token_expires_in">Last refreshed: %1$s · Expires in %2$s</string>
+    <string name="label_debug_token_expired">Last refreshed: %s · Expired</string>
     <string name="label_debug_never_refreshed">Never refreshed</string>
 
     <string name="label_genre_category_popular">Popular</string>

--- a/i18n/generator/src/commonMain/moko-resources/de/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/de/strings.xml
@@ -343,8 +343,8 @@
     <string name="label_debug_trigger_crash_title">Testabsturz</string>
     <string name="label_debug_trigger_crash_description">Einen Testabsturz für Crashlytics auslösen</string>
     <string name="label_debug_token_status_title">Token-Status</string>
-    <string name="label_debug_token_refresh_valid">Zuletzt aktualisiert: %s · Token ist gültig</string>
-    <string name="label_debug_token_refresh_expired">Zuletzt aktualisiert: %s · Token ist abgelaufen</string>
+    <string name="label_debug_token_expires_in">Zuletzt aktualisiert: %1$s · Läuft ab in %2$s</string>
+    <string name="label_debug_token_expired">Zuletzt aktualisiert: %s · Abgelaufen</string>
     <string name="label_debug_never_refreshed">Nie aktualisiert</string>
 
     <string name="label_genre_category_popular">Beliebt</string>

--- a/i18n/generator/src/commonMain/moko-resources/fr/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/fr/strings.xml
@@ -341,8 +341,8 @@
     <string name="label_debug_trigger_crash_title">Test de crash</string>
     <string name="label_debug_trigger_crash_description">Déclencher un crash de test pour Crashlytics</string>
     <string name="label_debug_token_status_title">Statut du token</string>
-    <string name="label_debug_token_refresh_valid">Dernière actualisation : %s · Le token est valide</string>
-    <string name="label_debug_token_refresh_expired">Dernière actualisation : %s · Le token a expiré</string>
+    <string name="label_debug_token_expires_in">Dernière actualisation : %1$s · Expire dans %2$s</string>
+    <string name="label_debug_token_expired">Dernière actualisation : %s · Expiré</string>
     <string name="label_debug_never_refreshed">Jamais actualisé</string>
 
     <string name="label_genre_category_popular">Populaire</string>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -87,6 +87,7 @@ include(
     ":core:appconfig:api",
     ":core:appconfig:implementation",
     ":core:base",
+    ":core:base:testing",
     ":core:connectivity:api",
     ":core:connectivity:implementation",
     ":core:connectivity:testing",


### PR DESCRIPTION
## Description
This PR makes background data sync reliable when the user moves away from a screen mid-flight, and tightens iOS BGTaskScheduler around thread safety and timer behaviour. Following a show, marking episodes watched, or refreshing show content no longer drops mid-sync because Decompose cancelled the presenter scope. The local DB write still completes synchronously so the UI flips immediately, while the remote sync runs on a process-scoped supervisor that survives screen exit.
