### PR TITLE
chore: Standardize show and episode identifier naming

### DIFF
--- a/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/TraktEpisodeHistoryRemoteDataSource.kt
+++ b/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/TraktEpisodeHistoryRemoteDataSource.kt
@@ -6,7 +6,7 @@ import com.thomaskioko.tvmaniac.trakt.api.model.TraktSyncItems
 import com.thomaskioko.tvmaniac.trakt.api.model.TraktSyncResponse
 
 public interface TraktEpisodeHistoryRemoteDataSource {
-    public suspend fun getShowEpisodeWatches(showTraktId: Long): ApiResponse<List<TraktHistoryEntry>>
+    public suspend fun getShowEpisodeWatches(showId: Long): ApiResponse<List<TraktHistoryEntry>>
     public suspend fun addEpisodeWatches(items: TraktSyncItems): ApiResponse<TraktSyncResponse>
     public suspend fun removeEpisodeWatches(items: TraktSyncItems): ApiResponse<TraktSyncResponse>
 }

--- a/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/TraktListRemoteDataSource.kt
+++ b/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/TraktListRemoteDataSource.kt
@@ -28,25 +28,25 @@ public interface TraktListRemoteDataSource {
 
     public suspend fun removeShowFromWatchListByTmdbId(tmdbId: Long): ApiResponse<TraktAddRemoveShowFromListResponse>
 
-    public suspend fun addShowToWatchListById(traktId: Long): ApiResponse<TraktAddShowToListResponse>
+    public suspend fun addShowToWatchListById(showId: Long): ApiResponse<TraktAddShowToListResponse>
 
-    public suspend fun removeShowFromWatchListById(traktId: Long): ApiResponse<TraktAddRemoveShowFromListResponse>
+    public suspend fun removeShowFromWatchListById(showId: Long): ApiResponse<TraktAddRemoveShowFromListResponse>
 
-    public suspend fun addShowsToWatchListByIds(traktIds: List<Long>): ApiResponse<TraktAddShowToListResponse>
+    public suspend fun addShowsToWatchListByIds(showIds: List<Long>): ApiResponse<TraktAddShowToListResponse>
 
     public suspend fun removeShowsFromWatchListByIds(
-        traktIds: List<Long>,
+        showIds: List<Long>,
     ): ApiResponse<TraktAddRemoveShowFromListResponse>
 
     public suspend fun addShowToList(
         userSlug: String,
         listId: Long,
-        traktShowId: Long,
+        showId: Long,
     ): ApiResponse<TraktAddShowToListResponse>
 
     public suspend fun removeShowFromList(
         userSlug: String,
         listId: Long,
-        traktShowId: Long,
+        showId: Long,
     ): ApiResponse<TraktAddRemoveShowFromListResponse>
 }

--- a/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/TraktListRemoteDataSource.kt
+++ b/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/TraktListRemoteDataSource.kt
@@ -28,13 +28,13 @@ public interface TraktListRemoteDataSource {
 
     public suspend fun removeShowFromWatchListByTmdbId(tmdbId: Long): ApiResponse<TraktAddRemoveShowFromListResponse>
 
-    public suspend fun addShowToWatchListByTraktId(traktId: Long): ApiResponse<TraktAddShowToListResponse>
+    public suspend fun addShowToWatchListById(traktId: Long): ApiResponse<TraktAddShowToListResponse>
 
-    public suspend fun removeShowFromWatchListByTraktId(traktId: Long): ApiResponse<TraktAddRemoveShowFromListResponse>
+    public suspend fun removeShowFromWatchListById(traktId: Long): ApiResponse<TraktAddRemoveShowFromListResponse>
 
-    public suspend fun addShowsToWatchListByTraktIds(traktIds: List<Long>): ApiResponse<TraktAddShowToListResponse>
+    public suspend fun addShowsToWatchListByIds(traktIds: List<Long>): ApiResponse<TraktAddShowToListResponse>
 
-    public suspend fun removeShowsFromWatchListByTraktIds(
+    public suspend fun removeShowsFromWatchListByIds(
         traktIds: List<Long>,
     ): ApiResponse<TraktAddRemoveShowFromListResponse>
 

--- a/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/TraktShowsRemoteDataSource.kt
+++ b/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/TraktShowsRemoteDataSource.kt
@@ -103,14 +103,14 @@ public interface TraktShowsRemoteDataSource {
      * Related shows are determined by Trakt's recommendation algorithm based on
      * user behavior patterns (users who liked X also liked Y).
      *
-     * @param traktId The Trakt ID of the show to find related shows for
+     * @param showId The Trakt ID of the show to find related shows for
      * @param page Page number for pagination (1-indexed)
      * @param limit Number of results per page (max 100)
      * @return List of related shows
      * @see [Trakt Related Shows](https://trakt.docs.apiary.io/#reference/shows/related)
      */
     public suspend fun getRelatedShows(
-        traktId: Long,
+        showId: Long,
         page: Int = 1,
         limit: Int = 20,
     ): ApiResponse<List<TraktShowResponse>>
@@ -118,31 +118,31 @@ public interface TraktShowsRemoteDataSource {
     /**
      * Fetches detailed information for a specific show.
      *
-     * @param traktId The Trakt ID of the show
+     * @param showId The Trakt ID of the show
      * @return Full show details including all extended information
      * @see [Trakt Show Summary](https://trakt.docs.apiary.io/#reference/shows/summary)
      */
-    public suspend fun getShowDetails(traktId: Long): ApiResponse<TraktShowResponse>
+    public suspend fun getShowDetails(showId: Long): ApiResponse<TraktShowResponse>
 
     /**
      * Fetches all seasons for a specific show with extended information.
      *
-     * @param traktId The Trakt ID of the show
+     * @param showId The Trakt ID of the show
      * @return List of seasons with episode counts, ratings, and air dates
      * @see [Trakt Show Seasons](https://trakt.docs.apiary.io/#reference/seasons/summary)
      */
-    public suspend fun getShowSeasons(traktId: Long): ApiResponse<List<TraktSeasonsResponse>>
+    public suspend fun getShowSeasons(showId: Long): ApiResponse<List<TraktSeasonsResponse>>
 
     /**
      * Fetches a specific season with all episodes.
      *
-     * @param traktId The Trakt ID of the show
+     * @param showId The Trakt ID of the show
      * @param seasonNumber The season number to fetch
      * @return Season details with all episodes
      * @see [Trakt Season Summary](https://trakt.docs.apiary.io/#reference/seasons/season)
      */
     public suspend fun getShowSeasonEpisodes(
-        traktId: Long,
+        showId: Long,
         seasonNumber: Int,
     ): ApiResponse<List<TraktEpisodesResponse>>
 
@@ -152,11 +152,11 @@ public interface TraktShowsRemoteDataSource {
      * Uses extended=full,episodes to get complete season and episode data,
      * reducing API calls from N (one per season) to 1.
      *
-     * @param traktId The Trakt ID of the show
+     * @param showId The Trakt ID of the show
      * @return List of seasons, each containing its episodes
      * @see [Trakt Seasons](https://trakt.docs.apiary.io/#reference/seasons/summary)
      */
-    public suspend fun getSeasonsWithEpisodes(traktId: Long): ApiResponse<List<TraktSeasonEpisodesResponse>>
+    public suspend fun getSeasonsWithEpisodes(showId: Long): ApiResponse<List<TraktSeasonEpisodesResponse>>
 
     /**
      * Searches for a show by its TMDB ID.
@@ -192,22 +192,22 @@ public interface TraktShowsRemoteDataSource {
      * Returns all cast members with their character names and episode counts.
      * Data is sorted by episode count (most appearances first).
      *
-     * @param traktId The Trakt ID of the show
+     * @param showId The Trakt ID of the show
      * @return Show people response containing cast information
      * @see [Trakt Show People](https://trakt.docs.apiary.io/#reference/shows/people)
      */
-    public suspend fun getShowPeople(traktId: Long): ApiResponse<TraktShowPeopleResponse>
+    public suspend fun getShowPeople(showId: Long): ApiResponse<TraktShowPeopleResponse>
 
     /**
      * Fetches all videos for a specific show.
      *
      * Returns trailers, teasers, and other video content from YouTube and other sites.
      *
-     * @param traktId The Trakt ID of the show
+     * @param showId The Trakt ID of the show
      * @return List of video responses containing URLs and metadata
      * @see [Trakt Show Videos](https://trakt.docs.apiary.io/#reference/shows/videos)
      */
-    public suspend fun getShowVideos(traktId: Long): ApiResponse<List<TraktVideosResponse>>
+    public suspend fun getShowVideos(showId: Long): ApiResponse<List<TraktVideosResponse>>
 
     /**
      * Fetches the user's watch progress for a specific show.
@@ -216,11 +216,11 @@ public interface TraktShowsRemoteDataSource {
      * Requires user authentication. The response includes `aired`, `completed` counts,
      * and nested `next_episode` / `last_episode` objects.
      *
-     * @param traktId The Trakt ID of the show
+     * @param showId The Trakt ID of the show
      * @return Watch progress with next and last episode information
      * @see [Trakt Watched Progress](https://trakt.docs.apiary.io/#reference/shows/watched-progress)
      */
-    public suspend fun getWatchedProgress(traktId: Long): ApiResponse<TraktWatchedProgressResponse>
+    public suspend fun getWatchedProgress(showId: Long): ApiResponse<TraktWatchedProgressResponse>
 }
 
 /**

--- a/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/TraktSyncRemoteDataSource.kt
+++ b/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/TraktSyncRemoteDataSource.kt
@@ -16,7 +16,7 @@ public interface TraktSyncRemoteDataSource {
     ): ApiResponse<List<TraktPlaybackEpisodeResponse>>
 
     public suspend fun getShowWatchedProgress(
-        traktId: Long,
+        showId: Long,
         lastActivity: String? = null,
         hidden: Boolean = false,
         specials: Boolean = false,

--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktEpisodeRemoteDataSource.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktEpisodeRemoteDataSource.kt
@@ -24,11 +24,11 @@ public class DefaultTraktEpisodeRemoteDataSource(
     private val httpClient: HttpClient,
 ) : TraktEpisodeHistoryRemoteDataSource {
 
-    override suspend fun getShowEpisodeWatches(showTraktId: Long): ApiResponse<List<TraktHistoryEntry>> =
+    override suspend fun getShowEpisodeWatches(showId: Long): ApiResponse<List<TraktHistoryEntry>> =
         httpClient.authSafeRequest {
             url {
                 method = HttpMethod.Get
-                path("users/me/history/shows/$showTraktId")
+                path("users/me/history/shows/$showId")
                 parameters.append("extended", "noseasons")
                 parameters.append("limit", "10000")
             }

--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktListRemoteDataSource.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktListRemoteDataSource.kt
@@ -115,15 +115,15 @@ public class DefaultTraktListRemoteDataSource(
         }
 
     override suspend fun addShowToWatchListById(
-        traktId: Long,
-    ): ApiResponse<TraktAddShowToListResponse> = addShowsToWatchListByIds(listOf(traktId))
+        showId: Long,
+    ): ApiResponse<TraktAddShowToListResponse> = addShowsToWatchListByIds(listOf(showId))
 
     override suspend fun removeShowFromWatchListById(
-        traktId: Long,
-    ): ApiResponse<TraktAddRemoveShowFromListResponse> = removeShowsFromWatchListByIds(listOf(traktId))
+        showId: Long,
+    ): ApiResponse<TraktAddRemoveShowFromListResponse> = removeShowsFromWatchListByIds(listOf(showId))
 
     override suspend fun addShowsToWatchListByIds(
-        traktIds: List<Long>,
+        showIds: List<Long>,
     ): ApiResponse<TraktAddShowToListResponse> =
         httpClient.authSafeRequest {
             url {
@@ -133,13 +133,13 @@ public class DefaultTraktListRemoteDataSource(
             contentType(ContentType.Application.Json)
             setBody(
                 TraktAddShowRequest(
-                    shows = traktIds.map { TraktShow(ids = TraktShowIds(traktId = it)) },
+                    shows = showIds.map { TraktShow(ids = TraktShowIds(traktId = it)) },
                 ),
             )
         }
 
     override suspend fun removeShowsFromWatchListByIds(
-        traktIds: List<Long>,
+        showIds: List<Long>,
     ): ApiResponse<TraktAddRemoveShowFromListResponse> =
         httpClient.authSafeRequest {
             url {
@@ -149,7 +149,7 @@ public class DefaultTraktListRemoteDataSource(
             contentType(ContentType.Application.Json)
             setBody(
                 TraktAddShowRequest(
-                    shows = traktIds.map { TraktShow(ids = TraktShowIds(traktId = it)) },
+                    shows = showIds.map { TraktShow(ids = TraktShowIds(traktId = it)) },
                 ),
             )
         }
@@ -157,7 +157,7 @@ public class DefaultTraktListRemoteDataSource(
     override suspend fun addShowToList(
         userSlug: String,
         listId: Long,
-        traktShowId: Long,
+        showId: Long,
     ): ApiResponse<TraktAddShowToListResponse> =
         httpClient.authSafeRequest {
             url {
@@ -170,7 +170,7 @@ public class DefaultTraktListRemoteDataSource(
                     shows = listOf(
                         TraktShow(
                             ids = TraktShowIds(
-                                traktId = traktShowId,
+                                traktId = showId,
                             ),
                         ),
                     ),
@@ -181,7 +181,7 @@ public class DefaultTraktListRemoteDataSource(
     override suspend fun removeShowFromList(
         userSlug: String,
         listId: Long,
-        traktShowId: Long,
+        showId: Long,
     ): ApiResponse<TraktAddRemoveShowFromListResponse> =
         httpClient.authSafeRequest {
             url {
@@ -194,7 +194,7 @@ public class DefaultTraktListRemoteDataSource(
                     shows = listOf(
                         TraktShow(
                             ids = TraktShowIds(
-                                traktId = traktShowId,
+                                traktId = showId,
                             ),
                         ),
                     ),

--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktListRemoteDataSource.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktListRemoteDataSource.kt
@@ -114,15 +114,15 @@ public class DefaultTraktListRemoteDataSource(
             )
         }
 
-    override suspend fun addShowToWatchListByTraktId(
+    override suspend fun addShowToWatchListById(
         traktId: Long,
-    ): ApiResponse<TraktAddShowToListResponse> = addShowsToWatchListByTraktIds(listOf(traktId))
+    ): ApiResponse<TraktAddShowToListResponse> = addShowsToWatchListByIds(listOf(traktId))
 
-    override suspend fun removeShowFromWatchListByTraktId(
+    override suspend fun removeShowFromWatchListById(
         traktId: Long,
-    ): ApiResponse<TraktAddRemoveShowFromListResponse> = removeShowsFromWatchListByTraktIds(listOf(traktId))
+    ): ApiResponse<TraktAddRemoveShowFromListResponse> = removeShowsFromWatchListByIds(listOf(traktId))
 
-    override suspend fun addShowsToWatchListByTraktIds(
+    override suspend fun addShowsToWatchListByIds(
         traktIds: List<Long>,
     ): ApiResponse<TraktAddShowToListResponse> =
         httpClient.authSafeRequest {
@@ -138,7 +138,7 @@ public class DefaultTraktListRemoteDataSource(
             )
         }
 
-    override suspend fun removeShowsFromWatchListByTraktIds(
+    override suspend fun removeShowsFromWatchListByIds(
         traktIds: List<Long>,
     ): ApiResponse<TraktAddRemoveShowFromListResponse> =
         httpClient.authSafeRequest {

--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktShowsRemoteDataSource.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktShowsRemoteDataSource.kt
@@ -114,55 +114,55 @@ public class DefaultTraktShowsRemoteDataSource(
         }
 
     override suspend fun getRelatedShows(
-        traktId: Long,
+        showId: Long,
         page: Int,
         limit: Int,
     ): ApiResponse<List<TraktShowResponse>> =
         httpClient.safeRequest {
             url {
                 method = HttpMethod.Get
-                path("shows/$traktId/related")
+                path("shows/$showId/related")
             }
             parameter("page", page)
             parameter("limit", limit)
             parameter("extended", "full")
         }
 
-    override suspend fun getShowDetails(traktId: Long): ApiResponse<TraktShowResponse> =
+    override suspend fun getShowDetails(showId: Long): ApiResponse<TraktShowResponse> =
         httpClient.safeRequest {
             url {
                 method = HttpMethod.Get
-                path("shows/$traktId")
+                path("shows/$showId")
             }
             parameter("extended", "full")
         }
 
-    override suspend fun getShowSeasons(traktId: Long): ApiResponse<List<TraktSeasonsResponse>> =
+    override suspend fun getShowSeasons(showId: Long): ApiResponse<List<TraktSeasonsResponse>> =
         httpClient.safeRequest {
             url {
                 method = HttpMethod.Get
-                path("shows/$traktId/seasons")
+                path("shows/$showId/seasons")
             }
             parameter("extended", "full")
         }
 
     override suspend fun getShowSeasonEpisodes(
-        traktId: Long,
+        showId: Long,
         seasonNumber: Int,
     ): ApiResponse<List<TraktEpisodesResponse>> =
         httpClient.safeRequest {
             url {
                 method = HttpMethod.Get
-                path("shows/$traktId/seasons/$seasonNumber")
+                path("shows/$showId/seasons/$seasonNumber")
             }
             parameter("extended", "full")
         }
 
-    override suspend fun getSeasonsWithEpisodes(traktId: Long): ApiResponse<List<TraktSeasonEpisodesResponse>> =
+    override suspend fun getSeasonsWithEpisodes(showId: Long): ApiResponse<List<TraktSeasonEpisodesResponse>> =
         httpClient.safeRequest {
             url {
                 method = HttpMethod.Get
-                path("shows/$traktId/seasons")
+                path("shows/$showId/seasons")
             }
             parameter("extended", "full,episodes")
         }
@@ -192,28 +192,28 @@ public class DefaultTraktShowsRemoteDataSource(
             parameter("extended", "full")
         }
 
-    override suspend fun getShowPeople(traktId: Long): ApiResponse<TraktShowPeopleResponse> =
+    override suspend fun getShowPeople(showId: Long): ApiResponse<TraktShowPeopleResponse> =
         httpClient.safeRequest {
             url {
                 method = HttpMethod.Get
-                path("shows/$traktId/people")
+                path("shows/$showId/people")
             }
             parameter("extended", "full")
         }
 
-    override suspend fun getShowVideos(traktId: Long): ApiResponse<List<TraktVideosResponse>> =
+    override suspend fun getShowVideos(showId: Long): ApiResponse<List<TraktVideosResponse>> =
         httpClient.safeRequest {
             url {
                 method = HttpMethod.Get
-                path("shows/$traktId/videos")
+                path("shows/$showId/videos")
             }
         }
 
-    override suspend fun getWatchedProgress(traktId: Long): ApiResponse<TraktWatchedProgressResponse> =
+    override suspend fun getWatchedProgress(showId: Long): ApiResponse<TraktWatchedProgressResponse> =
         httpClient.authSafeRequest {
             url {
                 method = HttpMethod.Get
-                path("shows/$traktId/progress/watched")
+                path("shows/$showId/progress/watched")
             }
             parameter("extended", "full")
         }

--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktSyncRemoteDataSource.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktSyncRemoteDataSource.kt
@@ -43,7 +43,7 @@ public class DefaultTraktSyncRemoteDataSource(
         }
 
     override suspend fun getShowWatchedProgress(
-        traktId: Long,
+        showId: Long,
         lastActivity: String?,
         hidden: Boolean,
         specials: Boolean,
@@ -51,7 +51,7 @@ public class DefaultTraktSyncRemoteDataSource(
         httpClient.authSafeRequest {
             url {
                 method = HttpMethod.Get
-                path("shows/$traktId/progress/watched")
+                path("shows/$showId/progress/watched")
                 lastActivity?.let { parameters.append("last_activity", it) }
                 parameters.append("hidden", hidden.toString())
                 parameters.append("specials", specials.toString())

--- a/api/trakt/implementation/src/jvmTest/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktListRemoteDataSourceTest.kt
+++ b/api/trakt/implementation/src/jvmTest/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktListRemoteDataSourceTest.kt
@@ -142,7 +142,7 @@ class DefaultTraktListRemoteDataSourceTest {
         }
         val dataSource = createDataSource(engine)
 
-        dataSource.addShowsToWatchListByIds(traktIds = listOf(101L, 202L, 303L))
+        dataSource.addShowsToWatchListByIds(showIds = listOf(101L, 202L, 303L))
 
         requestCount shouldBe 1
         capturedBody shouldContain "101"
@@ -168,7 +168,7 @@ class DefaultTraktListRemoteDataSourceTest {
         }
         val dataSource = createDataSource(engine)
 
-        dataSource.removeShowsFromWatchListByIds(traktIds = listOf(404L, 505L))
+        dataSource.removeShowsFromWatchListByIds(showIds = listOf(404L, 505L))
 
         requestCount shouldBe 1
         capturedPath shouldBe "/sync/watchlist/remove"

--- a/api/trakt/implementation/src/jvmTest/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktListRemoteDataSourceTest.kt
+++ b/api/trakt/implementation/src/jvmTest/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktListRemoteDataSourceTest.kt
@@ -127,7 +127,7 @@ class DefaultTraktListRemoteDataSourceTest {
     }
 
     @Test
-    fun `should batch all trakt ids into a single POST given addShowsToWatchListByTraktIds`() = runTest {
+    fun `should batch all trakt ids into a single POST given addShowsToWatchListByIds`() = runTest {
         var requestCount = 0
         var capturedBody: String? = null
 
@@ -142,7 +142,7 @@ class DefaultTraktListRemoteDataSourceTest {
         }
         val dataSource = createDataSource(engine)
 
-        dataSource.addShowsToWatchListByTraktIds(traktIds = listOf(101L, 202L, 303L))
+        dataSource.addShowsToWatchListByIds(traktIds = listOf(101L, 202L, 303L))
 
         requestCount shouldBe 1
         capturedBody shouldContain "101"
@@ -151,7 +151,7 @@ class DefaultTraktListRemoteDataSourceTest {
     }
 
     @Test
-    fun `should batch all trakt ids into a single POST given removeShowsFromWatchListByTraktIds`() = runTest {
+    fun `should batch all trakt ids into a single POST given removeShowsFromWatchListByIds`() = runTest {
         var requestCount = 0
         var capturedPath: String? = null
         var capturedBody: String? = null
@@ -168,7 +168,7 @@ class DefaultTraktListRemoteDataSourceTest {
         }
         val dataSource = createDataSource(engine)
 
-        dataSource.removeShowsFromWatchListByTraktIds(traktIds = listOf(404L, 505L))
+        dataSource.removeShowsFromWatchListByIds(traktIds = listOf(404L, 505L))
 
         requestCount shouldBe 1
         capturedPath shouldBe "/sync/watchlist/remove"

--- a/api/trakt/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/testing/FakeTraktSyncRemoteDataSource.kt
+++ b/api/trakt/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/testing/FakeTraktSyncRemoteDataSource.kt
@@ -52,10 +52,10 @@ public class FakeTraktSyncRemoteDataSource : TraktSyncRemoteDataSource {
     }
 
     public fun setShowWatchedProgress(
-        traktId: Long,
+        showId: Long,
         response: ApiResponse<TraktWatchedProgressResponse>,
     ) {
-        showWatchedProgressResponses[traktId] = response
+        showWatchedProgressResponses[showId] = response
     }
 
     public fun setUpNextNitro(response: ApiResponse<List<TraktUpNextNitroResponse>>) {
@@ -78,11 +78,11 @@ public class FakeTraktSyncRemoteDataSource : TraktSyncRemoteDataSource {
 
     public fun playbackEpisodesInvocations(): Int = playbackEpisodesInvocations
 
-    public fun showWatchedProgressInvocations(traktId: Long): Int =
-        showWatchedProgressInvocations[traktId] ?: 0
+    public fun showWatchedProgressInvocations(showId: Long): Int =
+        showWatchedProgressInvocations[showId] ?: 0
 
-    public fun showWatchedProgressLastActivity(traktId: Long): String? =
-        showWatchedProgressLastActivityArgs[traktId]
+    public fun showWatchedProgressLastActivity(showId: Long): String? =
+        showWatchedProgressLastActivityArgs[showId]
 
     public fun upNextNitroInvocations(): Int = upNextNitroInvocations
 
@@ -115,16 +115,16 @@ public class FakeTraktSyncRemoteDataSource : TraktSyncRemoteDataSource {
     }
 
     override suspend fun getShowWatchedProgress(
-        traktId: Long,
+        showId: Long,
         lastActivity: String?,
         hidden: Boolean,
         specials: Boolean,
     ): ApiResponse<TraktWatchedProgressResponse> {
-        showWatchedProgressInvocations[traktId] =
-            (showWatchedProgressInvocations[traktId] ?: 0) + 1
-        showWatchedProgressLastActivityArgs[traktId] = lastActivity
-        return showWatchedProgressResponses[traktId]
-            ?: error("FakeTraktSyncRemoteDataSource: no showWatchedProgress response configured for traktId=$traktId")
+        showWatchedProgressInvocations[showId] =
+            (showWatchedProgressInvocations[showId] ?: 0) + 1
+        showWatchedProgressLastActivityArgs[showId] = lastActivity
+        return showWatchedProgressResponses[showId]
+            ?: error("FakeTraktSyncRemoteDataSource: no showWatchedProgress response configured for showId=$showId")
     }
 
     override suspend fun getUpNextNitro(

--- a/app/src/test/kotlin/com/thomaskioko/tvmaniac/app/test/graph/NavigationRouteTest.kt
+++ b/app/src/test/kotlin/com/thomaskioko/tvmaniac/app/test/graph/NavigationRouteTest.kt
@@ -36,10 +36,10 @@ internal class NavigationRouteTest : BaseAppFlowTest() {
             SettingsRoute,
             SearchRoute,
             DebugRoute,
-            TrailersRoute(traktShowId = 1L),
-            ShowDetailsRoute(param = ShowDetailsParam(id = 1L)),
+            TrailersRoute(showId = 1L),
+            ShowDetailsRoute(param = ShowDetailsParam(showId = 1L)),
             SeasonDetailsRoute(
-                param = SeasonDetailsUiParam(showTraktId = 1L, seasonId = 1L, seasonNumber = 1L),
+                param = SeasonDetailsUiParam(showId = 1L, seasonId = 1L, seasonNumber = 1L),
             ),
             GenreShowsRoute(id = 1L),
             MoreShowsRoute(categoryId = 1L),
@@ -116,7 +116,7 @@ internal class NavigationRouteTest : BaseAppFlowTest() {
         val showDetailsGraph = activityGraph.showDetailsScreenGraphFactory
             .createShowDetailsGraph(componentContext)
         showDetailsGraph.showDetailsFactory
-            .create(ShowDetailsParam(id = 1L))
+            .create(ShowDetailsParam(showId = 1L))
             .shouldNotBeNull()
     }
 }

--- a/core/syncstate/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/syncstate/api/SyncError.kt
+++ b/core/syncstate/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/syncstate/api/SyncError.kt
@@ -4,17 +4,17 @@ public sealed interface SyncError {
     public val cause: Throwable
 
     public data class MarkWatchedFailed(
-        public val showTraktId: Long,
+        public val showId: Long,
         override val cause: Throwable,
     ) : SyncError
 
     public data class MarkUnwatchedFailed(
-        public val showTraktId: Long,
+        public val showId: Long,
         override val cause: Throwable,
     ) : SyncError
 
     public data class BatchMarkFailed(
-        public val showTraktId: Long,
+        public val showId: Long,
         override val cause: Throwable,
     ) : SyncError
 

--- a/core/test-tags/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testtags/calendar/CalendarTestTags.kt
+++ b/core/test-tags/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testtags/calendar/CalendarTestTags.kt
@@ -9,7 +9,7 @@ public object CalendarTestTags {
     public const val NEXT_WEEK_BUTTON: String = "calendar_next_week_button"
     public const val WEEK_LABEL: String = "calendar_week_label"
     public fun dateHeader(date: String): String = "calendar_date_header_$date"
-    public fun episodeCard(episodeTraktId: Long): String = "calendar_episode_card_$episodeTraktId"
-    public fun additionalEpisodesCount(episodeTraktId: Long): String =
-        "calendar_additional_episodes_$episodeTraktId"
+    public fun episodeCard(episodeId: Long): String = "calendar_episode_card_$episodeId"
+    public fun additionalEpisodesCount(episodeId: Long): String =
+        "calendar_additional_episodes_$episodeId"
 }

--- a/data/calendar/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/CalendarEntry.kt
+++ b/data/calendar/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/CalendarEntry.kt
@@ -1,8 +1,8 @@
 package com.thomaskioko.tvmaniac.data.calendar
 
 public data class CalendarEntry(
-    val showTraktId: Long,
-    val episodeTraktId: Long,
+    val showId: Long,
+    val episodeId: Long,
     val seasonNumber: Int,
     val episodeNumber: Int,
     val episodeTitle: String?,

--- a/data/calendar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/implementation/CalendarStore.kt
+++ b/data/calendar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/implementation/CalendarStore.kt
@@ -47,20 +47,20 @@ public class CalendarStore(
                 databaseTransactionRunner {
                     calendarDao.deleteEntriesInRange(params.startEpoch, params.endEpoch)
 
-                    val showTraktIds = response.map { it.show.ids.trakt }.distinct()
-                    val showPosters = tvShowsDao.getShowsByTraktIds(showTraktIds)
-                        .associate { it.traktId to it.posterPath }
+                    val showIds = response.map { it.show.ids.trakt }.distinct()
+                    val showPosters = tvShowsDao.getShowsByTraktIds(showIds)
+                        .associate { it.showId to it.posterPath }
 
                     response.forEach { calendarResponse ->
-                        val showTraktId = calendarResponse.show.ids.trakt
+                        val showId = calendarResponse.show.ids.trakt
                         val firstAiredEpoch = Instant.parse(calendarResponse.firstAired).toEpochMilliseconds()
 
-                        val posterPath = showPosters[showTraktId]
+                        val posterPath = showPosters[showId]
 
                         calendarDao.upsert(
                             CalendarEntry(
-                                showTraktId = showTraktId,
-                                episodeTraktId = calendarResponse.episode.ids.trakt.toLong(),
+                                showId = showId,
+                                episodeId = calendarResponse.episode.ids.trakt.toLong(),
                                 seasonNumber = calendarResponse.episode.seasonNumber,
                                 episodeNumber = calendarResponse.episode.episodeNumber,
                                 episodeTitle = calendarResponse.episode.title,

--- a/data/calendar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/implementation/CalendarStore.kt
+++ b/data/calendar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/implementation/CalendarStore.kt
@@ -48,7 +48,7 @@ public class CalendarStore(
                     calendarDao.deleteEntriesInRange(params.startEpoch, params.endEpoch)
 
                     val showIds = response.map { it.show.ids.trakt }.distinct()
-                    val showPosters = tvShowsDao.getShowsByTraktIds(showIds)
+                    val showPosters = tvShowsDao.getShowsByIds(showIds)
                         .associate { it.showId to it.posterPath }
 
                     response.forEach { calendarResponse ->

--- a/data/calendar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/implementation/DefaultCalendarDao.kt
+++ b/data/calendar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/implementation/DefaultCalendarDao.kt
@@ -34,8 +34,8 @@ public class DefaultCalendarDao(
 
     override fun upsert(entry: CalendarEntry) {
         database.calendarQueries.upsert(
-            show_trakt_id = Id<TraktId>(entry.showTraktId),
-            episode_trakt_id = entry.episodeTraktId,
+            show_trakt_id = Id<TraktId>(entry.showId),
+            episode_trakt_id = entry.episodeId,
             season_number = entry.seasonNumber.toLong(),
             episode_number = entry.episodeNumber.toLong(),
             episode_title = entry.episodeTitle,
@@ -64,8 +64,8 @@ public class DefaultCalendarDao(
 }
 
 private fun ObserveEntriesBetweenDates.toCalendarEntry(): CalendarEntry = CalendarEntry(
-    showTraktId = show_trakt_id.id,
-    episodeTraktId = episode_trakt_id,
+    showId = show_trakt_id.id,
+    episodeId = episode_trakt_id,
     seasonNumber = season_number.toInt(),
     episodeNumber = episode_number.toInt(),
     episodeTitle = episode_title,

--- a/data/cast/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/cast/api/CastDao.kt
+++ b/data/cast/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/cast/api/CastDao.kt
@@ -8,9 +8,9 @@ import kotlinx.coroutines.flow.Flow
 public interface CastDao {
     public fun upsert(entity: Casts)
 
-    public suspend fun getShowCast(traktId: Long): List<ShowCast>
+    public suspend fun getShowCast(showId: Long): List<ShowCast>
 
-    public fun observeShowCast(traktId: Long): Flow<List<ShowCast>>
+    public fun observeShowCast(showId: Long): Flow<List<ShowCast>>
 
     public fun observeSeasonCast(seasonId: Long): Flow<List<SeasonCast>>
 }

--- a/data/cast/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/cast/api/CastRepository.kt
+++ b/data/cast/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/cast/api/CastRepository.kt
@@ -5,9 +5,9 @@ import com.thomaskioko.tvmaniac.db.ShowCast
 import kotlinx.coroutines.flow.Flow
 
 public interface CastRepository {
-    public suspend fun fetchShowCast(showTraktId: Long, forceRefresh: Boolean = false)
+    public suspend fun fetchShowCast(showId: Long, forceRefresh: Boolean = false)
 
     public fun observeSeasonCast(seasonId: Long): Flow<List<SeasonCast>>
 
-    public fun observeShowCast(showTraktId: Long): Flow<List<ShowCast>>
+    public fun observeShowCast(showId: Long): Flow<List<ShowCast>>
 }

--- a/data/cast/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/cast/implementation/DefaultCastDao.kt
+++ b/data/cast/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/cast/implementation/DefaultCastDao.kt
@@ -37,15 +37,15 @@ public class DefaultCastDao(
         )
     }
 
-    override suspend fun getShowCast(traktId: Long): List<ShowCast> =
+    override suspend fun getShowCast(showId: Long): List<ShowCast> =
         withContext(dispatcher.io) {
-            val showId = showIdResolver.showIdForTraktId(traktId) ?: return@withContext emptyList()
-            database.castQueries.showCast(showId).executeAsList()
+            val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@withContext emptyList()
+            database.castQueries.showCast(internalShowId).executeAsList()
         }
 
-    override fun observeShowCast(traktId: Long): Flow<List<ShowCast>> {
-        val showId = showIdResolver.showIdForTraktId(traktId) ?: return flowOf(emptyList())
-        return database.castQueries.showCast(showId).asFlow().mapToList(dispatcher.io)
+    override fun observeShowCast(showId: Long): Flow<List<ShowCast>> {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return flowOf(emptyList())
+        return database.castQueries.showCast(internalShowId).asFlow().mapToList(dispatcher.io)
     }
 
     override fun observeSeasonCast(seasonId: Long): Flow<List<SeasonCast>> =

--- a/data/cast/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/cast/implementation/DefaultCastRepository.kt
+++ b/data/cast/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/cast/implementation/DefaultCastRepository.kt
@@ -18,17 +18,17 @@ public class DefaultCastRepository(
     private val showCastStore: ShowCastStore,
 ) : CastRepository {
 
-    override suspend fun fetchShowCast(showTraktId: Long, forceRefresh: Boolean) {
-        val isEmpty = dao.getShowCast(showTraktId).isEmpty()
+    override suspend fun fetchShowCast(showId: Long, forceRefresh: Boolean) {
+        val isEmpty = dao.getShowCast(showId).isEmpty()
         when {
-            forceRefresh || isEmpty -> showCastStore.fresh(showTraktId)
-            else -> showCastStore.get(showTraktId)
+            forceRefresh || isEmpty -> showCastStore.fresh(showId)
+            else -> showCastStore.get(showId)
         }
     }
 
     override fun observeSeasonCast(seasonId: Long): Flow<List<SeasonCast>> =
         dao.observeSeasonCast(seasonId)
 
-    override fun observeShowCast(showTraktId: Long): Flow<List<ShowCast>> =
-        dao.observeShowCast(showTraktId)
+    override fun observeShowCast(showId: Long): Flow<List<ShowCast>> =
+        dao.observeShowCast(showId)
 }

--- a/data/cast/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/cast/implementation/ShowCastResult.kt
+++ b/data/cast/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/cast/implementation/ShowCastResult.kt
@@ -6,12 +6,12 @@ import com.thomaskioko.tvmaniac.trakt.api.model.TraktShowPeopleResponse
 /**
  * Intermediate result from fetching show cast data.
  *
- * @property showTraktId The Trakt ID of the show
+ * @property showId The Trakt ID of the show
  * @property traktPeople The people response from Trakt API
  * @property tmdbCredits The credits response from TMDB API (for profile images)
  */
 internal data class ShowCastResult(
-    val showTraktId: Long,
+    val showId: Long,
     val traktPeople: TraktShowPeopleResponse,
     val tmdbCredits: CreditsResponse?,
 )

--- a/data/cast/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/cast/implementation/ShowCastStore.kt
+++ b/data/cast/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/cast/implementation/ShowCastStore.kt
@@ -40,7 +40,7 @@ public class ShowCastStore(
 ) : Store<Long, List<ShowCast>> by storeBuilder(
     fetcher = Fetcher.of { showId: Long ->
         coroutineScope {
-            val tmdbId = tvShowsDao.getTmdbIdByTraktId(showId)
+            val tmdbId = tvShowsDao.getTmdbIdByShowId(showId)
 
             val traktDeferred = async {
                 traktRemoteDataSource.getShowPeople(showId).getOrThrow()

--- a/data/cast/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/cast/implementation/ShowCastStore.kt
+++ b/data/cast/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/cast/implementation/ShowCastStore.kt
@@ -38,25 +38,25 @@ public class ShowCastStore(
     private val databaseTransactionRunner: DatabaseTransactionRunner,
     private val dispatchers: AppCoroutineDispatchers,
 ) : Store<Long, List<ShowCast>> by storeBuilder(
-    fetcher = Fetcher.of { traktId: Long ->
+    fetcher = Fetcher.of { showId: Long ->
         coroutineScope {
-            val tmdbId = tvShowsDao.getTmdbIdByTraktId(traktId)
+            val tmdbId = tvShowsDao.getTmdbIdByTraktId(showId)
 
             val traktDeferred = async {
-                traktRemoteDataSource.getShowPeople(traktId).getOrThrow()
+                traktRemoteDataSource.getShowPeople(showId).getOrThrow()
             }
             val tmdbCreditsDeferred = tmdbId?.let { id ->
                 async { tmdbNetworkDataSource.getShowCredits(id).getOrNull() }
             }
 
             val result = ShowCastResult(
-                showTraktId = traktId,
+                showId = showId,
                 traktPeople = traktDeferred.await(),
                 tmdbCredits = tmdbCreditsDeferred?.await(),
             )
 
             requestManagerRepository.upsert(
-                entityId = traktId,
+                entityId = showId,
                 requestType = SHOW_CAST.name,
             )
 
@@ -64,12 +64,12 @@ public class ShowCastStore(
         }
     },
     sourceOfTruth = SourceOfTruth.of<Long, ShowCastResult, List<ShowCast>>(
-        reader = { traktId: Long ->
-            castDao.observeShowCast(traktId)
+        reader = { showId: Long ->
+            castDao.observeShowCast(showId)
         },
-        writer = { traktId, result ->
+        writer = { showId, result ->
             databaseTransactionRunner {
-                val showId = showIdResolver.showIdForTraktId(traktId)
+                val internalShowId = showIdResolver.showIdForTraktId(showId)
                     ?: return@databaseTransactionRunner
 
                 val tmdbCastMap = result.tmdbCredits?.cast
@@ -89,7 +89,7 @@ public class ShowCastStore(
                             Casts(
                                 id = Id(tmdbId),
                                 trakt_id = Id(person.ids.trakt),
-                                show_id = showId,
+                                show_id = internalShowId,
                                 season_id = null,
                                 name = person.name,
                                 character_name = castMember.characters.firstOrNull() ?: "",
@@ -109,9 +109,9 @@ public class ShowCastStore(
 ).validator(
     Validator.by { result ->
         withContext(dispatchers.io) {
-            val traktId = result.firstOrNull()?.show_trakt_id ?: return@withContext false
+            val showId = result.firstOrNull()?.show_trakt_id ?: return@withContext false
             !requestManagerRepository.isRequestExpired(
-                entityId = traktId,
+                entityId = showId,
                 requestType = SHOW_CAST.name,
                 threshold = SHOW_CAST.duration,
             )

--- a/data/cast/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/cast/testing/FakeCastRepository.kt
+++ b/data/cast/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/cast/testing/FakeCastRepository.kt
@@ -20,12 +20,12 @@ public class FakeCastRepository : CastRepository {
         showCastEntityList.send(result)
     }
 
-    override suspend fun fetchShowCast(showTraktId: Long, forceRefresh: Boolean) {
+    override suspend fun fetchShowCast(showId: Long, forceRefresh: Boolean) {
     }
 
     override fun observeSeasonCast(seasonId: Long): Flow<List<SeasonCast>> =
         seasonCastEntityList.receiveAsFlow()
 
-    override fun observeShowCast(showTraktId: Long): Flow<List<ShowCast>> =
+    override fun observeShowCast(showId: Long): Flow<List<ShowCast>> =
         showCastEntityList.receiveAsFlow()
 }

--- a/data/continue-watching/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/api/ContinueWatchingDao.kt
+++ b/data/continue-watching/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/api/ContinueWatchingDao.kt
@@ -14,7 +14,7 @@ public interface ContinueWatchingDao {
 
     public fun upsertPlaceholder(showId: Long, tmdbId: Long?, title: String?, year: Long?)
 
-    public fun deleteByTraktId(showId: Long)
+    public fun deleteByShowId(showId: Long)
 
     public fun deleteAll()
 }

--- a/data/continue-watching/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/api/ContinueWatchingDao.kt
+++ b/data/continue-watching/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/api/ContinueWatchingDao.kt
@@ -8,13 +8,13 @@ public interface ContinueWatchingDao {
 
     public fun entriesObservable(): Flow<List<ContinueWatchingEntry>>
 
-    public fun traktIdsMissingShowDetails(): List<Long>
+    public fun showIdsMissingShowDetails(): List<Long>
 
     public fun upsert(entry: ContinueWatchingEntry)
 
-    public fun upsertPlaceholder(traktId: Long, tmdbId: Long?, title: String?, year: Long?)
+    public fun upsertPlaceholder(showId: Long, tmdbId: Long?, title: String?, year: Long?)
 
-    public fun deleteByTraktId(traktId: Long)
+    public fun deleteByTraktId(showId: Long)
 
     public fun deleteAll()
 }

--- a/data/continue-watching/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/api/ContinueWatchingEntry.kt
+++ b/data/continue-watching/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/api/ContinueWatchingEntry.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.continuewatching.api
 
 public data class ContinueWatchingEntry(
-    val traktId: Long,
+    val showId: Long,
     val tmdbId: Long?,
     val airedEpisodes: Long,
     val completedCount: Long,

--- a/data/continue-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/DefaultContinueWatchingDao.kt
+++ b/data/continue-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/DefaultContinueWatchingDao.kt
@@ -25,7 +25,7 @@ public class DefaultContinueWatchingDao(
     override fun entries(): List<ContinueWatchingEntry> =
         database.continueWatchingQueries.entries().executeAsList().map { row ->
             ContinueWatchingEntry(
-                traktId = row.trakt_id,
+                showId = row.trakt_id,
                 tmdbId = row.tmdb_id?.id,
                 airedEpisodes = row.aired_episodes,
                 completedCount = row.completed_count,
@@ -43,7 +43,7 @@ public class DefaultContinueWatchingDao(
             .map { rows ->
                 rows.map { row ->
                     ContinueWatchingEntry(
-                        traktId = row.trakt_id,
+                        showId = row.trakt_id,
                         tmdbId = row.tmdb_id?.id,
                         airedEpisodes = row.aired_episodes,
                         completedCount = row.completed_count,
@@ -55,12 +55,12 @@ public class DefaultContinueWatchingDao(
                 }
             }
 
-    override fun traktIdsMissingShowDetails(): List<Long> =
+    override fun showIdsMissingShowDetails(): List<Long> =
         database.continueWatchingQueries.traktIdsMissingShowDetails()
             .executeAsList()
 
     override fun upsert(entry: ContinueWatchingEntry) {
-        val showId = showIdResolver.showIdForTraktId(entry.traktId) ?: return
+        val showId = showIdResolver.showIdForTraktId(entry.showId) ?: return
         database.continueWatchingQueries.upsert(
             showId = showId,
             tmdbId = entry.tmdbId?.let { Id(it) },
@@ -73,19 +73,19 @@ public class DefaultContinueWatchingDao(
         )
     }
 
-    override fun upsertPlaceholder(traktId: Long, tmdbId: Long?, title: String?, year: Long?) {
-        val showId = showIdResolver.showIdForTraktId(traktId) ?: return
+    override fun upsertPlaceholder(showId: Long, tmdbId: Long?, title: String?, year: Long?) {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return
         database.continueWatchingQueries.upsertPlaceholder(
-            showId = showId,
+            showId = internalShowId,
             tmdbId = tmdbId?.let { Id(it) },
             title = title,
             year = year,
         )
     }
 
-    override fun deleteByTraktId(traktId: Long) {
-        val showId = showIdResolver.showIdForTraktId(traktId) ?: return
-        database.continueWatchingQueries.deleteByShowId(showId)
+    override fun deleteByTraktId(showId: Long) {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return
+        database.continueWatchingQueries.deleteByShowId(internalShowId)
     }
 
     override fun deleteAll() {

--- a/data/continue-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/DefaultContinueWatchingDao.kt
+++ b/data/continue-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/DefaultContinueWatchingDao.kt
@@ -83,7 +83,7 @@ public class DefaultContinueWatchingDao(
         )
     }
 
-    override fun deleteByTraktId(showId: Long) {
+    override fun deleteByShowId(showId: Long) {
         val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return
         database.continueWatchingQueries.deleteByShowId(internalShowId)
     }

--- a/data/continue-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/NitroContinueWatchingFetcher.kt
+++ b/data/continue-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/NitroContinueWatchingFetcher.kt
@@ -72,7 +72,7 @@ public class NitroContinueWatchingFetcher(
                 .map { it.toEntry() }
 
             entries.forEach { emit(ProgressBatch.Entry(it)) }
-            emit(ProgressBatch.Complete(entries.map { it.traktId }.toSet()))
+            emit(ProgressBatch.Complete(entries.map { it.showId }.toSet()))
         }
     }
 
@@ -92,7 +92,7 @@ private fun TraktUpNextNitroResponse.toEntry(): ContinueWatchingEntry {
         ?.let { Instant.parse(it).toEpochMilliseconds() }
         ?: 0L
     return ContinueWatchingEntry(
-        traktId = show.ids.trakt,
+        showId = show.ids.trakt,
         tmdbId = show.ids.tmdb,
         airedEpisodes = progress.aired.toLong(),
         completedCount = progress.completed.toLong(),

--- a/data/continue-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/NitroContinueWatchingStore.kt
+++ b/data/continue-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/NitroContinueWatchingStore.kt
@@ -70,8 +70,8 @@ public class NitroContinueWatchingStore(
                 withContext(dispatchers.databaseWrite) {
                     transactionRunner {
                         continueWatchingDao.entries()
-                            .filter { it.traktId !in batch.finalTraktIds }
-                            .forEach { continueWatchingDao.deleteByTraktId(it.traktId) }
+                            .filter { it.showId !in batch.finalTraktIds }
+                            .forEach { continueWatchingDao.deleteByTraktId(it.showId) }
                     }
                 }
                 requestManagerRepository.upsert(
@@ -95,7 +95,7 @@ private fun ContinueWatchingEntry.toMinimalTvshow(): ShowToPersist? {
     val tmdb = tmdbId ?: return null
     val name = title ?: return null
     return ShowToPersist(
-        traktId = Id<TraktId>(traktId),
+        showId = Id<TraktId>(showId),
         tmdbId = Id<TmdbId>(tmdb),
         name = name,
         overview = "",

--- a/data/continue-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/NitroContinueWatchingStore.kt
+++ b/data/continue-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/NitroContinueWatchingStore.kt
@@ -71,7 +71,7 @@ public class NitroContinueWatchingStore(
                     transactionRunner {
                         continueWatchingDao.entries()
                             .filter { it.showId !in batch.finalTraktIds }
-                            .forEach { continueWatchingDao.deleteByTraktId(it.showId) }
+                            .forEach { continueWatchingDao.deleteByShowId(it.showId) }
                     }
                 }
                 requestManagerRepository.upsert(

--- a/data/continue-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/ProgressContinueWatchingFetcher.kt
+++ b/data/continue-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/ProgressContinueWatchingFetcher.kt
@@ -72,7 +72,7 @@ public class ProgressContinueWatchingFetcher(
         var rateLimitedAt: Long? = null
         for (showId in candidates) {
             val response = traktSyncDataSource.getShowWatchedProgress(
-                traktId = showId,
+                showId = showId,
                 lastActivity = lastActivity,
                 specials = includeSpecials,
             )

--- a/data/continue-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/ProgressContinueWatchingFetcher.kt
+++ b/data/continue-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/ProgressContinueWatchingFetcher.kt
@@ -70,13 +70,13 @@ public class ProgressContinueWatchingFetcher(
 
         val responses = mutableListOf<Pair<Long, ApiResponse<TraktWatchedProgressResponse>>>()
         var rateLimitedAt: Long? = null
-        for (traktId in candidates) {
+        for (showId in candidates) {
             val response = traktSyncDataSource.getShowWatchedProgress(
-                traktId = traktId,
+                traktId = showId,
                 lastActivity = lastActivity,
                 specials = includeSpecials,
             )
-            responses += traktId to response
+            responses += showId to response
             when (response) {
                 is ApiResponse.Success -> {
                     val progress = response.body
@@ -84,17 +84,17 @@ public class ProgressContinueWatchingFetcher(
                     // Trakt's per-show logic returns null next_episode. Removing it would persist rows
                     // that never render in the watchlist.
                     if (progress.nextEpisode != null) {
-                        send(ProgressBatch.Entry(toEntry(traktId, descriptors[traktId], progress)))
+                        send(ProgressBatch.Entry(toEntry(showId, descriptors[showId], progress)))
                     }
                 }
                 is ApiResponse.Error -> {
                     if (response.toSyncError() is SyncError.Retryable) {
-                        rateLimitedAt = traktId
+                        rateLimitedAt = showId
                         break
                     }
                 }
                 is ApiResponse.Unauthenticated -> {
-                    rateLimitedAt = traktId
+                    rateLimitedAt = showId
                     break
                 }
             }
@@ -115,9 +115,9 @@ public class ProgressContinueWatchingFetcher(
 
         if (responses.all { (_, response) -> response is ApiResponse.Success }) {
             val finalTraktIds = responses
-                .mapNotNull { (traktId, response) ->
+                .mapNotNull { (showId, response) ->
                     val progress = (response as ApiResponse.Success).body
-                    if (progress.nextEpisode != null) traktId else null
+                    if (progress.nextEpisode != null) showId else null
                 }
                 .toSet()
             send(ProgressBatch.Complete(finalTraktIds))
@@ -167,7 +167,7 @@ internal sealed interface ProgressBatch {
 }
 
 private fun toEntry(
-    traktId: Long,
+    showId: Long,
     descriptor: ProgressDescriptor?,
     progress: TraktWatchedProgressResponse,
 ): ContinueWatchingEntry {
@@ -175,7 +175,7 @@ private fun toEntry(
         ?.let { Instant.parse(it).toEpochMilliseconds() }
         ?: 0L
     return ContinueWatchingEntry(
-        traktId = traktId,
+        showId = showId,
         tmdbId = descriptor?.tmdbId,
         airedEpisodes = progress.aired.toLong(),
         completedCount = progress.completed.toLong(),

--- a/data/continue-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/ProgressContinueWatchingStore.kt
+++ b/data/continue-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/ProgressContinueWatchingStore.kt
@@ -68,8 +68,8 @@ public class ProgressContinueWatchingStore(
                 withContext(dispatchers.databaseWrite) {
                     transactionRunner {
                         continueWatchingDao.entries()
-                            .filter { it.traktId !in batch.finalTraktIds }
-                            .forEach { continueWatchingDao.deleteByTraktId(it.traktId) }
+                            .filter { it.showId !in batch.finalTraktIds }
+                            .forEach { continueWatchingDao.deleteByTraktId(it.showId) }
                     }
                 }
                 requestManagerRepository.upsert(
@@ -93,7 +93,7 @@ private fun ContinueWatchingEntry.toMinimalTvshow(): ShowToPersist? {
     val tmdb = tmdbId ?: return null
     val name = title ?: return null
     return ShowToPersist(
-        traktId = Id(traktId),
+        showId = Id(showId),
         tmdbId = Id(tmdb),
         name = name,
         overview = "",

--- a/data/continue-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/ProgressContinueWatchingStore.kt
+++ b/data/continue-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/ProgressContinueWatchingStore.kt
@@ -69,7 +69,7 @@ public class ProgressContinueWatchingStore(
                     transactionRunner {
                         continueWatchingDao.entries()
                             .filter { it.showId !in batch.finalTraktIds }
-                            .forEach { continueWatchingDao.deleteByTraktId(it.showId) }
+                            .forEach { continueWatchingDao.deleteByShowId(it.showId) }
                     }
                 }
                 requestManagerRepository.upsert(

--- a/data/continue-watching/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/DefaultContinueWatchingDaoTest.kt
+++ b/data/continue-watching/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/DefaultContinueWatchingDaoTest.kt
@@ -35,9 +35,9 @@ internal class DefaultContinueWatchingDaoTest : BaseDatabaseTest() {
     @BeforeTest
     fun setUp() {
         dao = DefaultContinueWatchingDao(database, showIdResolver, dispatchers)
-        insertTvShow(traktId = BREAKING_BAD_TRAKT_ID, tmdbId = BREAKING_BAD_TMDB_ID)
-        insertTvShow(traktId = THE_WIRE_TRAKT_ID, tmdbId = THE_WIRE_TMDB_ID)
-        insertTvShow(traktId = ORPHAN_TRAKT_ID, tmdbId = ORPHAN_TMDB_ID)
+        insertTvShow(showId = BREAKING_BAD_TRAKT_ID, tmdbId = BREAKING_BAD_TMDB_ID)
+        insertTvShow(showId = THE_WIRE_TRAKT_ID, tmdbId = THE_WIRE_TMDB_ID)
+        insertTvShow(showId = ORPHAN_TRAKT_ID, tmdbId = ORPHAN_TMDB_ID)
     }
 
     @AfterTest
@@ -84,12 +84,12 @@ internal class DefaultContinueWatchingDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `should preserve null tmdb id`() {
-        val orphan = breakingBadEntry.copy(traktId = ORPHAN_TRAKT_ID, tmdbId = null)
+        val orphan = breakingBadEntry.copy(showId = ORPHAN_TRAKT_ID, tmdbId = null)
         dao.upsert(orphan)
 
         val stored = dao.entries().first()
         stored.tmdbId.shouldBeNull()
-        stored.traktId shouldBe ORPHAN_TRAKT_ID
+        stored.showId shouldBe ORPHAN_TRAKT_ID
     }
 
     @Test
@@ -121,7 +121,7 @@ internal class DefaultContinueWatchingDaoTest : BaseDatabaseTest() {
         dao.upsert(breakingBadEntry)
         dao.upsert(theWireEntry)
 
-        dao.deleteByTraktId(breakingBadEntry.traktId)
+        dao.deleteByTraktId(breakingBadEntry.showId)
 
         dao.entries() shouldContainExactlyInAnyOrder listOf(theWireEntry)
     }
@@ -136,10 +136,10 @@ internal class DefaultContinueWatchingDaoTest : BaseDatabaseTest() {
         dao.entries().shouldBeEmpty()
     }
 
-    private fun insertTvShow(traktId: Long, tmdbId: Long) {
+    private fun insertTvShow(showId: Long, tmdbId: Long) {
         database.tvShowQueries.upsert(
             tmdb_id = Id<TmdbId>(tmdbId),
-            name = "show-$traktId",
+            name = "show-$showId",
             overview = "overview",
             language = "en",
             year = "2020-01-01",
@@ -152,7 +152,7 @@ internal class DefaultContinueWatchingDaoTest : BaseDatabaseTest() {
             poster_path = null,
             backdrop_path = null,
         )
-        showIdForTraktId(traktId = traktId, tmdbId = tmdbId)
+        showIdForTraktId(traktId = showId, tmdbId = tmdbId)
     }
 
     private companion object {
@@ -166,7 +166,7 @@ internal class DefaultContinueWatchingDaoTest : BaseDatabaseTest() {
 }
 
 private val breakingBadEntry = ContinueWatchingEntry(
-    traktId = 1388L,
+    showId = 1388L,
     tmdbId = 1396L,
     airedEpisodes = 62L,
     completedCount = 56L,
@@ -175,7 +175,7 @@ private val breakingBadEntry = ContinueWatchingEntry(
 )
 
 private val theWireEntry = ContinueWatchingEntry(
-    traktId = 1429L,
+    showId = 1429L,
     tmdbId = 1438L,
     airedEpisodes = 60L,
     completedCount = 12L,

--- a/data/continue-watching/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/DefaultContinueWatchingDaoTest.kt
+++ b/data/continue-watching/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/DefaultContinueWatchingDaoTest.kt
@@ -121,7 +121,7 @@ internal class DefaultContinueWatchingDaoTest : BaseDatabaseTest() {
         dao.upsert(breakingBadEntry)
         dao.upsert(theWireEntry)
 
-        dao.deleteByTraktId(breakingBadEntry.showId)
+        dao.deleteByShowId(breakingBadEntry.showId)
 
         dao.entries() shouldContainExactlyInAnyOrder listOf(theWireEntry)
     }

--- a/data/continue-watching/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/NitroContinueWatchingFetcherTest.kt
+++ b/data/continue-watching/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/NitroContinueWatchingFetcherTest.kt
@@ -71,12 +71,12 @@ internal class NitroContinueWatchingFetcherTest {
             ApiResponse.Success(listOf(breakingBadNitro, theWireNitro)),
         )
         userDataSource.setHiddenProgressWatched(
-            ApiResponse.Success(listOf(hiddenItem(traktId = BREAKING_BAD_ID))),
+            ApiResponse.Success(listOf(hiddenItem(showId = BREAKING_BAD_ID))),
         )
 
         val result = fetcher.collectEntries()
 
-        result.shouldNotBeNull().map { it.traktId } shouldContainExactlyInAnyOrder listOf(THE_WIRE_ID)
+        result.shouldNotBeNull().map { it.showId } shouldContainExactlyInAnyOrder listOf(THE_WIRE_ID)
     }
 
     @Test
@@ -87,7 +87,7 @@ internal class NitroContinueWatchingFetcherTest {
 
         val result = fetcher.collectEntries()
 
-        result.shouldNotBeNull().map { it.traktId } shouldContainExactlyInAnyOrder listOf(BREAKING_BAD_ID)
+        result.shouldNotBeNull().map { it.showId } shouldContainExactlyInAnyOrder listOf(BREAKING_BAD_ID)
     }
 
     @Test
@@ -202,7 +202,7 @@ private val resetShowNitro = TraktUpNextNitroResponse(
 )
 
 private val breakingBadEntry = ContinueWatchingEntry(
-    traktId = BREAKING_BAD_ID,
+    showId = BREAKING_BAD_ID,
     tmdbId = 1396,
     airedEpisodes = 62,
     completedCount = 30,
@@ -212,7 +212,7 @@ private val breakingBadEntry = ContinueWatchingEntry(
 )
 
 private val theWireEntry = ContinueWatchingEntry(
-    traktId = THE_WIRE_ID,
+    showId = THE_WIRE_ID,
     tmdbId = 1438,
     airedEpisodes = 60,
     completedCount = 12,
@@ -221,13 +221,13 @@ private val theWireEntry = ContinueWatchingEntry(
     title = "The Wire",
 )
 
-private fun hiddenItem(traktId: Long): TraktHiddenItemResponse =
+private fun hiddenItem(showId: Long): TraktHiddenItemResponse =
     TraktHiddenItemResponse(
         hiddenAt = "2026-04-01T12:00:00Z",
         type = "show",
         show = TraktShowResponse(
             title = "Hidden",
-            ids = ShowIds(trakt = traktId, slug = "hidden-$traktId"),
+            ids = ShowIds(trakt = showId, slug = "hidden-$showId"),
         ),
     )
 

--- a/data/continue-watching/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/NitroContinueWatchingStoreTest.kt
+++ b/data/continue-watching/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/NitroContinueWatchingStoreTest.kt
@@ -206,7 +206,7 @@ private val breakingBadNitro = TraktUpNextNitroResponse(
 )
 
 private val breakingBadEntry = ContinueWatchingEntry(
-    traktId = BREAKING_BAD_ID,
+    showId = BREAKING_BAD_ID,
     tmdbId = 1396,
     airedEpisodes = 62,
     completedCount = 30,
@@ -216,7 +216,7 @@ private val breakingBadEntry = ContinueWatchingEntry(
 )
 
 private val theWireEntry = ContinueWatchingEntry(
-    traktId = THE_WIRE_ID,
+    showId = THE_WIRE_ID,
     tmdbId = 1438,
     airedEpisodes = 60,
     completedCount = 12,

--- a/data/continue-watching/implementation/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/ContinueWatchingFetcherTest.kt
+++ b/data/continue-watching/implementation/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/ContinueWatchingFetcherTest.kt
@@ -214,7 +214,7 @@ internal class ContinueWatchingFetcherTest {
             ApiResponse.Success(baselinePlayback + resetShowPlayback),
         )
         syncDataSource.setShowWatchedProgress(
-            traktId = RESET_SHOW_ID,
+            showId = RESET_SHOW_ID,
             response = ApiResponse.Success(resetShowProgress),
         )
         syncDataSource.setUpNextNitro(
@@ -252,11 +252,11 @@ internal class ContinueWatchingFetcherTest {
         syncDataSource.setUpNextNitro(ApiResponse.Success(nitro))
 
         syncDataSource.setShowWatchedProgress(
-            traktId = BREAKING_BAD_ID,
+            showId = BREAKING_BAD_ID,
             response = ApiResponse.Success(loadProgress("progress_1388.json")),
         )
         syncDataSource.setShowWatchedProgress(
-            traktId = THE_WIRE_ID,
+            showId = THE_WIRE_ID,
             response = ApiResponse.Success(loadProgress("progress_1429.json")),
         )
     }

--- a/data/continue-watching/implementation/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/ContinueWatchingFetcherTest.kt
+++ b/data/continue-watching/implementation/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/ContinueWatchingFetcherTest.kt
@@ -193,7 +193,7 @@ internal class ContinueWatchingFetcherTest {
 
             result.size shouldBe 1
             val entry = result.single()
-            entry.traktId shouldBe HELLS_PARADISE_ID
+            entry.showId shouldBe HELLS_PARADISE_ID
             entry.tmdbId shouldBe 117465L
             entry.airedEpisodes shouldBe 25L
             entry.completedCount shouldBe 20L
@@ -276,28 +276,28 @@ private const val RESET_SHOW_ID = 5000L
 private const val HELLS_PARADISE_ID = 181120L
 
 private data class ParityTuple(
-    val traktId: Long,
+    val showId: Long,
     val completedCount: Long,
     val airedEpisodes: Long,
     val lastWatchedAt: Long,
 )
 
 private fun ContinueWatchingEntry.parityTuple(): ParityTuple = ParityTuple(
-    traktId = traktId,
+    showId = showId,
     completedCount = completedCount,
     airedEpisodes = airedEpisodes,
     lastWatchedAt = lastWatchedAt,
 )
 
 private val breakingBadTuple = ParityTuple(
-    traktId = BREAKING_BAD_ID,
+    showId = BREAKING_BAD_ID,
     completedCount = 30,
     airedEpisodes = 62,
     lastWatchedAt = Instant.parse("2026-05-10T20:15:00Z").toEpochMilliseconds(),
 )
 
 private val theWireTuple = ParityTuple(
-    traktId = THE_WIRE_ID,
+    showId = THE_WIRE_ID,
     completedCount = 12,
     airedEpisodes = 60,
     lastWatchedAt = Instant.parse("2026-04-22T09:00:00Z").toEpochMilliseconds(),

--- a/data/continue-watching/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/testing/FakeContinueWatchingDao.kt
+++ b/data/continue-watching/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/testing/FakeContinueWatchingDao.kt
@@ -20,17 +20,17 @@ public class FakeContinueWatchingDao : ContinueWatchingDao {
     override fun entriesObservable(): Flow<List<ContinueWatchingEntry>> =
         state.map { it.values.toList() }
 
-    override fun traktIdsMissingShowDetails(): List<Long> = idsMissingShowDetails
+    override fun showIdsMissingShowDetails(): List<Long> = idsMissingShowDetails
 
     override fun upsert(entry: ContinueWatchingEntry) {
-        state.value += (entry.traktId to entry)
+        state.value += (entry.showId to entry)
     }
 
-    override fun upsertPlaceholder(traktId: Long, tmdbId: Long?, title: String?, year: Long?) {
-        if (state.value.containsKey(traktId)) return
+    override fun upsertPlaceholder(showId: Long, tmdbId: Long?, title: String?, year: Long?) {
+        if (state.value.containsKey(showId)) return
         state.value += (
-            traktId to ContinueWatchingEntry(
-                traktId = traktId,
+            showId to ContinueWatchingEntry(
+                showId = showId,
                 tmdbId = tmdbId,
                 airedEpisodes = 0L,
                 completedCount = 0L,
@@ -42,8 +42,8 @@ public class FakeContinueWatchingDao : ContinueWatchingDao {
             )
     }
 
-    override fun deleteByTraktId(traktId: Long) {
-        state.value -= traktId
+    override fun deleteByTraktId(showId: Long) {
+        state.value -= showId
     }
 
     override fun deleteAll() {

--- a/data/continue-watching/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/testing/FakeContinueWatchingDao.kt
+++ b/data/continue-watching/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/testing/FakeContinueWatchingDao.kt
@@ -42,7 +42,7 @@ public class FakeContinueWatchingDao : ContinueWatchingDao {
             )
     }
 
-    override fun deleteByTraktId(showId: Long) {
+    override fun deleteByShowId(showId: Long) {
         state.value -= showId
     }
 

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Trailers.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Trailers.sq
@@ -24,7 +24,7 @@ INSERT OR REPLACE INTO trailers(
 )
 VALUES(?,?,?,?,?,?,?);
 
-selectByShowTraktId:
+selectByShowId:
 SELECT
     trailers.id AS trailer_id,
     tvshow.tmdb_id AS show_tmdb_id,

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/TvShow.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/TvShow.sq
@@ -165,12 +165,12 @@ SELECT EXISTS(
     SELECT 1 FROM tvshow WHERE tmdb_id = ?
 );
 
-existsByTraktId:
+existsByShowId:
 SELECT EXISTS(
     SELECT 1 FROM show_trakt WHERE trakt_id = ?
 );
 
-showsByTraktIds:
+showsByIds:
 SELECT
     show_trakt.trakt_id,
     tvshow.tmdb_id,
@@ -203,7 +203,7 @@ WHERE tvshow.tmdb_id IN ?;
 getShowIdByTmdbId:
 SELECT id FROM tvshow WHERE tmdb_id = ?;
 
-getTmdbIdByTraktId:
+getTmdbIdByShowId:
 SELECT tvshow.tmdb_id
 FROM tvshow
 INNER JOIN show_trakt ON show_trakt.show_id = tvshow.id

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/WatchProviders.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/WatchProviders.sq
@@ -38,7 +38,7 @@ FROM
 WHERE
     watch_providers.tmdb_id = :showId;
 
-watchProvidersByTraktId:
+watchProvidersByShowId:
 SELECT
     watch_providers.id AS provider_id,
     watch_providers.name,

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/EpisodeRepository.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/EpisodeRepository.kt
@@ -16,7 +16,7 @@ public interface EpisodeRepository {
     public fun observeRecentlyWatched(limit: Long): Flow<List<RecentlyWatchedEpisode>>
 
     public suspend fun markEpisodeAsWatched(
-        showTraktId: Long,
+        showId: Long,
         episodeId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
@@ -27,7 +27,7 @@ public interface EpisodeRepository {
      * Automatically adds the show to the library if not already there.
      */
     public suspend fun markEpisodeAndPreviousEpisodesWatched(
-        showTraktId: Long,
+        showId: Long,
         episodeId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
@@ -36,50 +36,50 @@ public interface EpisodeRepository {
     /**
      * Mark an episode as unwatched. The SQL view automatically updates next episode calculations.
      */
-    public suspend fun markEpisodeAsUnwatched(showTraktId: Long, episodeId: Long)
+    public suspend fun markEpisodeAsUnwatched(showId: Long, episodeId: Long)
 
     /**
      * Observe watch progress for a specific season.
      */
-    public fun observeSeasonWatchProgress(showTraktId: Long, seasonNumber: Long): Flow<SeasonWatchProgress>
+    public fun observeSeasonWatchProgress(showId: Long, seasonNumber: Long): Flow<SeasonWatchProgress>
 
     /**
      * Observe watch progress for an entire show (across all seasons).
      */
-    public fun observeShowWatchProgress(showTraktId: Long): Flow<ShowWatchProgress>
+    public fun observeShowWatchProgress(showId: Long): Flow<ShowWatchProgress>
 
     /**
      * Observe watch progress for all seasons of a show.
      * Returns a list of SeasonWatchProgress, one per season.
      */
-    public fun observeAllSeasonsWatchProgress(showTraktId: Long): Flow<List<SeasonWatchProgress>>
+    public fun observeAllSeasonsWatchProgress(showId: Long): Flow<List<SeasonWatchProgress>>
 
     /**
      * Mark all episodes in a season as watched.
      * Automatically adds the show to the library if not already there.
      */
-    public suspend fun markSeasonWatched(showTraktId: Long, seasonNumber: Long)
+    public suspend fun markSeasonWatched(showId: Long, seasonNumber: Long)
 
     /**
      * Mark all episodes in a season as watched along with all previous seasons.
      * Automatically adds the show to the library if not already there.
      */
     public suspend fun markSeasonAndPreviousSeasonsWatched(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
     )
 
     /**
      * Mark all episodes in a season as unwatched.
      */
-    public suspend fun markSeasonUnwatched(showTraktId: Long, seasonNumber: Long)
+    public suspend fun markSeasonUnwatched(showId: Long, seasonNumber: Long)
 
     /**
      * Observe count of unwatched episodes in seasons before the specified season number.
      * Used for reactive UI to determine if previous seasons dialog should be shown.
      */
     public fun observeUnwatchedCountInPreviousSeasons(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
     ): Flow<Long>
 

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/EpisodeWatchesDataSource.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/EpisodeWatchesDataSource.kt
@@ -23,5 +23,5 @@ public interface EpisodeWatchesDataSource {
      * episode in a single call, which matches the app's "unwatch" intent
      * (one episode toggle removes every prior play of that episode).
      */
-    public suspend fun removeEpisodeWatches(episodeTraktIds: List<Long>)
+    public suspend fun removeEpisodeWatches(episodeIds: List<Long>)
 }

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/EpisodeWatchesDataSource.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/EpisodeWatchesDataSource.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.episodes.api
 
 public interface EpisodeWatchesDataSource {
-    public suspend fun getShowEpisodeWatches(showTraktId: Long): List<WatchedEpisodeEntry>
+    public suspend fun getShowEpisodeWatches(showId: Long): List<WatchedEpisodeEntry>
 
     /**
      * Fetches a single page of Trakt's bulk `/sync/watched/shows` endpoint

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/EpisodesDao.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/EpisodesDao.kt
@@ -21,7 +21,7 @@ public interface EpisodesDao {
     public fun observeEpisodeById(episodeId: Long): Flow<EpisodeById?>
 
     public suspend fun getEpisodeByShowSeasonEpisodeNumber(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
     ): GetEpisodeByShowSeasonEpisodeNumber?
@@ -42,12 +42,12 @@ public interface EpisodesDao {
     ): List<UpcomingEpisodesFromFollowedShows>
 
     public fun observeNextEpisodeForShow(
-        showTraktId: Long,
+        showId: Long,
         includeSpecials: Boolean,
     ): Flow<NextEpisodeForShow?>
 
     public suspend fun getNextEpisodeForShow(
-        showTraktId: Long,
+        showId: Long,
         includeSpecials: Boolean,
     ): NextEpisodeForShow?
 }

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeDao.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeDao.kt
@@ -11,18 +11,18 @@ import kotlinx.coroutines.flow.Flow
 
 public interface WatchedEpisodeDao {
 
-    public fun observeWatchedEpisodes(showTraktId: Long): Flow<List<GetWatchedEpisodes>>
+    public fun observeWatchedEpisodes(showId: Long): Flow<List<GetWatchedEpisodes>>
 
     public fun observeRecentlyWatched(limit: Long): Flow<List<RecentlyWatchedEpisode>>
 
-    public fun observeSeasonWatchProgress(showTraktId: Long, seasonNumber: Long): Flow<SeasonWatchProgress>
+    public fun observeSeasonWatchProgress(showId: Long, seasonNumber: Long): Flow<SeasonWatchProgress>
 
-    public fun observeShowWatchProgress(showTraktId: Long): Flow<ShowWatchProgress>
+    public fun observeShowWatchProgress(showId: Long): Flow<ShowWatchProgress>
 
-    public fun observeAllSeasonsWatchProgress(showTraktId: Long): Flow<List<SeasonWatchProgress>>
+    public fun observeAllSeasonsWatchProgress(showId: Long): Flow<List<SeasonWatchProgress>>
 
     public suspend fun markAsWatched(
-        showTraktId: Long,
+        showId: Long,
         episodeId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
@@ -30,32 +30,32 @@ public interface WatchedEpisodeDao {
     )
 
     public suspend fun markAsUnwatched(
-        showTraktId: Long,
+        showId: Long,
         episodeId: Long,
         includeSpecials: Boolean,
     )
 
     public suspend fun markSeasonAsWatched(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
         episodes: List<EpisodeWatchParams>,
         includeSpecials: Boolean,
     )
 
     public suspend fun markSeasonAsUnwatched(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
         includeSpecials: Boolean,
     )
 
     public suspend fun markSeasonAndPreviousAsWatched(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
         includeSpecials: Boolean,
     )
 
     public suspend fun markEpisodeAndPreviousAsWatched(
-        showTraktId: Long,
+        showId: Long,
         episodeId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
@@ -63,18 +63,18 @@ public interface WatchedEpisodeDao {
     )
 
     public suspend fun getEpisodesForSeason(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
     ): List<EpisodeWatchParams>
 
     public suspend fun getUnwatchedEpisodeCountInPreviousSeasons(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
         includeSpecials: Boolean,
     ): Long
 
     public fun observeUnwatchedCountInPreviousSeasons(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
         includeSpecials: Boolean,
     ): Flow<Long>
@@ -99,7 +99,7 @@ public interface WatchedEpisodeDao {
     public suspend fun purgeSyncedDeletesOlderThan(thresholdMillis: Long)
 
     public suspend fun upsertBatchFromTrakt(
-        showTraktId: Long,
+        showId: Long,
         entries: List<WatchedEpisodeEntry>,
         includeSpecials: Boolean,
     )

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeEntry.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeEntry.kt
@@ -5,7 +5,7 @@ import kotlin.time.Instant
 
 public data class WatchedEpisodeEntry(
     val id: Long = 0,
-    val showTraktId: Long,
+    val showId: Long,
     val episodeId: Long?,
     val seasonNumber: Long,
     val episodeNumber: Long,

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeSyncRepository.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeSyncRepository.kt
@@ -24,5 +24,5 @@ public interface WatchedEpisodeSyncRepository {
      * flow. With [forceRefresh] false the call short-circuits when the bulk
      * consumer is already caught up or the per-show TTL has not expired.
      */
-    public suspend fun syncShowEpisodeWatches(showTraktId: Long, forceRefresh: Boolean = false)
+    public suspend fun syncShowEpisodeWatches(showId: Long, forceRefresh: Boolean = false)
 }

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedShowBatch.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedShowBatch.kt
@@ -3,12 +3,12 @@ package com.thomaskioko.tvmaniac.episodes.api
 /**
  * One show's worth of remote watched-episode state from Trakt's bulk
  * `/sync/watched/shows` endpoint. Each entry already carries its own
- * [WatchedEpisodeEntry.showTraktId], so the wrapping `showTraktId` here
+ * [WatchedEpisodeEntry.showId], so the wrapping `showId` here
  * is redundant for individual rows; it stays at the show level so callers
  * can detect end-of-pagination by checking `result.size` against the
  * requested page limit without flattening first.
  */
 public data class WatchedShowBatch(
-    public val showTraktId: Long,
+    public val showId: Long,
     public val episodes: List<WatchedEpisodeEntry>,
 )

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/model/LastWatchedEpisode.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/model/LastWatchedEpisode.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.episodes.api.model
 
 public data class LastWatchedEpisode(
-    val showTraktId: Long,
+    val showId: Long,
     val episodeId: Long,
     val seasonNumber: Long,
     val episodeNumber: Long,

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/model/RecentlyWatchedEpisode.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/model/RecentlyWatchedEpisode.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.episodes.api.model
 
 public data class RecentlyWatchedEpisode(
-    val showTraktId: Long,
+    val showId: Long,
     val showTmdbId: Long,
     val showTitle: String,
     val posterPath: String?,

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/model/SeasonWatchProgress.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/model/SeasonWatchProgress.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.episodes.api.model
 
 public data class SeasonWatchProgress(
-    val showTraktId: Long,
+    val showId: Long,
     val seasonNumber: Long,
     val watchedCount: Int,
     val totalCount: Int,

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/model/ShowWatchProgress.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/model/ShowWatchProgress.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.episodes.api.model
 
 public data class ShowWatchProgress(
-    val showTraktId: Long,
+    val showId: Long,
     val watchedCount: Int,
     val totalCount: Int,
 ) {

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/model/WatchProgress.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/model/WatchProgress.kt
@@ -3,7 +3,7 @@ package com.thomaskioko.tvmaniac.episodes.api.model
 import com.thomaskioko.tvmaniac.upnext.api.model.NextEpisodeWithShow
 
 public data class WatchProgress(
-    val showTraktId: Long,
+    val showId: Long,
     val totalEpisodesWatched: Int,
     val lastSeasonWatched: Long?,
     val lastEpisodeWatched: Long?,

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/model/WatchedEpisode.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/model/WatchedEpisode.kt
@@ -2,7 +2,7 @@ package com.thomaskioko.tvmaniac.episodes.api.model
 
 public data class WatchedEpisode(
     val id: Long,
-    val showTraktId: Long,
+    val showId: Long,
     val episodeId: Long,
     val seasonNumber: Long,
     val episodeNumber: Long,

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepository.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepository.kt
@@ -48,112 +48,112 @@ public class DefaultEpisodeRepository(
             .distinctUntilChanged()
 
     override suspend fun markEpisodeAsWatched(
-        showTraktId: Long,
+        showId: Long,
         episodeId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
     ) {
         val includeSpecials = getIncludeSpecials()
         watchedEpisodeDao.markAsWatched(
-            showTraktId = showTraktId,
+            showId = showId,
             episodeId = episodeId,
             seasonNumber = seasonNumber,
             episodeNumber = episodeNumber,
             includeSpecials = includeSpecials,
         )
 
-        launchSyncReporting { SyncError.MarkWatchedFailed(showTraktId, it) }
+        launchSyncReporting { SyncError.MarkWatchedFailed(showId, it) }
     }
 
     override suspend fun markEpisodeAndPreviousEpisodesWatched(
-        showTraktId: Long,
+        showId: Long,
         episodeId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
     ) {
         val includeSpecials = getIncludeSpecials()
         watchedEpisodeDao.markEpisodeAndPreviousAsWatched(
-            showTraktId = showTraktId,
+            showId = showId,
             episodeId = episodeId,
             seasonNumber = seasonNumber,
             episodeNumber = episodeNumber,
             includeSpecials = includeSpecials,
         )
 
-        launchSyncReporting { SyncError.BatchMarkFailed(showTraktId, it) }
+        launchSyncReporting { SyncError.BatchMarkFailed(showId, it) }
     }
 
-    override suspend fun markEpisodeAsUnwatched(showTraktId: Long, episodeId: Long) {
+    override suspend fun markEpisodeAsUnwatched(showId: Long, episodeId: Long) {
         val includeSpecials = getIncludeSpecials()
         watchedEpisodeDao.markAsUnwatched(
-            showTraktId = showTraktId,
+            showId = showId,
             episodeId = episodeId,
             includeSpecials = includeSpecials,
         )
 
-        launchSyncReporting { SyncError.MarkUnwatchedFailed(showTraktId, it) }
+        launchSyncReporting { SyncError.MarkUnwatchedFailed(showId, it) }
     }
 
     override fun observeSeasonWatchProgress(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
     ): Flow<SeasonWatchProgress> =
-        watchedEpisodeDao.observeSeasonWatchProgress(showTraktId, seasonNumber)
+        watchedEpisodeDao.observeSeasonWatchProgress(showId, seasonNumber)
             .distinctUntilChanged()
 
-    override fun observeShowWatchProgress(showTraktId: Long): Flow<ShowWatchProgress> =
-        watchedEpisodeDao.observeShowWatchProgress(showTraktId)
+    override fun observeShowWatchProgress(showId: Long): Flow<ShowWatchProgress> =
+        watchedEpisodeDao.observeShowWatchProgress(showId)
             .distinctUntilChanged()
 
-    override fun observeAllSeasonsWatchProgress(showTraktId: Long): Flow<List<SeasonWatchProgress>> =
-        watchedEpisodeDao.observeAllSeasonsWatchProgress(showTraktId)
+    override fun observeAllSeasonsWatchProgress(showId: Long): Flow<List<SeasonWatchProgress>> =
+        watchedEpisodeDao.observeAllSeasonsWatchProgress(showId)
             .distinctUntilChanged()
 
     override suspend fun markSeasonWatched(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
     ) {
         val includeSpecials = getIncludeSpecials()
-        val episodes = watchedEpisodeDao.getEpisodesForSeason(showTraktId, seasonNumber)
+        val episodes = watchedEpisodeDao.getEpisodesForSeason(showId, seasonNumber)
         watchedEpisodeDao.markSeasonAsWatched(
-            showTraktId = showTraktId,
+            showId = showId,
             seasonNumber = seasonNumber,
             episodes = episodes,
             includeSpecials = includeSpecials,
         )
 
-        launchSyncReporting { SyncError.BatchMarkFailed(showTraktId, it) }
+        launchSyncReporting { SyncError.BatchMarkFailed(showId, it) }
     }
 
     override suspend fun markSeasonAndPreviousSeasonsWatched(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
     ) {
         val includeSpecials = getIncludeSpecials()
         watchedEpisodeDao.markSeasonAndPreviousAsWatched(
-            showTraktId = showTraktId,
+            showId = showId,
             seasonNumber = seasonNumber,
             includeSpecials = includeSpecials,
         )
 
-        launchSyncReporting { SyncError.BatchMarkFailed(showTraktId, it) }
+        launchSyncReporting { SyncError.BatchMarkFailed(showId, it) }
     }
 
-    override suspend fun markSeasonUnwatched(showTraktId: Long, seasonNumber: Long) {
+    override suspend fun markSeasonUnwatched(showId: Long, seasonNumber: Long) {
         val includeSpecials = getIncludeSpecials()
-        watchedEpisodeDao.markSeasonAsUnwatched(showTraktId, seasonNumber, includeSpecials)
+        watchedEpisodeDao.markSeasonAsUnwatched(showId, seasonNumber, includeSpecials)
 
-        launchSyncReporting { SyncError.BatchMarkFailed(showTraktId, it) }
+        launchSyncReporting { SyncError.BatchMarkFailed(showId, it) }
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun observeUnwatchedCountInPreviousSeasons(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
     ): Flow<Long> = datastoreRepository.observeIncludeSpecials()
         .flatMapLatest { includeSpecials ->
             watchedEpisodeDao.observeUnwatchedCountInPreviousSeasons(
-                showTraktId,
+                showId,
                 seasonNumber,
                 includeSpecials,
             )

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepository.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepository.kt
@@ -146,15 +146,15 @@ public class DefaultWatchedEpisodeSyncRepository(
     ) {
         logger.debug(TAG, "Processing ${pending.size} pending deletes")
 
-        val episodeTraktIds = pending.mapNotNull { episode ->
+        val episodeIds = pending.mapNotNull { episode ->
             episodesDao.getEpisodeByShowSeasonEpisodeNumber(
                 showId = episode.show_trakt_id,
                 seasonNumber = episode.season_number,
                 episodeNumber = episode.episode_number,
             )?.trakt_id
         }
-        if (episodeTraktIds.isNotEmpty()) {
-            dataSource.removeEpisodeWatches(episodeTraktIds)
+        if (episodeIds.isNotEmpty()) {
+            dataSource.removeEpisodeWatches(episodeIds)
         }
 
         pending.forEach { episode ->

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepository.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepository.kt
@@ -86,18 +86,18 @@ public class DefaultWatchedEpisodeSyncRepository(
         }
     }
 
-    override suspend fun syncShowEpisodeWatches(showTraktId: Long, forceRefresh: Boolean) {
+    override suspend fun syncShowEpisodeWatches(showId: Long, forceRefresh: Boolean) {
         val authState = traktAuthRepository.getAuthState()
         if (authState == null || !authState.isAuthorized) return
 
-        val perShowExpired = lastRequestStore.isShowRequestExpired(showTraktId)
+        val perShowExpired = lastRequestStore.isShowRequestExpired(showId)
         if (!forceRefresh && !perShowExpired) {
-            logger.debug(TAG, "Per-show sync skipped for $showTraktId — per-show TTL fresh")
+            logger.debug(TAG, "Per-show sync skipped for $showId — per-show TTL fresh")
             return
         }
 
-        syncShowWatches(showTraktId)
-        lastRequestStore.updateShowLastRequest(showTraktId)
+        syncShowWatches(showId)
+        lastRequestStore.updateShowLastRequest(showId)
     }
 
     private suspend fun processPendingEpisodesToUploads() {
@@ -122,7 +122,7 @@ public class DefaultWatchedEpisodeSyncRepository(
         val entries = pending.map { episode ->
             WatchedEpisodeEntry(
                 id = episode.watched_id,
-                showTraktId = episode.show_trakt_id,
+                showId = episode.show_trakt_id,
                 episodeId = episode.episode_id?.id,
                 seasonNumber = episode.season_number,
                 episodeNumber = episode.episode_number,
@@ -148,7 +148,7 @@ public class DefaultWatchedEpisodeSyncRepository(
 
         val episodeTraktIds = pending.mapNotNull { episode ->
             episodesDao.getEpisodeByShowSeasonEpisodeNumber(
-                showTraktId = episode.show_trakt_id,
+                showId = episode.show_trakt_id,
                 seasonNumber = episode.season_number,
                 episodeNumber = episode.episode_number,
             )?.trakt_id
@@ -198,29 +198,29 @@ public class DefaultWatchedEpisodeSyncRepository(
             currentCoroutineContext().ensureActive()
             val resolved = chunk.map { entry ->
                 val episode = episodesDao.getEpisodeByShowSeasonEpisodeNumber(
-                    showTraktId = entry.showTraktId,
+                    showId = entry.showId,
                     seasonNumber = entry.seasonNumber,
                     episodeNumber = entry.episodeNumber,
                 )
                 entry.copy(episodeId = episode?.episode_id?.id)
             }
             dao.upsertBatchFromTrakt(
-                showTraktId = batch.showTraktId,
+                showId = batch.showId,
                 entries = resolved,
                 includeSpecials = includeSpecials,
             )
         }
     }
 
-    private suspend fun syncShowWatches(showTraktId: Long) {
-        val remoteWatches = dataSource.getShowEpisodeWatches(showTraktId)
+    private suspend fun syncShowWatches(showId: Long) {
+        val remoteWatches = dataSource.getShowEpisodeWatches(showId)
 
         if (remoteWatches.isEmpty()) {
-            logger.debug(TAG, "No remote watches for show $showTraktId")
+            logger.debug(TAG, "No remote watches for show $showId")
             return
         }
 
-        logger.debug(TAG, "Found ${remoteWatches.size} remote watches for show $showTraktId")
+        logger.debug(TAG, "Found ${remoteWatches.size} remote watches for show $showId")
 
         val includeSpecials = datastoreRepository.getIncludeSpecials()
 
@@ -229,7 +229,7 @@ public class DefaultWatchedEpisodeSyncRepository(
 
             val entriesWithEpisodeIds = batch.map { remoteEntry ->
                 val episode = episodesDao.getEpisodeByShowSeasonEpisodeNumber(
-                    showTraktId = showTraktId,
+                    showId = showId,
                     seasonNumber = remoteEntry.seasonNumber,
                     episodeNumber = remoteEntry.episodeNumber,
                 )
@@ -237,13 +237,13 @@ public class DefaultWatchedEpisodeSyncRepository(
             }
 
             dao.upsertBatchFromTrakt(
-                showTraktId = showTraktId,
+                showId = showId,
                 entries = entriesWithEpisodeIds,
                 includeSpecials = includeSpecials,
             )
         }
 
-        logger.debug(TAG, "Synced ${remoteWatches.size} episode watches for show $showTraktId")
+        logger.debug(TAG, "Synced ${remoteWatches.size} episode watches for show $showId")
     }
 
     private companion object {

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/EpisodeWatchesLastRequestStore.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/EpisodeWatchesLastRequestStore.kt
@@ -23,11 +23,11 @@ public class EpisodeWatchesLastRequestStore(
     public fun isRequestExpired(expiry: Duration = DEFAULT_EXPIRY): Boolean =
         !isRequestValid(expiry)
 
-    public fun isShowRequestExpired(showTraktId: Long, expiry: Duration = SHOW_DEFAULT_EXPIRY): Boolean =
-        requestManagerRepository.isRequestExpired(showTraktId, SHOW_REQUEST_TYPE, expiry)
+    public fun isShowRequestExpired(showId: Long, expiry: Duration = SHOW_DEFAULT_EXPIRY): Boolean =
+        requestManagerRepository.isRequestExpired(showId, SHOW_REQUEST_TYPE, expiry)
 
-    public fun updateShowLastRequest(showTraktId: Long) {
-        requestManagerRepository.upsert(showTraktId, SHOW_REQUEST_TYPE)
+    public fun updateShowLastRequest(showId: Long) {
+        requestManagerRepository.upsert(showId, SHOW_REQUEST_TYPE)
     }
 
     private companion object {

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/TraktEpisodeWatchesDataSource.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/TraktEpisodeWatchesDataSource.kt
@@ -29,13 +29,13 @@ public class TraktEpisodeWatchesDataSource(
     private val followedShowsDao: FollowedShowsDao,
 ) : EpisodeWatchesDataSource {
 
-    override suspend fun getShowEpisodeWatches(showTraktId: Long): List<WatchedEpisodeEntry> {
-        return when (val response = remoteDataSource.getShowEpisodeWatches(showTraktId)) {
+    override suspend fun getShowEpisodeWatches(showId: Long): List<WatchedEpisodeEntry> {
+        return when (val response = remoteDataSource.getShowEpisodeWatches(showId)) {
             is ApiResponse.Success -> {
                 response.body.mapNotNull { entry ->
                     val traktId = entry.show.ids.traktId ?: return@mapNotNull null
                     WatchedEpisodeEntry(
-                        showTraktId = traktId,
+                        showId = traktId,
                         episodeId = 0L,
                         seasonNumber = entry.episode.season.toLong(),
                         episodeNumber = entry.episode.number.toLong(),
@@ -68,11 +68,11 @@ public class TraktEpisodeWatchesDataSource(
     override suspend fun addEpisodeWatches(watches: List<WatchedEpisodeEntry>) {
         if (watches.isEmpty()) return
 
-        val showsMap = watches.groupBy { it.showTraktId }
+        val showsMap = watches.groupBy { it.showId }
 
         val shows = showsMap.mapNotNull { (showId, showWatches) ->
             val showEntry = followedShowsDao.entryWithTraktId(showId)
-            val traktId = showEntry?.traktId ?: return@mapNotNull null
+            val traktId = showEntry?.showId ?: return@mapNotNull null
 
             val seasons = showWatches
                 .groupBy { it.seasonNumber }
@@ -125,14 +125,14 @@ public class TraktEpisodeWatchesDataSource(
 internal class BulkWatchedShowsFetchException(message: String) : Exception(message)
 
 private fun TraktWatchedShowResponse.toBatch(): WatchedShowBatch? {
-    val showTraktId = show.ids.trakt
+    val showId = show.ids.trakt
     val seasons = seasons ?: return null
     val episodes = seasons.flatMap { season ->
         season.episodes.mapNotNull { episode ->
             val watchedAt = episode.lastWatchedAt?.let { runCatching { Instant.parse(it) }.getOrNull() }
                 ?: return@mapNotNull null
             WatchedEpisodeEntry(
-                showTraktId = showTraktId,
+                showId = showId,
                 episodeId = null,
                 seasonNumber = season.number,
                 episodeNumber = episode.number,
@@ -142,5 +142,5 @@ private fun TraktWatchedShowResponse.toBatch(): WatchedShowBatch? {
             )
         }
     }
-    return WatchedShowBatch(showTraktId = showTraktId, episodes = episodes)
+    return WatchedShowBatch(showId = showId, episodes = episodes)
 }

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/TraktEpisodeWatchesDataSource.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/TraktEpisodeWatchesDataSource.kt
@@ -105,11 +105,11 @@ public class TraktEpisodeWatchesDataSource(
         }
     }
 
-    override suspend fun removeEpisodeWatches(episodeTraktIds: List<Long>) {
-        if (episodeTraktIds.isEmpty()) return
+    override suspend fun removeEpisodeWatches(episodeIds: List<Long>) {
+        if (episodeIds.isEmpty()) return
 
         val items = TraktSyncItems(
-            episodes = episodeTraktIds.map { id ->
+            episodes = episodeIds.map { id ->
                 TraktSyncEpisode(ids = TraktEpisodeIds(traktId = id))
             },
         )

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/dao/DefaultEpisodesDao.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/dao/DefaultEpisodesDao.kt
@@ -73,13 +73,13 @@ public class DefaultEpisodesDao(
             .mapToOneOrNull(dispatchers.databaseRead)
 
     override suspend fun getEpisodeByShowSeasonEpisodeNumber(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
     ): GetEpisodeByShowSeasonEpisodeNumber? = withContext(dispatchers.databaseRead) {
-        val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return@withContext null
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@withContext null
         episodeQueries.getEpisodeByShowSeasonEpisodeNumber(
-            showId = showId,
+            showId = internalShowId,
             seasonNumber = seasonNumber,
             episodeNumber = episodeNumber,
         ).executeAsOneOrNull()
@@ -125,23 +125,23 @@ public class DefaultEpisodesDao(
     }
 
     override fun observeNextEpisodeForShow(
-        showTraktId: Long,
+        showId: Long,
         includeSpecials: Boolean,
     ): Flow<NextEpisodeForShow?> {
-        val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return flowOf(null)
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return flowOf(null)
         return database.showsNextToWatchQueries.nextEpisodeForShow(
-            showId = showId,
+            showId = internalShowId,
             includeSpecials = if (includeSpecials) 1L else 0L,
         ).asFlow().mapToOneOrNull(dispatchers.databaseRead)
     }
 
     override suspend fun getNextEpisodeForShow(
-        showTraktId: Long,
+        showId: Long,
         includeSpecials: Boolean,
     ): NextEpisodeForShow? = withContext(dispatchers.databaseRead) {
-        val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return@withContext null
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@withContext null
         database.showsNextToWatchQueries.nextEpisodeForShow(
-            showId = showId,
+            showId = internalShowId,
             includeSpecials = if (includeSpecials) 1L else 0L,
         ).executeAsOneOrNull()
     }

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/dao/DefaultNextEpisodeDao.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/dao/DefaultNextEpisodeDao.kt
@@ -49,7 +49,7 @@ public class DefaultNextEpisodeDao(
 
 private fun CompletedShowsForWatchlist.toCompletedShow(): CompletedShow {
     return CompletedShow(
-        showTraktId = show_trakt_id,
+        showId = show_trakt_id,
         showTmdbId = show_tmdb_id?.id,
         showName = show_name,
         showPoster = show_poster,
@@ -61,7 +61,7 @@ private fun CompletedShowsForWatchlist.toCompletedShow(): CompletedShow {
 
 private fun NextEpisodesForWatchlist.toNextEpisodeWithShow(): NextEpisodeWithShow {
     return NextEpisodeWithShow(
-        showTraktId = show_trakt_id,
+        showId = show_trakt_id,
         showTmdbId = show_tmdb_id?.id,
         episodeId = episode_id?.id,
         episodeName = episode_name,

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/dao/DefaultWatchedEpisodeDao.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/dao/DefaultWatchedEpisodeDao.kt
@@ -38,10 +38,10 @@ public class DefaultWatchedEpisodeDao(
     private val dateTimeProvider: DateTimeProvider,
 ) : WatchedEpisodeDao {
 
-    override fun observeWatchedEpisodes(showTraktId: Long): Flow<List<GetWatchedEpisodes>> {
-        val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return flowOf(emptyList())
+    override fun observeWatchedEpisodes(showId: Long): Flow<List<GetWatchedEpisodes>> {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return flowOf(emptyList())
         return database.watchedEpisodesQueries
-            .getWatchedEpisodes(showId)
+            .getWatchedEpisodes(internalShowId)
             .asFlow()
             .mapToList(dispatchers.databaseRead)
             .catch { emit(emptyList()) }
@@ -55,7 +55,7 @@ public class DefaultWatchedEpisodeDao(
             .map { rows ->
                 rows.map { row ->
                     RecentlyWatchedEpisode(
-                        showTraktId = row.show_trakt_id,
+                        showId = row.show_trakt_id,
                         showTmdbId = row.show_tmdb_id.id,
                         showTitle = row.show_title,
                         posterPath = row.poster_path,
@@ -70,7 +70,7 @@ public class DefaultWatchedEpisodeDao(
     }
 
     override suspend fun markAsWatched(
-        showTraktId: Long,
+        showId: Long,
         episodeId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
@@ -78,21 +78,21 @@ public class DefaultWatchedEpisodeDao(
     ) {
         val timestamp = dateTimeProvider.nowMillis()
         withContext(dispatchers.databaseWrite) {
-            val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return@withContext
+            val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@withContext
             database.transaction {
                 val _ = database.followedShowsQueries.upsertIfNotExists(
-                    showId = showId,
+                    showId = internalShowId,
                     tmdbId = null,
                     followedAt = timestamp,
                 )
                 val _ = database.continueWatchingQueries.upsertMembershipForLocalMark(
-                    showId = showId,
+                    showId = internalShowId,
                     tmdbId = null,
                     watchedAt = timestamp,
                 )
-                val localEpisodeId = getEpisodeIdOrNull(showId, seasonNumber, episodeNumber)
+                val localEpisodeId = getEpisodeIdOrNull(internalShowId, seasonNumber, episodeNumber)
                 val _ = database.watchedEpisodesQueries.markAsWatched(
-                    show_id = showId,
+                    show_id = internalShowId,
                     episode_id = localEpisodeId?.let { Id(it) },
                     season_number = seasonNumber,
                     episode_number = episodeNumber,
@@ -100,7 +100,7 @@ public class DefaultWatchedEpisodeDao(
                     pending_action = PendingAction.UPLOAD.value,
                 )
                 val _ = database.showMetadataQueries.recalculateLastWatched(
-                    showId = showId,
+                    showId = internalShowId,
                     include_specials = if (includeSpecials) 1L else 0L,
                 )
             }
@@ -108,98 +108,98 @@ public class DefaultWatchedEpisodeDao(
     }
 
     override suspend fun markAsUnwatched(
-        showTraktId: Long,
+        showId: Long,
         episodeId: Long,
         includeSpecials: Boolean,
     ) {
         withContext(dispatchers.databaseWrite) {
-            val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return@withContext
+            val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@withContext
             database.transaction {
                 val entry = database.watchedEpisodesQueries
-                    .getEntryByShowAndEpisode(showId, Id(episodeId))
+                    .getEntryByShowAndEpisode(internalShowId, Id(episodeId))
                     .executeAsOneOrNull()
 
                 if (entry != null) {
                     if (entry.trakt_id != null) {
                         val _ = database.watchedEpisodesQueries.updatePendingActionByShowAndEpisode(
                             pending_action = PendingAction.DELETE.value,
-                            show_id = showId,
+                            show_id = internalShowId,
                             episode_id = Id(episodeId),
                         )
                     } else {
                         val _ = database.watchedEpisodesQueries.markAsUnwatched(
-                            show_id = showId,
+                            show_id = internalShowId,
                             episode_id = Id(episodeId),
                         )
                     }
                 }
                 val _ = database.showMetadataQueries.recalculateLastWatched(
-                    showId = showId,
+                    showId = internalShowId,
                     include_specials = if (includeSpecials) 1L else 0L,
                 )
-                recalculateContinueWatchingLastWatchedAt(showId)
+                recalculateContinueWatchingLastWatchedAt(internalShowId)
             }
         }
     }
 
     override fun observeSeasonWatchProgress(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
     ): Flow<SeasonWatchProgress> {
-        val showId = showIdResolver.showIdForTraktId(showTraktId)
-            ?: return flowOf(SeasonWatchProgress(showTraktId, seasonNumber, 0, 0))
+        val internalShowId = showIdResolver.showIdForTraktId(showId)
+            ?: return flowOf(SeasonWatchProgress(showId, seasonNumber, 0, 0))
         return combine(
             database.watchedEpisodesQueries
-                .getWatchedEpisodesForSeason(showId, seasonNumber)
+                .getWatchedEpisodesForSeason(internalShowId, seasonNumber)
                 .asFlow()
                 .mapToList(dispatchers.databaseRead),
             database.watchedEpisodesQueries
-                .getTotalEpisodesForSeason(showId, seasonNumber)
+                .getTotalEpisodesForSeason(internalShowId, seasonNumber)
                 .asFlow()
                 .map { it.executeAsOne() },
         ) { watchedEpisodes, totalCount ->
             SeasonWatchProgress(
-                showTraktId = showTraktId,
+                showId = showId,
                 seasonNumber = seasonNumber,
                 watchedCount = watchedEpisodes.size,
                 totalCount = totalCount.toInt(),
             )
         }.catch {
-            emit(SeasonWatchProgress(showTraktId, seasonNumber, 0, 0))
+            emit(SeasonWatchProgress(showId, seasonNumber, 0, 0))
         }
     }
 
-    override fun observeShowWatchProgress(showTraktId: Long): Flow<ShowWatchProgress> {
-        val showId = showIdResolver.showIdForTraktId(showTraktId)
-            ?: return flowOf(ShowWatchProgress(showTraktId, 0, 0))
+    override fun observeShowWatchProgress(showId: Long): Flow<ShowWatchProgress> {
+        val internalShowId = showIdResolver.showIdForTraktId(showId)
+            ?: return flowOf(ShowWatchProgress(showId, 0, 0))
         return combine(
             database.watchedEpisodesQueries
-                .getWatchedEpisodesCountForShow(showId)
+                .getWatchedEpisodesCountForShow(internalShowId)
                 .asFlow()
                 .map { it.executeAsOne() },
             database.watchedEpisodesQueries
-                .getTotalEpisodesForShow(showId)
+                .getTotalEpisodesForShow(internalShowId)
                 .asFlow()
                 .map { it.executeAsOne() },
         ) { watchedCount, totalCount ->
             ShowWatchProgress(
-                showTraktId = showTraktId,
+                showId = showId,
                 watchedCount = watchedCount.toInt(),
                 totalCount = totalCount.toInt(),
             )
         }
     }
 
-    override fun observeAllSeasonsWatchProgress(showTraktId: Long): Flow<List<SeasonWatchProgress>> {
-        val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return flowOf(emptyList())
+    override fun observeAllSeasonsWatchProgress(showId: Long): Flow<List<SeasonWatchProgress>> {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return flowOf(emptyList())
         return database.watchedEpisodesQueries
-            .getAllSeasonsWatchProgress(showId)
+            .getAllSeasonsWatchProgress(internalShowId)
             .asFlow()
             .mapToList(dispatchers.databaseRead)
             .map { results ->
                 results.map { result ->
                     SeasonWatchProgress(
-                        showTraktId = showTraktId,
+                        showId = showId,
                         seasonNumber = result.season_number,
                         watchedCount = result.watched_count.toInt(),
                         totalCount = result.total_count.toInt(),
@@ -210,22 +210,22 @@ public class DefaultWatchedEpisodeDao(
     }
 
     override suspend fun markSeasonAsWatched(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
         episodes: List<EpisodeWatchParams>,
         includeSpecials: Boolean,
     ) {
         val timestamp = dateTimeProvider.nowMillis()
         withContext(dispatchers.databaseWrite) {
-            val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return@withContext
+            val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@withContext
             database.transaction {
                 val _ = database.followedShowsQueries.upsertIfNotExists(
-                    showId = showId,
+                    showId = internalShowId,
                     tmdbId = null,
                     followedAt = timestamp,
                 )
                 val _ = database.continueWatchingQueries.upsertMembershipForLocalMark(
-                    showId = showId,
+                    showId = internalShowId,
                     tmdbId = null,
                     watchedAt = timestamp,
                 )
@@ -235,7 +235,7 @@ public class DefaultWatchedEpisodeDao(
                     }
                     val episodeTimestamp = episode.watchedAt ?: timestamp
                     val _ = database.watchedEpisodesQueries.markAsWatched(
-                        show_id = showId,
+                        show_id = internalShowId,
                         episode_id = Id(episode.episodeId),
                         season_number = episode.seasonNumber,
                         episode_number = episode.episodeNumber,
@@ -244,7 +244,7 @@ public class DefaultWatchedEpisodeDao(
                     )
                 }
                 val _ = database.showMetadataQueries.recalculateLastWatched(
-                    showId = showId,
+                    showId = internalShowId,
                     include_specials = if (includeSpecials) 1L else 0L,
                 )
             }
@@ -252,15 +252,15 @@ public class DefaultWatchedEpisodeDao(
     }
 
     override suspend fun markSeasonAsUnwatched(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
         includeSpecials: Boolean,
     ) {
         withContext(dispatchers.databaseWrite) {
-            val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return@withContext
+            val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@withContext
             database.transaction {
                 val seasonRows = database.watchedEpisodesQueries
-                    .getWatchedEpisodesForSeason(showId, seasonNumber)
+                    .getWatchedEpisodesForSeason(internalShowId, seasonNumber)
                     .executeAsList()
 
                 seasonRows.forEach { row ->
@@ -274,10 +274,10 @@ public class DefaultWatchedEpisodeDao(
                     }
                 }
                 val _ = database.showMetadataQueries.recalculateLastWatched(
-                    showId = showId,
+                    showId = internalShowId,
                     include_specials = if (includeSpecials) 1L else 0L,
                 )
-                recalculateContinueWatchingLastWatchedAt(showId)
+                recalculateContinueWatchingLastWatchedAt(internalShowId)
             }
         }
     }
@@ -298,17 +298,17 @@ public class DefaultWatchedEpisodeDao(
     }
 
     override suspend fun markSeasonAndPreviousAsWatched(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
         includeSpecials: Boolean,
     ) {
         val timestamp = dateTimeProvider.nowMillis()
         withContext(dispatchers.databaseWrite) {
-            val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return@withContext
+            val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@withContext
             database.transaction {
                 val unwatchedEpisodesInPreviousSeasons = database.watchedEpisodesQueries
                     .getUnwatchedEpisodesInPreviousSeasons(
-                        showId = showId,
+                        showId = internalShowId,
                         season_number = seasonNumber,
                         include_specials = if (includeSpecials) 1L else 0L,
                     )
@@ -316,7 +316,7 @@ public class DefaultWatchedEpisodeDao(
 
                 unwatchedEpisodesInPreviousSeasons.forEach { episode ->
                     val _ = database.watchedEpisodesQueries.markAsWatched(
-                        show_id = showId,
+                        show_id = internalShowId,
                         episode_id = episode.episode_id,
                         season_number = episode.season_number,
                         episode_number = episode.episode_number,
@@ -326,23 +326,23 @@ public class DefaultWatchedEpisodeDao(
                 }
 
                 val currentSeasonEpisodes = database.watchedEpisodesQueries
-                    .getEpisodesForSeason(showId, seasonNumber)
+                    .getEpisodesForSeason(internalShowId, seasonNumber)
                     .executeAsList()
 
                 val _ = database.followedShowsQueries.upsertIfNotExists(
-                    showId = showId,
+                    showId = internalShowId,
                     tmdbId = null,
                     followedAt = timestamp,
                 )
                 val _ = database.continueWatchingQueries.upsertMembershipForLocalMark(
-                    showId = showId,
+                    showId = internalShowId,
                     tmdbId = null,
                     watchedAt = timestamp,
                 )
 
                 currentSeasonEpisodes.forEach { episode ->
                     val _ = database.watchedEpisodesQueries.markAsWatched(
-                        show_id = showId,
+                        show_id = internalShowId,
                         episode_id = episode.episode_id,
                         season_number = episode.season_number,
                         episode_number = episode.episode_number,
@@ -352,7 +352,7 @@ public class DefaultWatchedEpisodeDao(
                 }
 
                 val _ = database.showMetadataQueries.recalculateLastWatched(
-                    showId = showId,
+                    showId = internalShowId,
                     include_specials = if (includeSpecials) 1L else 0L,
                 )
             }
@@ -360,7 +360,7 @@ public class DefaultWatchedEpisodeDao(
     }
 
     override suspend fun markEpisodeAndPreviousAsWatched(
-        showTraktId: Long,
+        showId: Long,
         episodeId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
@@ -368,10 +368,10 @@ public class DefaultWatchedEpisodeDao(
     ) {
         val timestamp = dateTimeProvider.nowMillis()
         withContext(dispatchers.databaseWrite) {
-            val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return@withContext
+            val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@withContext
             database.transaction {
                 val unwatchedEpisodes = getPreviousUnwatchedEpisodes(
-                    showId = showId,
+                    showId = internalShowId,
                     seasonNumber = seasonNumber,
                     episodeNumber = episodeNumber,
                     includeSpecials = includeSpecials,
@@ -379,7 +379,7 @@ public class DefaultWatchedEpisodeDao(
 
                 unwatchedEpisodes.forEach { episode ->
                     val _ = database.watchedEpisodesQueries.markAsWatched(
-                        show_id = showId,
+                        show_id = internalShowId,
                         episode_id = episode.episode_id,
                         season_number = episode.season_number,
                         episode_number = episode.episode_number,
@@ -389,17 +389,17 @@ public class DefaultWatchedEpisodeDao(
                 }
 
                 val _ = database.followedShowsQueries.upsertIfNotExists(
-                    showId = showId,
+                    showId = internalShowId,
                     tmdbId = null,
                     followedAt = timestamp,
                 )
                 val _ = database.continueWatchingQueries.upsertMembershipForLocalMark(
-                    showId = showId,
+                    showId = internalShowId,
                     tmdbId = null,
                     watchedAt = timestamp,
                 )
                 val _ = database.watchedEpisodesQueries.markAsWatched(
-                    show_id = showId,
+                    show_id = internalShowId,
                     episode_id = Id(episodeId),
                     season_number = seasonNumber,
                     episode_number = episodeNumber,
@@ -407,7 +407,7 @@ public class DefaultWatchedEpisodeDao(
                     pending_action = PendingAction.UPLOAD.value,
                 )
                 val _ = database.showMetadataQueries.recalculateLastWatched(
-                    showId = showId,
+                    showId = internalShowId,
                     include_specials = if (includeSpecials) 1L else 0L,
                 )
             }
@@ -460,13 +460,13 @@ public class DefaultWatchedEpisodeDao(
     }
 
     override suspend fun getEpisodesForSeason(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
     ): List<EpisodeWatchParams> {
         return withContext(dispatchers.databaseRead) {
-            val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return@withContext emptyList()
+            val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@withContext emptyList()
             database.watchedEpisodesQueries
-                .getEpisodesForSeason(showId, seasonNumber)
+                .getEpisodesForSeason(internalShowId, seasonNumber)
                 .executeAsList()
                 .map { result ->
                     EpisodeWatchParams(
@@ -479,15 +479,15 @@ public class DefaultWatchedEpisodeDao(
     }
 
     override suspend fun getUnwatchedEpisodeCountInPreviousSeasons(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
         includeSpecials: Boolean,
     ): Long {
         return withContext(dispatchers.databaseRead) {
-            val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return@withContext 0L
+            val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@withContext 0L
             database.watchedEpisodesQueries
                 .getUnwatchedEpisodeCountInPreviousSeasons(
-                    showId = showId,
+                    showId = internalShowId,
                     season_number = seasonNumber,
                     include_specials = if (includeSpecials) 1L else 0L,
                 )
@@ -496,14 +496,14 @@ public class DefaultWatchedEpisodeDao(
     }
 
     override fun observeUnwatchedCountInPreviousSeasons(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
         includeSpecials: Boolean,
     ): Flow<Long> {
-        val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return flowOf(0L)
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return flowOf(0L)
         return database.watchedEpisodesQueries
             .getUnwatchedEpisodeCountInPreviousSeasons(
-                showId = showId,
+                showId = internalShowId,
                 season_number = seasonNumber,
                 include_specials = if (includeSpecials) 1L else 0L,
             )
@@ -533,7 +533,7 @@ public class DefaultWatchedEpisodeDao(
     }
 
     override suspend fun upsertBatchFromTrakt(
-        showTraktId: Long,
+        showId: Long,
         entries: List<WatchedEpisodeEntry>,
         includeSpecials: Boolean,
     ) {
@@ -542,22 +542,22 @@ public class DefaultWatchedEpisodeDao(
         val syncedAt = Clock.System.now().toEpochMilliseconds()
 
         withContext(dispatchers.databaseWrite) {
-            val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return@withContext
+            val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@withContext
             database.transaction {
                 val showExists = database.tvShowQueries
-                    .existsByTraktId(showTraktId)
+                    .existsByTraktId(showId)
                     .executeAsOne()
                 if (!showExists) return@transaction
 
                 val _ = database.followedShowsQueries.upsertIfNotExists(
-                    showId = showId,
+                    showId = internalShowId,
                     tmdbId = null,
                     followedAt = entries.first().watchedAt.toEpochMilliseconds(),
                 )
 
                 entries.forEach { entry ->
                     val _ = database.watchedEpisodesQueries.upsertFromTrakt(
-                        show_id = showId,
+                        show_id = internalShowId,
                         episode_id = entry.episodeId?.let { Id(it) },
                         season_number = entry.seasonNumber,
                         episode_number = entry.episodeNumber,
@@ -569,7 +569,7 @@ public class DefaultWatchedEpisodeDao(
                 }
 
                 val _ = database.showMetadataQueries.recalculateLastWatched(
-                    showId = showId,
+                    showId = internalShowId,
                     include_specials = if (includeSpecials) 1L else 0L,
                 )
             }

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/dao/DefaultWatchedEpisodeDao.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/dao/DefaultWatchedEpisodeDao.kt
@@ -545,7 +545,7 @@ public class DefaultWatchedEpisodeDao(
             val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@withContext
             database.transaction {
                 val showExists = database.tvShowQueries
-                    .existsByTraktId(showId)
+                    .existsByShowId(showId)
                     .executeAsOne()
                 if (!showExists) return@transaction
 

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/model/NextEpisodeKey.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/model/NextEpisodeKey.kt
@@ -1,6 +1,6 @@
 package com.thomaskioko.tvmaniac.episodes.implementation.model
 
 public data class NextEpisodeKey(
-    val showTraktId: Long,
+    val showId: Long,
     val seasonNumber: Long = 1,
 )

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/ContinueTrackingTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/ContinueTrackingTest.kt
@@ -63,7 +63,7 @@ internal class ContinueTrackingTest : BaseDatabaseTest() {
             initial?.is_watched shouldBe 0L
 
             watchedEpisodeDao.markAsWatched(
-                showTraktId = SHOW_ID,
+                showId = SHOW_ID,
                 episodeId = EPISODE_1_ID,
                 seasonNumber = 1L,
                 episodeNumber = 1L,
@@ -78,14 +78,14 @@ internal class ContinueTrackingTest : BaseDatabaseTest() {
     @Test
     fun `should advance next episode for show given local mark-as-watched write`() = runTest {
         episodesDao.observeNextEpisodeForShow(
-            showTraktId = SHOW_ID,
+            showId = SHOW_ID,
             includeSpecials = false,
         ).test {
             val initial = awaitItem()
             initial?.episode_number shouldBe 1L
 
             watchedEpisodeDao.markAsWatched(
-                showTraktId = SHOW_ID,
+                showId = SHOW_ID,
                 episodeId = EPISODE_1_ID,
                 seasonNumber = 1L,
                 episodeNumber = 1L,
@@ -110,14 +110,14 @@ internal class ContinueTrackingTest : BaseDatabaseTest() {
         )
 
         episodesDao.observeNextEpisodeForShow(
-            showTraktId = unfollowedShowId,
+            showId = unfollowedShowId,
             includeSpecials = false,
         ).test {
             val initial = awaitItem()
             initial?.episode_number shouldBe 1L
 
             watchedEpisodeDao.markAsWatched(
-                showTraktId = unfollowedShowId,
+                showId = unfollowedShowId,
                 episodeId = 401L,
                 seasonNumber = 1L,
                 episodeNumber = 1L,
@@ -141,7 +141,7 @@ internal class ContinueTrackingTest : BaseDatabaseTest() {
             secondEpisodeFirstAired = realNow + 7L * 86_400_000L,
         )
         watchedEpisodeDao.markAsWatched(
-            showTraktId = futureShowId,
+            showId = futureShowId,
             episodeId = 201L,
             seasonNumber = 1L,
             episodeNumber = 1L,
@@ -149,7 +149,7 @@ internal class ContinueTrackingTest : BaseDatabaseTest() {
         )
 
         episodesDao.observeNextEpisodeForShow(
-            showTraktId = futureShowId,
+            showId = futureShowId,
             includeSpecials = false,
         ).test {
             awaitItem() shouldBe null
@@ -167,7 +167,7 @@ internal class ContinueTrackingTest : BaseDatabaseTest() {
             secondEpisodeFirstAired = null,
         )
         watchedEpisodeDao.markAsWatched(
-            showTraktId = tbdShowId,
+            showId = tbdShowId,
             episodeId = 301L,
             seasonNumber = 1L,
             episodeNumber = 1L,
@@ -175,7 +175,7 @@ internal class ContinueTrackingTest : BaseDatabaseTest() {
         )
 
         episodesDao.observeNextEpisodeForShow(
-            showTraktId = tbdShowId,
+            showId = tbdShowId,
             includeSpecials = false,
         ).test {
             awaitItem() shouldBe null

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepositorySyncErrorTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepositorySyncErrorTest.kt
@@ -65,7 +65,7 @@ internal class DefaultEpisodeRepositorySyncErrorTest : BaseDatabaseTest() {
 
         syncObserver.errors.test {
             repository.markEpisodeAsWatched(
-                showTraktId = SHOW_ID,
+                showId = SHOW_ID,
                 episodeId = EPISODE_ID,
                 seasonNumber = 1L,
                 episodeNumber = 1L,
@@ -73,7 +73,7 @@ internal class DefaultEpisodeRepositorySyncErrorTest : BaseDatabaseTest() {
 
             val event = awaitItem()
             event.shouldBeInstanceOf<SyncError.MarkWatchedFailed>()
-            event.showTraktId shouldBe SHOW_ID
+            event.showId shouldBe SHOW_ID
             event.cause.message shouldBe "network down"
         }
     }
@@ -85,11 +85,11 @@ internal class DefaultEpisodeRepositorySyncErrorTest : BaseDatabaseTest() {
         syncRepository.setPendingEpisodesError(RuntimeException("network down"))
 
         syncObserver.errors.test {
-            repository.markEpisodeAsUnwatched(showTraktId = SHOW_ID, episodeId = EPISODE_ID)
+            repository.markEpisodeAsUnwatched(showId = SHOW_ID, episodeId = EPISODE_ID)
 
             val event = awaitItem()
             event.shouldBeInstanceOf<SyncError.MarkUnwatchedFailed>()
-            event.showTraktId shouldBe SHOW_ID
+            event.showId shouldBe SHOW_ID
         }
     }
 
@@ -100,11 +100,11 @@ internal class DefaultEpisodeRepositorySyncErrorTest : BaseDatabaseTest() {
         syncRepository.setPendingEpisodesError(RuntimeException("network down"))
 
         syncObserver.errors.test {
-            repository.markSeasonWatched(showTraktId = SHOW_ID, seasonNumber = 1L)
+            repository.markSeasonWatched(showId = SHOW_ID, seasonNumber = 1L)
 
             val event = awaitItem()
             event.shouldBeInstanceOf<SyncError.BatchMarkFailed>()
-            event.showTraktId shouldBe SHOW_ID
+            event.showId shouldBe SHOW_ID
         }
     }
 
@@ -116,7 +116,7 @@ internal class DefaultEpisodeRepositorySyncErrorTest : BaseDatabaseTest() {
 
         syncObserver.errors.test {
             repository.markEpisodeAsWatched(
-                showTraktId = SHOW_ID,
+                showId = SHOW_ID,
                 episodeId = EPISODE_ID,
                 seasonNumber = 1L,
                 episodeNumber = 1L,

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodesDaoTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodesDaoTest.kt
@@ -251,7 +251,7 @@ internal class DefaultEpisodesDaoTest : BaseDatabaseTest() {
         insertEpisode(episodeId = 100L, seasonId = 10L, showId = 1L, episodeNumber = 3L, title = "Target Ep")
 
         val result = episodesDao.getEpisodeByShowSeasonEpisodeNumber(
-            showTraktId = 1L,
+            showId = 1L,
             seasonNumber = 1L,
             episodeNumber = 3L,
         )
@@ -266,7 +266,7 @@ internal class DefaultEpisodesDaoTest : BaseDatabaseTest() {
         insertSeason(seasonId = 10L, showId = 1L, seasonNumber = 1L)
 
         val result = episodesDao.getEpisodeByShowSeasonEpisodeNumber(
-            showTraktId = 1L,
+            showId = 1L,
             seasonNumber = 1L,
             episodeNumber = 99L,
         )

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultNextEpisodeDaoTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultNextEpisodeDaoTest.kt
@@ -69,14 +69,14 @@ internal class DefaultNextEpisodeDaoTest : BaseDatabaseTest() {
             watchlistEpisodes.size shouldBe 2
 
             val show2Episode = watchlistEpisodes[0]
-            show2Episode.showTraktId shouldBe 2L
+            show2Episode.showId shouldBe 2L
             show2Episode.showName shouldBe "Test Show 2"
             show2Episode.episodeName shouldBe "Show 2 Episode 1"
             show2Episode.seasonNumber shouldBe 1
             show2Episode.episodeNumber shouldBe 1
 
             val show1Episode = watchlistEpisodes[1]
-            show1Episode.showTraktId shouldBe 1L
+            show1Episode.showId shouldBe 1L
             show1Episode.showName shouldBe "Test Show 1"
             show1Episode.episodeName shouldBe "Episode 2"
             show1Episode.seasonNumber shouldBe 1
@@ -93,7 +93,7 @@ internal class DefaultNextEpisodeDaoTest : BaseDatabaseTest() {
             episodes.size shouldBe 1
 
             val nextEpisode = episodes[0]
-            nextEpisode.showTraktId shouldBe 1L
+            nextEpisode.showId shouldBe 1L
             nextEpisode.showName shouldBe "Test Show 1"
             nextEpisode.episodeName shouldBe "Episode 1"
             nextEpisode.seasonNumber shouldBe 1
@@ -138,7 +138,7 @@ internal class DefaultNextEpisodeDaoTest : BaseDatabaseTest() {
         nextEpisodeDao.observeNextEpisodesForWatchlist(includeSpecials = false).test {
             val episodes = awaitItem()
             episodes.size shouldBe 1
-            episodes[0].showTraktId shouldBe 2L
+            episodes[0].showId shouldBe 2L
             episodes[0].showName shouldBe "Test Show 2"
         }
     }
@@ -184,7 +184,7 @@ internal class DefaultNextEpisodeDaoTest : BaseDatabaseTest() {
         nextEpisodeDao.observeNextEpisodesForWatchlist(includeSpecials = false).test {
             val episodes1 = awaitItem()
             episodes1.size shouldBe 1
-            episodes1[0].showTraktId shouldBe 1L
+            episodes1[0].showId shouldBe 1L
             episodes1[0].showName shouldBe "Test Show 1"
 
             followShow(showId = 2L, followedAt = watchDate + 1000)
@@ -192,10 +192,10 @@ internal class DefaultNextEpisodeDaoTest : BaseDatabaseTest() {
             val episodes2 = awaitItem()
             episodes2.size shouldBe 2
 
-            episodes2[0].showTraktId shouldBe 2L
+            episodes2[0].showId shouldBe 2L
             episodes2[0].showName shouldBe "Test Show 2"
 
-            episodes2[1].showTraktId shouldBe 1L
+            episodes2[1].showId shouldBe 1L
             episodes2[1].showName shouldBe "Test Show 1"
         }
     }
@@ -224,7 +224,7 @@ internal class DefaultNextEpisodeDaoTest : BaseDatabaseTest() {
         nextEpisodeDao.observeNextEpisodesForWatchlist(includeSpecials = false).test {
             val episodes1 = awaitItem()
             episodes1.size shouldBe 1
-            episodes1[0].showTraktId shouldBe 5L
+            episodes1[0].showId shouldBe 5L
             episodes1[0].showName shouldBe "Breaking Bad"
             episodes1[0].episodeName shouldBe "Pilot"
             episodes1[0].seasonNumber shouldBe 1
@@ -235,13 +235,13 @@ internal class DefaultNextEpisodeDaoTest : BaseDatabaseTest() {
             val episodes2 = awaitItem()
             episodes2.size shouldBe 2
 
-            episodes2[0].showTraktId shouldBe 6L
+            episodes2[0].showId shouldBe 6L
             episodes2[0].showName shouldBe "Game of Thrones"
             episodes2[0].episodeName shouldBe "Winter Is Coming"
             episodes2[0].seasonNumber shouldBe 1
             episodes2[0].episodeNumber shouldBe 1
 
-            episodes2[1].showTraktId shouldBe 5L
+            episodes2[1].showId shouldBe 5L
             episodes2[1].showName shouldBe "Breaking Bad"
             episodes2[1].episodeName shouldBe "Pilot"
             episodes2[1].seasonNumber shouldBe 1
@@ -339,8 +339,8 @@ internal class DefaultNextEpisodeDaoTest : BaseDatabaseTest() {
         nextEpisodeDao.observeNextEpisodesForWatchlist(includeSpecials = false).test {
             val episodes = awaitItem()
             episodes.size shouldBe 2
-            episodes[0].showTraktId shouldBe 2L
-            episodes[1].showTraktId shouldBe 1L
+            episodes[0].showId shouldBe 2L
+            episodes[1].showId shouldBe 1L
         }
     }
 
@@ -485,7 +485,7 @@ internal class DefaultNextEpisodeDaoTest : BaseDatabaseTest() {
         nextEpisodeDao.observeNextEpisodesForWatchlist(includeSpecials = false).test {
             val episodes = awaitItem()
             episodes.size shouldBe 1
-            episodes[0].showTraktId shouldBe 1L
+            episodes[0].showId shouldBe 1L
             episodes[0].episodeName shouldBe "Episode 2"
         }
     }
@@ -506,7 +506,7 @@ internal class DefaultNextEpisodeDaoTest : BaseDatabaseTest() {
         nextEpisodeDao.observeNextEpisodesForWatchlist(includeSpecials = false).test {
             val episodes = awaitItem()
             episodes.size shouldBe 1
-            episodes[0].showTraktId shouldBe 12L
+            episodes[0].showId shouldBe 12L
             episodes[0].episodeNumber shouldBe 9L
             episodes[0].watchedCount shouldBe 8L
             episodes[0].totalCount shouldBe 10L
@@ -529,7 +529,7 @@ internal class DefaultNextEpisodeDaoTest : BaseDatabaseTest() {
         nextEpisodeDao.observeNextEpisodesForWatchlist(includeSpecials = false).test {
             val episodes = awaitItem()
             episodes.size shouldBe 1
-            episodes[0].showTraktId shouldBe 12L
+            episodes[0].showId shouldBe 12L
             episodes[0].episodeNumber shouldBe 9L
             episodes[0].watchedCount shouldBe 8L
             episodes[0].totalCount shouldBe 10L
@@ -566,7 +566,7 @@ internal class DefaultNextEpisodeDaoTest : BaseDatabaseTest() {
         nextEpisodeDao.observeNextEpisodesForWatchlist(includeSpecials = false).test {
             val episodes = awaitItem()
             episodes.size shouldBe 1
-            episodes[0].showTraktId shouldBe 12L
+            episodes[0].showId shouldBe 12L
             episodes[0].episodeNumber shouldBe 9L
             episodes[0].watchedCount shouldBe 6L
             episodes[0].totalCount shouldBe 10L

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeDaoTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeDaoTest.kt
@@ -79,7 +79,7 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
     @Test
     fun `should count all unwatched episodes in previous seasons`() = runTest {
         val count = watchedEpisodeDao.getUnwatchedEpisodeCountInPreviousSeasons(
-            showTraktId = TEST_SHOW_ID,
+            showId = TEST_SHOW_ID,
             seasonNumber = SEASON_2_NUMBER,
             includeSpecials = false,
         )
@@ -91,7 +91,7 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
     fun `should return recently watched episodes newest first with show and episode metadata`() = runTest {
         fakeDateTimeProvider.setCurrentTimeMillis(1_000L)
         watchedEpisodeDao.markAsWatched(
-            showTraktId = TEST_SHOW_ID,
+            showId = TEST_SHOW_ID,
             episodeId = 101L,
             seasonNumber = SEASON_1_NUMBER,
             episodeNumber = 1L,
@@ -99,7 +99,7 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
         )
         fakeDateTimeProvider.setCurrentTimeMillis(2_000L)
         watchedEpisodeDao.markAsWatched(
-            showTraktId = TEST_SHOW_ID,
+            showId = TEST_SHOW_ID,
             episodeId = 102L,
             seasonNumber = SEASON_1_NUMBER,
             episodeNumber = 2L,
@@ -168,28 +168,28 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
     @Test
     fun `should return all seasons watch progress with correct counts`() = runTest {
         watchedEpisodeDao.markAsWatched(
-            showTraktId = TEST_SHOW_ID,
+            showId = TEST_SHOW_ID,
             episodeId = 101L,
             seasonNumber = SEASON_1_NUMBER,
             episodeNumber = 1L,
             includeSpecials = false,
         )
         watchedEpisodeDao.markAsWatched(
-            showTraktId = TEST_SHOW_ID,
+            showId = TEST_SHOW_ID,
             episodeId = 102L,
             seasonNumber = SEASON_1_NUMBER,
             episodeNumber = 2L,
             includeSpecials = false,
         )
         watchedEpisodeDao.markAsWatched(
-            showTraktId = TEST_SHOW_ID,
+            showId = TEST_SHOW_ID,
             episodeId = 103L,
             seasonNumber = SEASON_1_NUMBER,
             episodeNumber = 3L,
             includeSpecials = false,
         )
         watchedEpisodeDao.markAsWatched(
-            showTraktId = TEST_SHOW_ID,
+            showId = TEST_SHOW_ID,
             episodeId = 201L,
             seasonNumber = SEASON_2_NUMBER,
             episodeNumber = 1L,
@@ -245,7 +245,7 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
             val episodeNumber = episodeIndex + 1
             val episodeId = 100L + episodeNumber
             watchedEpisodeDao.markAsWatched(
-                showTraktId = TEST_SHOW_ID,
+                showId = TEST_SHOW_ID,
                 episodeId = episodeId,
                 seasonNumber = SEASON_1_NUMBER,
                 episodeNumber = episodeNumber.toLong(),
@@ -269,7 +269,7 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
             initialProgress.first { it.seasonNumber == SEASON_1_NUMBER }.watchedCount shouldBe 0
 
             watchedEpisodeDao.markAsWatched(
-                showTraktId = TEST_SHOW_ID,
+                showId = TEST_SHOW_ID,
                 episodeId = 101L,
                 seasonNumber = SEASON_1_NUMBER,
                 episodeNumber = 1L,
@@ -287,7 +287,7 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
         val entries = (1..5).map { episodeNumber ->
             WatchedEpisodeEntry(
                 id = 0,
-                showTraktId = TEST_SHOW_ID,
+                showId = TEST_SHOW_ID,
                 episodeId = (100L + episodeNumber),
                 seasonNumber = SEASON_1_NUMBER,
                 episodeNumber = episodeNumber.toLong(),
@@ -297,7 +297,7 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
         }
 
         watchedEpisodeDao.upsertBatchFromTrakt(
-            showTraktId = TEST_SHOW_ID,
+            showId = TEST_SHOW_ID,
             entries = entries,
             includeSpecials = false,
         )
@@ -317,7 +317,7 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
     @Test
     fun `should handle empty batch upsert gracefully`() = runTest {
         watchedEpisodeDao.upsertBatchFromTrakt(
-            showTraktId = TEST_SHOW_ID,
+            showId = TEST_SHOW_ID,
             entries = emptyList(),
             includeSpecials = false,
         )
@@ -344,11 +344,11 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
 
         val laterWatchedAt = kotlin.time.Instant.fromEpochMilliseconds(priorSyncedAt + 86_400_000L)
         watchedEpisodeDao.upsertBatchFromTrakt(
-            showTraktId = TEST_SHOW_ID,
+            showId = TEST_SHOW_ID,
             entries = listOf(
                 WatchedEpisodeEntry(
                     id = 0,
-                    showTraktId = TEST_SHOW_ID,
+                    showId = TEST_SHOW_ID,
                     episodeId = 101L,
                     seasonNumber = SEASON_1_NUMBER,
                     episodeNumber = 1L,
@@ -381,11 +381,11 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
 
         val stalerWatchedAt = kotlin.time.Instant.fromEpochMilliseconds(syncedAt - 86_400_000L)
         watchedEpisodeDao.upsertBatchFromTrakt(
-            showTraktId = TEST_SHOW_ID,
+            showId = TEST_SHOW_ID,
             entries = listOf(
                 WatchedEpisodeEntry(
                     id = 0,
-                    showTraktId = TEST_SHOW_ID,
+                    showId = TEST_SHOW_ID,
                     episodeId = 101L,
                     seasonNumber = SEASON_1_NUMBER,
                     episodeNumber = 1L,
@@ -415,11 +415,11 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
         )
 
         watchedEpisodeDao.upsertBatchFromTrakt(
-            showTraktId = TEST_SHOW_ID,
+            showId = TEST_SHOW_ID,
             entries = listOf(
                 WatchedEpisodeEntry(
                     id = 0,
-                    showTraktId = TEST_SHOW_ID,
+                    showId = TEST_SHOW_ID,
                     episodeId = 101L,
                     seasonNumber = SEASON_1_NUMBER,
                     episodeNumber = 1L,
@@ -442,7 +442,7 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
         val unknownShowId = 7777L
         val entry = WatchedEpisodeEntry(
             id = 0,
-            showTraktId = unknownShowId,
+            showId = unknownShowId,
             episodeId = null,
             seasonNumber = 1L,
             episodeNumber = 1L,
@@ -451,7 +451,7 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
         )
 
         watchedEpisodeDao.upsertBatchFromTrakt(
-            showTraktId = unknownShowId,
+            showId = unknownShowId,
             entries = listOf(entry),
             includeSpecials = false,
         )
@@ -497,7 +497,7 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
         )
 
         watchedEpisodeDao.markAsWatched(
-            showTraktId = showId,
+            showId = showId,
             episodeId = nonExistentEpisodeId,
             seasonNumber = seasonNumber,
             episodeNumber = episodeNumber,
@@ -583,7 +583,7 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
     @Test
     fun `should keep watched episodes given an episode row is re-upserted during metadata sync`() = runTest {
         watchedEpisodeDao.markAsWatched(
-            showTraktId = TEST_SHOW_ID,
+            showId = TEST_SHOW_ID,
             episodeId = 101L,
             seasonNumber = SEASON_1_NUMBER,
             episodeNumber = 1L,

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepositoryTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepositoryTest.kt
@@ -128,7 +128,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
         requestManagerRepository.requestExpired = true
         recordingDataSource.showWatchesToReturn = listOf(
             WatchedEpisodeEntry(
-                showTraktId = SHOW_ID,
+                showId = SHOW_ID,
                 episodeId = null,
                 seasonNumber = 1L,
                 episodeNumber = 1L,
@@ -137,7 +137,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
             ),
         )
 
-        defaultWatchedEpisodeSyncRepository.syncShowEpisodeWatches(showTraktId = SHOW_ID, forceRefresh = false)
+        defaultWatchedEpisodeSyncRepository.syncShowEpisodeWatches(showId = SHOW_ID, forceRefresh = false)
 
         recordingDataSource.getShowEpisodeWatchesCalls shouldContainExactly listOf(SHOW_ID)
         readRow(seasonNumber = 1L, episodeNumber = 1L).shouldNotBeNull()
@@ -234,8 +234,8 @@ private class RecordingEpisodeWatchesDataSource : EpisodeWatchesDataSource {
     val getShowEpisodeWatchesCalls: List<Long> get() = _getShowEpisodeWatchesCalls.toList()
     var showWatchesToReturn: List<WatchedEpisodeEntry> = emptyList()
 
-    override suspend fun getShowEpisodeWatches(showTraktId: Long): List<WatchedEpisodeEntry> {
-        _getShowEpisodeWatchesCalls += showTraktId
+    override suspend fun getShowEpisodeWatches(showId: Long): List<WatchedEpisodeEntry> {
+        _getShowEpisodeWatchesCalls += showId
         return showWatchesToReturn
     }
     override suspend fun getAllWatchedShows(

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepositoryTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepositoryTest.kt
@@ -243,8 +243,8 @@ private class RecordingEpisodeWatchesDataSource : EpisodeWatchesDataSource {
         limit: Int,
     ): List<com.thomaskioko.tvmaniac.episodes.api.WatchedShowBatch> = emptyList()
     override suspend fun addEpisodeWatches(watches: List<WatchedEpisodeEntry>) {}
-    override suspend fun removeEpisodeWatches(episodeTraktIds: List<Long>) {
-        _removedTraktIds += episodeTraktIds
+    override suspend fun removeEpisodeWatches(episodeIds: List<Long>) {
+        _removedTraktIds += episodeIds
     }
 }
 

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/MarkWatchedFromDiscoverUpNextRefreshTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/MarkWatchedFromDiscoverUpNextRefreshTest.kt
@@ -66,7 +66,7 @@ internal class MarkWatchedFromDiscoverUpNextRefreshTest : BaseDatabaseTest() {
             initial[0].totalCount shouldBe 3L
 
             watchedEpisodeDao.markAsWatched(
-                showTraktId = SHOW_ID,
+                showId = SHOW_ID,
                 episodeId = EPISODE_1_ID,
                 seasonNumber = 1L,
                 episodeNumber = 1L,
@@ -80,7 +80,7 @@ internal class MarkWatchedFromDiscoverUpNextRefreshTest : BaseDatabaseTest() {
             afterFirst[0].totalCount shouldBe 3L
 
             watchedEpisodeDao.markAsWatched(
-                showTraktId = SHOW_ID,
+                showId = SHOW_ID,
                 episodeId = EPISODE_2_ID,
                 seasonNumber = 1L,
                 episodeNumber = 2L,
@@ -101,7 +101,7 @@ internal class MarkWatchedFromDiscoverUpNextRefreshTest : BaseDatabaseTest() {
             awaitItem().size shouldBe 1
 
             watchedEpisodeDao.markAsWatched(
-                showTraktId = SHOW_ID,
+                showId = SHOW_ID,
                 episodeId = EPISODE_1_ID,
                 seasonNumber = 1L,
                 episodeNumber = 1L,
@@ -110,7 +110,7 @@ internal class MarkWatchedFromDiscoverUpNextRefreshTest : BaseDatabaseTest() {
             awaitItem()[0].episodeNumber shouldBe 2L
 
             watchedEpisodeDao.markAsWatched(
-                showTraktId = SHOW_ID,
+                showId = SHOW_ID,
                 episodeId = EPISODE_2_ID,
                 seasonNumber = 1L,
                 episodeNumber = 2L,
@@ -119,7 +119,7 @@ internal class MarkWatchedFromDiscoverUpNextRefreshTest : BaseDatabaseTest() {
             awaitItem()[0].episodeNumber shouldBe 3L
 
             watchedEpisodeDao.markAsWatched(
-                showTraktId = SHOW_ID,
+                showId = SHOW_ID,
                 episodeId = EPISODE_3_ID,
                 seasonNumber = 1L,
                 episodeNumber = 3L,
@@ -139,7 +139,7 @@ internal class MarkWatchedFromDiscoverUpNextRefreshTest : BaseDatabaseTest() {
 
         fakeDateTimeProvider.setCurrentTimeMillis(now + 10_000L)
         watchedEpisodeDao.markAsWatched(
-            showTraktId = SHOW_ID,
+            showId = SHOW_ID,
             episodeId = EPISODE_1_ID,
             seasonNumber = 1L,
             episodeNumber = 1L,
@@ -158,7 +158,7 @@ internal class MarkWatchedFromDiscoverUpNextRefreshTest : BaseDatabaseTest() {
     fun `should recompute trakt continue watching last watched at on local unmark`() = runTest {
         fakeDateTimeProvider.setCurrentTimeMillis(now + 1_000L)
         watchedEpisodeDao.markAsWatched(
-            showTraktId = SHOW_ID,
+            showId = SHOW_ID,
             episodeId = EPISODE_1_ID,
             seasonNumber = 1L,
             episodeNumber = 1L,
@@ -166,7 +166,7 @@ internal class MarkWatchedFromDiscoverUpNextRefreshTest : BaseDatabaseTest() {
         )
         fakeDateTimeProvider.setCurrentTimeMillis(now + 5_000L)
         watchedEpisodeDao.markAsWatched(
-            showTraktId = SHOW_ID,
+            showId = SHOW_ID,
             episodeId = EPISODE_2_ID,
             seasonNumber = 1L,
             episodeNumber = 2L,
@@ -174,7 +174,7 @@ internal class MarkWatchedFromDiscoverUpNextRefreshTest : BaseDatabaseTest() {
         )
 
         watchedEpisodeDao.markAsUnwatched(
-            showTraktId = SHOW_ID,
+            showId = SHOW_ID,
             episodeId = EPISODE_2_ID,
             includeSpecials = false,
         )

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/MockData.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/MockData.kt
@@ -81,7 +81,7 @@ internal object MockData {
 
     val season1Details = SeasonDetailsWithEpisodes(
         seasonId = SEASON_1_ID,
-        showTraktId = TEST_SHOW_ID,
+        showId = TEST_SHOW_ID,
         showTmdbId = TEST_SHOW_ID,
         name = "Season 1",
         showTitle = TEST_SHOW_NAME,
@@ -94,7 +94,7 @@ internal object MockData {
 
     val season2Details = SeasonDetailsWithEpisodes(
         seasonId = SEASON_2_ID,
-        showTraktId = TEST_SHOW_ID,
+        showId = TEST_SHOW_ID,
         showTmdbId = TEST_SHOW_ID,
         name = "Season 2",
         showTitle = TEST_SHOW_NAME,
@@ -167,7 +167,7 @@ internal object MockData {
         episodes: List<EpisodeDetails>,
     ) = SeasonDetailsWithEpisodes(
         seasonId = seasonId,
-        showTraktId = TEST_SHOW_ID,
+        showId = TEST_SHOW_ID,
         showTmdbId = TEST_SHOW_ID,
         name = "Season $seasonNumber",
         showTitle = "Test Show",

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/WatchedEpisodeTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/WatchedEpisodeTest.kt
@@ -70,7 +70,7 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
     @Test
     fun `should preserve UPLOAD-pending row when upsertBatchFromTrakt has same key`() = runTest {
         dao.markAsWatched(
-            showTraktId = SHOW_ID,
+            showId = SHOW_ID,
             episodeId = EPISODE_1_ID,
             seasonNumber = 1L,
             episodeNumber = 1L,
@@ -78,7 +78,7 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
         )
 
         dao.upsertBatchFromTrakt(
-            showTraktId = SHOW_ID,
+            showId = SHOW_ID,
             entries = listOf(traktEntry(seasonNumber = 1L, episodeNumber = 1L, traktId = 999L)),
             includeSpecials = false,
         )
@@ -97,7 +97,7 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
         dao.markAsSyncedDelete(rowId)
 
         dao.upsertBatchFromTrakt(
-            showTraktId = SHOW_ID,
+            showId = SHOW_ID,
             entries = listOf(traktEntry(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L)),
             includeSpecials = false,
         )
@@ -164,7 +164,7 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
     @Test
     fun `should hard-delete UPLOAD-pending unsynced row when marked unwatched`() = runTest {
         dao.markAsWatched(
-            showTraktId = SHOW_ID,
+            showId = SHOW_ID,
             episodeId = EPISODE_1_ID,
             seasonNumber = 1L,
             episodeNumber = 1L,
@@ -173,7 +173,7 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
         readRow(seasonNumber = 1L, episodeNumber = 1L).shouldNotBeNull()
 
         dao.markAsUnwatched(
-            showTraktId = SHOW_ID,
+            showId = SHOW_ID,
             episodeId = EPISODE_1_ID,
             includeSpecials = false,
         )
@@ -185,14 +185,14 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
     fun `should flip DELETE to UPLOAD when re-marked watched`() = runTest {
         seedSyncedRow(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L)
         dao.markAsUnwatched(
-            showTraktId = SHOW_ID,
+            showId = SHOW_ID,
             episodeId = EPISODE_1_ID,
             includeSpecials = false,
         )
         readRow(seasonNumber = 1L, episodeNumber = 1L)!!.pending_action shouldBe PendingAction.DELETE.value
 
         dao.markAsWatched(
-            showTraktId = SHOW_ID,
+            showId = SHOW_ID,
             episodeId = EPISODE_1_ID,
             seasonNumber = 1L,
             episodeNumber = 1L,
@@ -212,7 +212,7 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
         readRow(seasonNumber = 1L, episodeNumber = 1L)!!.pending_action shouldBe PendingAction.SYNCED_DELETE.value
 
         dao.markAsWatched(
-            showTraktId = SHOW_ID,
+            showId = SHOW_ID,
             episodeId = EPISODE_1_ID,
             seasonNumber = 1L,
             episodeNumber = 1L,
@@ -231,7 +231,7 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
         readRow(seasonNumber = 1L, episodeNumber = 1L)!!.trakt_id shouldBe 555L
 
         dao.markAsWatched(
-            showTraktId = SHOW_ID,
+            showId = SHOW_ID,
             episodeId = EPISODE_1_ID,
             seasonNumber = 1L,
             episodeNumber = 1L,
@@ -249,7 +249,7 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
     fun `markSeasonAsUnwatched should flip synced rows to DELETE and hard-delete unsynced rows`() = runTest {
         seedSyncedRow(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L)
         dao.markAsWatched(
-            showTraktId = SHOW_ID,
+            showId = SHOW_ID,
             episodeId = EPISODE_2_ID,
             seasonNumber = 1L,
             episodeNumber = 2L,
@@ -257,7 +257,7 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
         )
 
         dao.markSeasonAsUnwatched(
-            showTraktId = SHOW_ID,
+            showId = SHOW_ID,
             seasonNumber = 1L,
             includeSpecials = false,
         )
@@ -335,7 +335,7 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
         episodeNumber: Long,
         traktId: Long,
     ): WatchedEpisodeEntry = WatchedEpisodeEntry(
-        showTraktId = SHOW_ID,
+        showId = SHOW_ID,
         episodeId = null,
         seasonNumber = seasonNumber,
         episodeNumber = episodeNumber,

--- a/data/episode/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/testing/FakeEpisodeRepository.kt
+++ b/data/episode/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/testing/FakeEpisodeRepository.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlin.time.Duration
 
 public data class MarkEpisodeWatchedCall(
-    val showTraktId: Long,
+    val showId: Long,
     val episodeId: Long,
     val seasonNumber: Long,
     val episodeNumber: Long,
@@ -21,13 +21,13 @@ public data class MarkEpisodeWatchedCall(
 )
 
 public data class MarkSeasonWatchedCall(
-    val showTraktId: Long,
+    val showId: Long,
     val seasonNumber: Long,
     val markPreviousSeasons: Boolean,
 )
 
 public data class MarkEpisodeUnwatchedCall(
-    val showTraktId: Long,
+    val showId: Long,
     val episodeId: Long,
 )
 
@@ -91,39 +91,39 @@ public class FakeEpisodeRepository : EpisodeRepository {
         recentlyWatchedFlow.asStateFlow()
 
     override suspend fun markEpisodeAsWatched(
-        showTraktId: Long,
+        showId: Long,
         episodeId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
     ) {
-        lastMarkEpisodeWatchedCall = MarkEpisodeWatchedCall(showTraktId, episodeId, seasonNumber, episodeNumber)
+        lastMarkEpisodeWatchedCall = MarkEpisodeWatchedCall(showId, episodeId, seasonNumber, episodeNumber)
     }
 
-    override suspend fun markEpisodeAsUnwatched(showTraktId: Long, episodeId: Long) {
-        lastMarkEpisodeUnwatchedCall = MarkEpisodeUnwatchedCall(showTraktId, episodeId)
+    override suspend fun markEpisodeAsUnwatched(showId: Long, episodeId: Long) {
+        lastMarkEpisodeUnwatchedCall = MarkEpisodeUnwatchedCall(showId, episodeId)
     }
 
-    override fun observeSeasonWatchProgress(showTraktId: Long, seasonNumber: Long): Flow<SeasonWatchProgress> =
+    override fun observeSeasonWatchProgress(showId: Long, seasonNumber: Long): Flow<SeasonWatchProgress> =
         seasonWatchProgressFlow.asStateFlow()
 
-    override fun observeShowWatchProgress(showTraktId: Long): Flow<ShowWatchProgress> =
+    override fun observeShowWatchProgress(showId: Long): Flow<ShowWatchProgress> =
         showWatchProgressFlow.asStateFlow()
 
-    override fun observeAllSeasonsWatchProgress(showTraktId: Long): Flow<List<SeasonWatchProgress>> =
+    override fun observeAllSeasonsWatchProgress(showId: Long): Flow<List<SeasonWatchProgress>> =
         allSeasonsWatchProgressFlow.asStateFlow()
 
-    override suspend fun markSeasonWatched(showTraktId: Long, seasonNumber: Long) {
-        lastMarkSeasonWatchedCall = MarkSeasonWatchedCall(showTraktId, seasonNumber, markPreviousSeasons = false)
+    override suspend fun markSeasonWatched(showId: Long, seasonNumber: Long) {
+        lastMarkSeasonWatchedCall = MarkSeasonWatchedCall(showId, seasonNumber, markPreviousSeasons = false)
     }
 
     override suspend fun markEpisodeAndPreviousEpisodesWatched(
-        showTraktId: Long,
+        showId: Long,
         episodeId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
     ) {
         lastMarkEpisodeWatchedCall = MarkEpisodeWatchedCall(
-            showTraktId,
+            showId,
             episodeId,
             seasonNumber,
             episodeNumber,
@@ -132,16 +132,16 @@ public class FakeEpisodeRepository : EpisodeRepository {
     }
 
     override suspend fun markSeasonAndPreviousSeasonsWatched(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
     ) {
-        lastMarkSeasonWatchedCall = MarkSeasonWatchedCall(showTraktId, seasonNumber, markPreviousSeasons = true)
+        lastMarkSeasonWatchedCall = MarkSeasonWatchedCall(showId, seasonNumber, markPreviousSeasons = true)
     }
 
-    override suspend fun markSeasonUnwatched(showTraktId: Long, seasonNumber: Long) {}
+    override suspend fun markSeasonUnwatched(showId: Long, seasonNumber: Long) {}
 
     override fun observeUnwatchedCountInPreviousSeasons(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
     ): Flow<Long> = unwatchedCountInPreviousSeasonsFlow.asStateFlow()
 

--- a/data/episode/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/testing/FakeEpisodeWatchesDataSource.kt
+++ b/data/episode/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/testing/FakeEpisodeWatchesDataSource.kt
@@ -42,7 +42,7 @@ public class FakeEpisodeWatchesDataSource : EpisodeWatchesDataSource {
         addEpisodeWatchesInvocations.add(watches)
     }
 
-    override suspend fun removeEpisodeWatches(episodeTraktIds: List<Long>) {
-        removeEpisodeWatchesInvocations.add(episodeTraktIds)
+    override suspend fun removeEpisodeWatches(episodeIds: List<Long>) {
+        removeEpisodeWatchesInvocations.add(episodeIds)
     }
 }

--- a/data/episode/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/testing/FakeEpisodeWatchesDataSource.kt
+++ b/data/episode/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/testing/FakeEpisodeWatchesDataSource.kt
@@ -11,8 +11,8 @@ public class FakeEpisodeWatchesDataSource : EpisodeWatchesDataSource {
     private val removeEpisodeWatchesInvocations = mutableListOf<List<Long>>()
     private var allWatchedShowsError: Throwable? = null
 
-    public fun setShowEpisodeWatches(showTraktId: Long, watches: List<WatchedEpisodeEntry>) {
-        watchesMap[showTraktId] = watches
+    public fun setShowEpisodeWatches(showId: Long, watches: List<WatchedEpisodeEntry>) {
+        watchesMap[showId] = watches
     }
 
     public fun setAllWatchedShowsPage(page: Int, batches: List<WatchedShowBatch>) {
@@ -29,8 +29,8 @@ public class FakeEpisodeWatchesDataSource : EpisodeWatchesDataSource {
     public fun removeEpisodeWatchesInvocations(): List<List<Long>> =
         removeEpisodeWatchesInvocations.toList()
 
-    override suspend fun getShowEpisodeWatches(showTraktId: Long): List<WatchedEpisodeEntry> {
-        return watchesMap[showTraktId] ?: emptyList()
+    override suspend fun getShowEpisodeWatches(showId: Long): List<WatchedEpisodeEntry> {
+        return watchesMap[showId] ?: emptyList()
     }
 
     override suspend fun getAllWatchedShows(page: Int, limit: Int): List<WatchedShowBatch> {

--- a/data/episode/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/testing/FakeWatchedEpisodeSyncRepository.kt
+++ b/data/episode/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/testing/FakeWatchedEpisodeSyncRepository.kt
@@ -37,8 +37,8 @@ public class FakeWatchedEpisodeSyncRepository : WatchedEpisodeSyncRepository {
         syncPendingCallCount = 0
     }
 
-    override suspend fun syncShowEpisodeWatches(showTraktId: Long, forceRefresh: Boolean) {
-        syncedShowIds.add(showTraktId)
+    override suspend fun syncShowEpisodeWatches(showId: Long, forceRefresh: Boolean) {
+        syncedShowIds.add(showId)
         lastForceRefresh = forceRefresh
     }
 

--- a/data/favorites/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/favorites/api/FavoriteShow.kt
+++ b/data/favorites/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/favorites/api/FavoriteShow.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.favorites.api
 
 public data class FavoriteShow(
-    val traktId: Long,
+    val showId: Long,
     val tmdbId: Long,
     val title: String,
     val posterPath: String?,

--- a/data/favorites/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/favorites/api/FavoritesDao.kt
+++ b/data/favorites/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/favorites/api/FavoritesDao.kt
@@ -6,7 +6,7 @@ public interface FavoritesDao {
 
     public fun observeFavoriteShows(): Flow<List<FavoriteShow>>
 
-    public fun upsert(traktId: Long, rank: Long, listedAt: String)
+    public fun upsert(showId: Long, rank: Long, listedAt: String)
 
     public fun deleteAll()
 }

--- a/data/favorites/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/favorites/implementation/DefaultFavoritesDao.kt
+++ b/data/favorites/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/favorites/implementation/DefaultFavoritesDao.kt
@@ -30,10 +30,10 @@ public class DefaultFavoritesDao(
             .map { rows -> rows.map { it.toFavoriteShow() } }
             .catch { emit(emptyList()) }
 
-    override fun upsert(traktId: Long, rank: Long, listedAt: String) {
-        val showId = showIdResolver.showIdForTraktId(traktId) ?: return
+    override fun upsert(showId: Long, rank: Long, listedAt: String) {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return
         database.favoritesQueries.upsert(
-            show_id = showId,
+            show_id = internalShowId,
             rank = rank,
             listed_at = listedAt,
         )
@@ -46,7 +46,7 @@ public class DefaultFavoritesDao(
 
 private fun FavoriteShows.toFavoriteShow(): FavoriteShow =
     FavoriteShow(
-        traktId = show_trakt_id,
+        showId = show_trakt_id,
         tmdbId = show_tmdb_id.id,
         title = title,
         posterPath = poster_path,

--- a/data/favorites/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/favorites/implementation/FavoritesStore.kt
+++ b/data/favorites/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/favorites/implementation/FavoritesStore.kt
@@ -79,7 +79,7 @@ public class FavoritesStore(
                         ),
                     )
                     favoritesDao.upsert(
-                        traktId = item.response.show.ids.trakt,
+                        showId = item.response.show.ids.trakt,
                         rank = item.response.rank.toLong(),
                         listedAt = item.response.listedAt,
                     )
@@ -115,7 +115,7 @@ private data class FavoriteWithImages(
 )
 
 private fun TraktFavoriteShowResponse.toTvshow(posterPath: String?, backdropPath: String?): ShowToPersist = ShowToPersist(
-    traktId = Id(show.ids.trakt),
+    showId = Id(show.ids.trakt),
     tmdbId = Id(show.ids.tmdb),
     name = show.title,
     overview = "",

--- a/data/favorites/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/favorites/implementation/DefaultFavoritesDaoTest.kt
+++ b/data/favorites/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/favorites/implementation/DefaultFavoritesDaoTest.kt
@@ -43,7 +43,7 @@ internal class DefaultFavoritesDaoTest : BaseDatabaseTest() {
     @Test
     fun `should emit favorite show joined with show metadata`() = runTest(testDispatcher) {
         insertShow(id = 1, name = "Breaking Bad")
-        dao.upsert(traktId = 1, rank = 0, listedAt = "2020-01-01T00:00:00Z")
+        dao.upsert(showId = 1, rank = 0, listedAt = "2020-01-01T00:00:00Z")
 
         dao.observeFavoriteShows().test {
             awaitItem() shouldContainExactly listOf(expectedShow(1, "Breaking Bad"))
@@ -55,8 +55,8 @@ internal class DefaultFavoritesDaoTest : BaseDatabaseTest() {
     fun `should order favorites by rank ascending`() = runTest(testDispatcher) {
         insertShow(id = 1, name = "First Rank")
         insertShow(id = 2, name = "Second Rank")
-        dao.upsert(traktId = 2, rank = 1, listedAt = "2020-01-02T00:00:00Z")
-        dao.upsert(traktId = 1, rank = 0, listedAt = "2020-01-01T00:00:00Z")
+        dao.upsert(showId = 2, rank = 1, listedAt = "2020-01-02T00:00:00Z")
+        dao.upsert(showId = 1, rank = 0, listedAt = "2020-01-01T00:00:00Z")
 
         dao.observeFavoriteShows().test {
             awaitItem() shouldContainExactly listOf(
@@ -70,7 +70,7 @@ internal class DefaultFavoritesDaoTest : BaseDatabaseTest() {
     @Test
     fun `should emit empty list after deleteAll`() = runTest(testDispatcher) {
         insertShow(id = 1, name = "Breaking Bad")
-        dao.upsert(traktId = 1, rank = 0, listedAt = "2020-01-01T00:00:00Z")
+        dao.upsert(showId = 1, rank = 0, listedAt = "2020-01-01T00:00:00Z")
 
         dao.observeFavoriteShows().test {
             awaitItem() shouldContainExactly listOf(expectedShow(1, "Breaking Bad"))
@@ -83,7 +83,7 @@ internal class DefaultFavoritesDaoTest : BaseDatabaseTest() {
     }
 
     private fun expectedShow(id: Long, title: String): FavoriteShow =
-        FavoriteShow(traktId = id, tmdbId = id, title = title, posterPath = "/$id.jpg", year = "2020-01-01")
+        FavoriteShow(showId = id, tmdbId = id, title = title, posterPath = "/$id.jpg", year = "2020-01-01")
 
     private fun insertShow(id: Long, name: String) {
         database.tvShowQueries.upsert(

--- a/data/featuredshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/featuredshows/implementation/DefaultFeaturedShowsDao.kt
+++ b/data/featuredshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/featuredshows/implementation/DefaultFeaturedShowsDao.kt
@@ -38,9 +38,9 @@ public class DefaultFeaturedShowsDao(
 
     override fun observeFeaturedShows(page: Long): Flow<List<ShowEntity>> =
         featuredShowsQueries
-            .entriesInPage { traktId, tmdbId, name, posterPath, overview, inLibrary ->
+            .entriesInPage { showId, tmdbId, name, posterPath, overview, inLibrary ->
                 ShowEntity(
-                    traktId = traktId,
+                    showId = showId,
                     tmdbId = tmdbId.id,
                     title = name,
                     posterPath = posterPath,

--- a/data/featuredshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/featuredshows/implementation/FeaturedShowsStore.kt
+++ b/data/featuredshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/featuredshows/implementation/FeaturedShowsStore.kt
@@ -89,7 +89,7 @@ public class FeaturedShowsStore(
 
                     response.forEach { showWithImages ->
                         val show = showWithImages.traktShow
-                        val traktId = show.ids.trakt
+                        val showId = show.ids.trakt
                         val tmdbId = showWithImages.tmdbId
                         val posterPath = showWithImages.tmdbPosterPath?.let {
                             formatterUtil.formatTmdbPosterPath(it)
@@ -98,13 +98,13 @@ public class FeaturedShowsStore(
                             formatterUtil.formatTmdbPosterPath(it)
                         }
 
-                        tvShowsDao.upsertMerging(show.toTvshow(traktId, tmdbId, posterPath, backdropPath, dateTimeProvider))
+                        tvShowsDao.upsertMerging(show.toTvshow(showId, tmdbId, posterPath, backdropPath, dateTimeProvider))
 
-                        val showId = showIdResolver.showIdForTraktId(traktId) ?: return@forEach
+                        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@forEach
 
                         featuredShowsDao.upsert(
                             Featured_shows(
-                                show_id = showId,
+                                show_id = internalShowId,
                                 tmdb_id = Id(tmdbId),
                                 name = show.title,
                                 poster_path = posterPath,
@@ -140,13 +140,13 @@ private data class FeaturedShowWithImages(
 )
 
 private fun TraktShowResponse.toTvshow(
-    traktId: Long,
+    showId: Long,
     tmdbId: Long,
     posterPath: String?,
     backdropPath: String?,
     dateTimeProvider: DateTimeProvider,
 ): ShowToPersist = ShowToPersist(
-    traktId = Id(traktId),
+    showId = Id(showId),
     tmdbId = Id(tmdbId),
     name = title,
     overview = overview ?: "",

--- a/data/featuredshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/featuredshows/implementation/DefaultFeaturedShowsDaoTest.kt
+++ b/data/featuredshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/featuredshows/implementation/DefaultFeaturedShowsDaoTest.kt
@@ -54,7 +54,7 @@ internal class DefaultFeaturedShowsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `should insert featured shows`() = runTest {
-        val showId = seedShow(traktId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
+        val showId = seedShow(showId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
 
         val featuredShow = Featured_shows(
             show_id = showId,
@@ -70,7 +70,7 @@ internal class DefaultFeaturedShowsDaoTest : BaseDatabaseTest() {
         dao.observeFeaturedShows(page = 1).test {
             val shows = awaitItem()
             shows.size shouldBe 3
-            shows.any { it.traktId == 999L } shouldBe true
+            shows.any { it.showId == 999L } shouldBe true
             cancelAndConsumeRemainingEvents()
         }
     }
@@ -81,13 +81,13 @@ internal class DefaultFeaturedShowsDaoTest : BaseDatabaseTest() {
             val shows = awaitItem()
             shows.size shouldBe 2
 
-            val show1 = shows.find { it.traktId == 1L }
+            val show1 = shows.find { it.showId == 1L }
             show1?.title shouldBe "Test Show 1"
             show1?.posterPath shouldBe "/test1.jpg"
             show1?.overview shouldBe "Test overview 1"
             show1?.inLibrary shouldBe false
 
-            val show2 = shows.find { it.traktId == 2L }
+            val show2 = shows.find { it.showId == 2L }
             show2?.title shouldBe "Test Show 2"
             show2?.posterPath shouldBe "/test2.jpg"
             show2?.overview shouldBe "Test overview 2"
@@ -99,7 +99,7 @@ internal class DefaultFeaturedShowsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `should not return shows with null names`() = runTest {
-        val showId = seedShow(traktId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
+        val showId = seedShow(showId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
         val _ = featuredShowsQueries.insert(
             showId = showId,
             tmdbId = Id<TmdbId>(999),
@@ -112,7 +112,7 @@ internal class DefaultFeaturedShowsDaoTest : BaseDatabaseTest() {
         dao.observeFeaturedShows(1).test {
             val shows = awaitItem()
             shows.size shouldBe 2
-            shows.none { it.traktId == 999L } shouldBe true
+            shows.none { it.showId == 999L } shouldBe true
             cancelAndConsumeRemainingEvents()
         }
     }
@@ -134,7 +134,7 @@ internal class DefaultFeaturedShowsDaoTest : BaseDatabaseTest() {
             val initialShows = awaitItem()
             initialShows.size shouldBe 2
 
-            val showId = seedShow(traktId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
+            val showId = seedShow(showId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
             val newShow = Featured_shows(
                 show_id = showId,
                 tmdb_id = Id<TmdbId>(999),
@@ -147,7 +147,7 @@ internal class DefaultFeaturedShowsDaoTest : BaseDatabaseTest() {
 
             val updatedShows = awaitItem()
             updatedShows.size shouldBe 3
-            updatedShows.any { it.traktId == 999L && it.title == "New Reactive Show" } shouldBe true
+            updatedShows.any { it.showId == 999L && it.title == "New Reactive Show" } shouldBe true
 
             cancelAndConsumeRemainingEvents()
         }
@@ -178,15 +178,15 @@ internal class DefaultFeaturedShowsDaoTest : BaseDatabaseTest() {
 
             val updatedShows = awaitItem()
             updatedShows.size shouldBe 1
-            updatedShows.none { it.traktId == 1L } shouldBe true
+            updatedShows.none { it.showId == 1L } shouldBe true
 
             cancelAndConsumeRemainingEvents()
         }
     }
 
-    private fun seedShow(traktId: Long, name: String, posterPath: String): Id<ShowId> {
+    private fun seedShow(showId: Long, name: String, posterPath: String): Id<ShowId> {
         val _ = database.tvShowQueries.upsert(
-            tmdb_id = Id<TmdbId>(traktId),
+            tmdb_id = Id<TmdbId>(showId),
             name = name,
             overview = "$name overview",
             language = "en",
@@ -200,7 +200,7 @@ internal class DefaultFeaturedShowsDaoTest : BaseDatabaseTest() {
             poster_path = posterPath,
             backdrop_path = "/new_backdrop.jpg",
         )
-        return showIdForTraktId(traktId)
+        return showIdForTraktId(showId)
     }
 
     private fun insertTestShows() {

--- a/data/followedshows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/api/FollowedShowEntry.kt
+++ b/data/followedshows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/api/FollowedShowEntry.kt
@@ -4,7 +4,7 @@ import kotlin.time.Instant
 
 public data class FollowedShowEntry(
     val id: Long = 0,
-    val traktId: Long,
+    val showId: Long,
     val tmdbId: Long? = null,
     val followedAt: Instant,
     val pendingAction: PendingAction = PendingAction.NOTHING,

--- a/data/followedshows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/api/FollowedShowsDao.kt
+++ b/data/followedshows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/api/FollowedShowsDao.kt
@@ -13,5 +13,5 @@ public interface FollowedShowsDao {
     public fun upsert(entry: FollowedShowEntry): Long
     public fun updatePendingAction(id: Long, action: PendingAction)
     public fun deleteById(id: Long)
-    public fun deleteByTraktId(showId: Long)
+    public fun deleteByShowId(showId: Long)
 }

--- a/data/followedshows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/api/FollowedShowsDao.kt
+++ b/data/followedshows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/api/FollowedShowsDao.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 public interface FollowedShowsDao {
     public fun entries(): List<FollowedShowEntry>
     public fun entriesObservable(): Flow<List<FollowedShowEntry>>
-    public fun entryWithTraktId(traktId: Long): FollowedShowEntry?
+    public fun entryWithTraktId(showId: Long): FollowedShowEntry?
     public fun entriesWithNoPendingAction(): List<FollowedShowEntry>
     public fun entriesExcludingDeleted(): List<FollowedShowEntry>
     public fun entriesWithUploadPendingAction(): List<FollowedShowEntry>
@@ -13,5 +13,5 @@ public interface FollowedShowsDao {
     public fun upsert(entry: FollowedShowEntry): Long
     public fun updatePendingAction(id: Long, action: PendingAction)
     public fun deleteById(id: Long)
-    public fun deleteByTraktId(traktId: Long)
+    public fun deleteByTraktId(showId: Long)
 }

--- a/data/followedshows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/api/FollowedShowsRepository.kt
+++ b/data/followedshows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/api/FollowedShowsRepository.kt
@@ -2,6 +2,6 @@ package com.thomaskioko.tvmaniac.followedshows.api
 
 public interface FollowedShowsRepository {
     public suspend fun getFollowedShows(): List<FollowedShowEntry>
-    public suspend fun addFollowedShow(traktId: Long)
-    public suspend fun removeFollowedShow(traktId: Long)
+    public suspend fun addFollowedShow(showId: Long)
+    public suspend fun removeFollowedShow(showId: Long)
 }

--- a/data/followedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/implementation/DefaultFollowedShowsDao.kt
+++ b/data/followedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/implementation/DefaultFollowedShowsDao.kt
@@ -41,9 +41,9 @@ public class DefaultFollowedShowsDao(
             .map { list -> list.map { toEntry(it.followed_id, it.trakt_id, it.tmdb_id?.id, it.followed_at, it.pending_action) } }
     }
 
-    override fun entryWithTraktId(traktId: Long): FollowedShowEntry? {
-        val showId = showIdResolver.showIdForTraktId(traktId) ?: return null
-        return queries.entryWithShowId(showId)
+    override fun entryWithTraktId(showId: Long): FollowedShowEntry? {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return null
+        return queries.entryWithShowId(internalShowId)
             .executeAsOneOrNull()
             ?.let { toEntry(it.followed_id, it.trakt_id, it.tmdb_id?.id, it.followed_at, it.pending_action) }
     }
@@ -73,7 +73,7 @@ public class DefaultFollowedShowsDao(
     }
 
     override fun upsert(entry: FollowedShowEntry): Long {
-        val showId = showIdResolver.showIdForTraktId(entry.traktId) ?: return 0
+        val showId = showIdResolver.showIdForTraktId(entry.showId) ?: return 0
         queries.upsert(
             showId = showId,
             tmdbId = entry.tmdbId?.let { Id(it) },
@@ -91,20 +91,20 @@ public class DefaultFollowedShowsDao(
         val _ = queries.deleteById(id)
     }
 
-    override fun deleteByTraktId(traktId: Long) {
-        val showId = showIdResolver.showIdForTraktId(traktId) ?: return
-        val _ = queries.deleteByShowId(showId)
+    override fun deleteByTraktId(showId: Long) {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return
+        val _ = queries.deleteByShowId(internalShowId)
     }
 
     private fun toEntry(
         followedId: Long,
-        traktId: Long,
+        showId: Long,
         tmdbId: Long?,
         followedAt: Long,
         pendingAction: String,
     ): FollowedShowEntry = FollowedShowEntry(
         id = followedId,
-        traktId = traktId,
+        showId = showId,
         tmdbId = tmdbId,
         followedAt = Instant.fromEpochMilliseconds(followedAt),
         pendingAction = PendingAction.fromValue(pendingAction),

--- a/data/followedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/implementation/DefaultFollowedShowsDao.kt
+++ b/data/followedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/implementation/DefaultFollowedShowsDao.kt
@@ -91,7 +91,7 @@ public class DefaultFollowedShowsDao(
         val _ = queries.deleteById(id)
     }
 
-    override fun deleteByTraktId(showId: Long) {
+    override fun deleteByShowId(showId: Long) {
         val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return
         val _ = queries.deleteByShowId(internalShowId)
     }

--- a/data/followedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/implementation/DefaultFollowedShowsRepository.kt
+++ b/data/followedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/implementation/DefaultFollowedShowsRepository.kt
@@ -26,35 +26,35 @@ public class DefaultFollowedShowsRepository(
     override suspend fun getFollowedShows(): List<FollowedShowEntry> =
         withContext(dispatchers.io) { followedShowsDao.entries() }
 
-    override suspend fun addFollowedShow(traktId: Long) {
+    override suspend fun addFollowedShow(showId: Long) {
         withContext(dispatchers.io) {
             transactionRunner {
-                val existingEntry = followedShowsDao.entryWithTraktId(traktId)
+                val existingEntry = followedShowsDao.entryWithTraktId(showId)
                 if (existingEntry == null || existingEntry.pendingAction == PendingAction.DELETE) {
                     val _ = followedShowsDao.upsert(
                         FollowedShowEntry(
-                            traktId = traktId,
+                            showId = showId,
                             tmdbId = existingEntry?.tmdbId,
                             followedAt = dateTimeProvider.now(),
                             pendingAction = PendingAction.UPLOAD,
                         ),
                     )
-                    logger.debug(TAG, "Marked show $traktId for upload")
+                    logger.debug(TAG, "Marked show $showId for upload")
                 }
             }
         }
     }
 
-    override suspend fun removeFollowedShow(traktId: Long) {
+    override suspend fun removeFollowedShow(showId: Long) {
         withContext(dispatchers.io) {
             transactionRunner {
-                followedShowsDao.entryWithTraktId(traktId)?.also { entry ->
+                followedShowsDao.entryWithTraktId(showId)?.also { entry ->
                     if (entry.pendingAction == PendingAction.UPLOAD) {
                         followedShowsDao.deleteById(entry.id)
-                        logger.debug(TAG, "Deleted local-only show $traktId")
+                        logger.debug(TAG, "Deleted local-only show $showId")
                     } else {
                         val _ = followedShowsDao.upsert(entry.copy(pendingAction = PendingAction.DELETE))
-                        logger.debug(TAG, "Marked show $traktId for deletion")
+                        logger.debug(TAG, "Marked show $showId for deletion")
                     }
                 }
             }

--- a/data/followedshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/followedshows/implementation/DefaultFollowedShowsDaoTest.kt
+++ b/data/followedshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/followedshows/implementation/DefaultFollowedShowsDaoTest.kt
@@ -49,7 +49,7 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `should upsert followed show entry`() {
         val entry = FollowedShowEntry(
-            traktId = 1L,
+            showId = 1L,
             followedAt = Clock.System.now(),
             pendingAction = PendingAction.UPLOAD,
         )
@@ -59,14 +59,14 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
         resultId shouldBe 1L
         val entries = dao.entries()
         entries.size shouldBe 1
-        entries.first().traktId shouldBe 1L
+        entries.first().showId shouldBe 1L
         entries.first().pendingAction shouldBe PendingAction.UPLOAD
     }
 
     @Test
     fun `should update existing entry on upsert`() {
         val entry = FollowedShowEntry(
-            traktId = 1L,
+            showId = 1L,
             followedAt = Clock.System.now(),
             pendingAction = PendingAction.UPLOAD,
         )
@@ -87,14 +87,14 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
     fun `should get all entries`() {
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 1L,
+                showId = 1L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.NOTHING,
             ),
         )
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 2L,
+                showId = 2L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.UPLOAD,
             ),
@@ -103,14 +103,14 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
         val entries = dao.entries()
 
         entries.size shouldBe 2
-        entries.map { it.traktId }.toSet() shouldBe setOf(1L, 2L)
+        entries.map { it.showId }.toSet() shouldBe setOf(1L, 2L)
     }
 
     @Test
     fun `should observe entries`() = runTest {
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 1L,
+                showId = 1L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.NOTHING,
             ),
@@ -119,11 +119,11 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
         dao.entriesObservable().test {
             val entries = awaitItem()
             entries.size shouldBe 1
-            entries.first().traktId shouldBe 1L
+            entries.first().showId shouldBe 1L
 
             val _ = dao.upsert(
                 FollowedShowEntry(
-                    traktId = 2L,
+                    showId = 2L,
                     followedAt = Clock.System.now(),
                     pendingAction = PendingAction.UPLOAD,
                 ),
@@ -140,14 +140,14 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
     fun `should get entry by show id`() {
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 1L,
+                showId = 1L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.UPLOAD,
             ),
         )
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 2L,
+                showId = 2L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.NOTHING,
             ),
@@ -156,7 +156,7 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
         val entry = dao.entryWithTraktId(1L)
 
         entry.shouldNotBeNull()
-        entry.traktId shouldBe 1L
+        entry.showId shouldBe 1L
         entry.pendingAction shouldBe PendingAction.UPLOAD
     }
 
@@ -171,21 +171,21 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
     fun `should get entries with no pending action`() {
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 1L,
+                showId = 1L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.NOTHING,
             ),
         )
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 2L,
+                showId = 2L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.UPLOAD,
             ),
         )
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 3L,
+                showId = 3L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.NOTHING,
             ),
@@ -194,7 +194,7 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
         val entries = dao.entriesWithNoPendingAction()
 
         entries.size shouldBe 2
-        entries.map { it.traktId }.toSet() shouldBe setOf(1L, 3L)
+        entries.map { it.showId }.toSet() shouldBe setOf(1L, 3L)
         entries.all { it.pendingAction == PendingAction.NOTHING } shouldBe true
     }
 
@@ -202,21 +202,21 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
     fun `should get entries with upload pending action`() {
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 1L,
+                showId = 1L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.UPLOAD,
             ),
         )
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 2L,
+                showId = 2L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.NOTHING,
             ),
         )
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 3L,
+                showId = 3L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.UPLOAD,
             ),
@@ -225,7 +225,7 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
         val entries = dao.entriesWithUploadPendingAction()
 
         entries.size shouldBe 2
-        entries.map { it.traktId }.toSet() shouldBe setOf(1L, 3L)
+        entries.map { it.showId }.toSet() shouldBe setOf(1L, 3L)
         entries.all { it.pendingAction == PendingAction.UPLOAD } shouldBe true
     }
 
@@ -233,21 +233,21 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
     fun `should get entries with delete pending action`() {
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 1L,
+                showId = 1L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.DELETE,
             ),
         )
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 2L,
+                showId = 2L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.NOTHING,
             ),
         )
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 3L,
+                showId = 3L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.DELETE,
             ),
@@ -256,7 +256,7 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
         val entries = dao.entriesWithDeletePendingAction()
 
         entries.size shouldBe 2
-        entries.map { it.traktId }.toSet() shouldBe setOf(1L, 3L)
+        entries.map { it.showId }.toSet() shouldBe setOf(1L, 3L)
         entries.all { it.pendingAction == PendingAction.DELETE } shouldBe true
     }
 
@@ -264,7 +264,7 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
     fun `should update pending action`() {
         val id = dao.upsert(
             FollowedShowEntry(
-                traktId = 1L,
+                showId = 1L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.UPLOAD,
             ),
@@ -281,14 +281,14 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
     fun `should delete by id`() {
         val id = dao.upsert(
             FollowedShowEntry(
-                traktId = 1L,
+                showId = 1L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.NOTHING,
             ),
         )
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 2L,
+                showId = 2L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.NOTHING,
             ),
@@ -298,21 +298,21 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
 
         val entries = dao.entries()
         entries.size shouldBe 1
-        entries.first().traktId shouldBe 2L
+        entries.first().showId shouldBe 2L
     }
 
     @Test
     fun `should delete by show id`() {
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 1L,
+                showId = 1L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.NOTHING,
             ),
         )
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 2L,
+                showId = 2L,
                 followedAt = Clock.System.now(),
                 pendingAction = PendingAction.NOTHING,
             ),
@@ -322,7 +322,7 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
 
         val entries = dao.entries()
         entries.size shouldBe 1
-        entries.first().traktId shouldBe 2L
+        entries.first().showId shouldBe 2L
     }
 
     @Test
@@ -330,7 +330,7 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
         val now = dateTimeProvider.now()
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 1L,
+                showId = 1L,
                 followedAt = now,
                 pendingAction = PendingAction.NOTHING,
             ),
@@ -346,7 +346,7 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
     fun `should preserve tmdb id`() {
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 1L,
+                showId = 1L,
                 followedAt = Clock.System.now(),
                 tmdbId = 98765L,
                 pendingAction = PendingAction.NOTHING,

--- a/data/followedshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/followedshows/implementation/DefaultFollowedShowsDaoTest.kt
+++ b/data/followedshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/followedshows/implementation/DefaultFollowedShowsDaoTest.kt
@@ -318,7 +318,7 @@ internal class DefaultFollowedShowsDaoTest : BaseDatabaseTest() {
             ),
         )
 
-        dao.deleteByTraktId(1L)
+        dao.deleteByShowId(1L)
 
         val entries = dao.entries()
         entries.size shouldBe 1

--- a/data/followedshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/followedshows/implementation/DefaultFollowedShowsRepositoryTest.kt
+++ b/data/followedshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/followedshows/implementation/DefaultFollowedShowsRepositoryTest.kt
@@ -85,7 +85,7 @@ internal class DefaultFollowedShowsRepositoryTest : BaseDatabaseTest() {
         val entries = dao.entries()
 
         entries.size shouldBe 1
-        entries.first().traktId shouldBe 1L
+        entries.first().showId shouldBe 1L
         entries.first().pendingAction shouldBe PendingAction.UPLOAD
     }
 
@@ -93,7 +93,7 @@ internal class DefaultFollowedShowsRepositoryTest : BaseDatabaseTest() {
     fun `should re-add show marked for deletion`() = runTest {
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 1L,
+                showId = 1L,
                 followedAt = testInstant,
                 pendingAction = PendingAction.DELETE,
             ),
@@ -109,7 +109,7 @@ internal class DefaultFollowedShowsRepositoryTest : BaseDatabaseTest() {
     fun `should not add show already in watchlist`() = runTest {
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 1L,
+                showId = 1L,
                 followedAt = testInstant,
                 pendingAction = PendingAction.NOTHING,
             ),
@@ -126,7 +126,7 @@ internal class DefaultFollowedShowsRepositoryTest : BaseDatabaseTest() {
     fun `should mark show for deletion given trakt id exists`() = runTest {
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 1L,
+                showId = 1L,
                 followedAt = testInstant,
                 pendingAction = PendingAction.NOTHING,
             ),
@@ -142,7 +142,7 @@ internal class DefaultFollowedShowsRepositoryTest : BaseDatabaseTest() {
     fun `should delete local entry given pending upload`() = runTest {
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 1L,
+                showId = 1L,
                 followedAt = testInstant,
                 pendingAction = PendingAction.UPLOAD,
             ),
@@ -158,14 +158,14 @@ internal class DefaultFollowedShowsRepositoryTest : BaseDatabaseTest() {
     fun `should get followed shows`() = runTest {
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 1L,
+                showId = 1L,
                 followedAt = testInstant,
                 pendingAction = PendingAction.NOTHING,
             ),
         )
         val _ = dao.upsert(
             FollowedShowEntry(
-                traktId = 2L,
+                showId = 2L,
                 followedAt = testInstant,
                 pendingAction = PendingAction.NOTHING,
             ),
@@ -173,6 +173,6 @@ internal class DefaultFollowedShowsRepositoryTest : BaseDatabaseTest() {
 
         val entries = repository.getFollowedShows()
         entries.size shouldBe 2
-        entries.map { it.traktId }.toSet() shouldBe setOf(1L, 2L)
+        entries.map { it.showId }.toSet() shouldBe setOf(1L, 2L)
     }
 }

--- a/data/followedshows/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/testing/FakeFollowedShowsDao.kt
+++ b/data/followedshows/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/testing/FakeFollowedShowsDao.kt
@@ -53,7 +53,7 @@ public class FakeFollowedShowsDao : FollowedShowsDao {
         entriesFlow.value = entriesFlow.value.filter { it.id != id }
     }
 
-    override fun deleteByTraktId(showId: Long) {
+    override fun deleteByShowId(showId: Long) {
         entriesFlow.value = entriesFlow.value.filter { it.showId != showId }
     }
 

--- a/data/followedshows/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/testing/FakeFollowedShowsDao.kt
+++ b/data/followedshows/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/testing/FakeFollowedShowsDao.kt
@@ -15,8 +15,8 @@ public class FakeFollowedShowsDao : FollowedShowsDao {
 
     override fun entriesObservable(): Flow<List<FollowedShowEntry>> = entriesFlow
 
-    override fun entryWithTraktId(traktId: Long): FollowedShowEntry? =
-        entriesFlow.value.find { it.traktId == traktId }
+    override fun entryWithTraktId(showId: Long): FollowedShowEntry? =
+        entriesFlow.value.find { it.showId == showId }
 
     override fun entriesWithNoPendingAction(): List<FollowedShowEntry> =
         entriesFlow.value.filter { it.pendingAction == PendingAction.NOTHING }
@@ -31,12 +31,12 @@ public class FakeFollowedShowsDao : FollowedShowsDao {
         entriesFlow.value.filter { it.pendingAction == PendingAction.DELETE }
 
     override fun upsert(entry: FollowedShowEntry): Long {
-        val existing = entriesFlow.value.find { it.traktId == entry.traktId }
+        val existing = entriesFlow.value.find { it.showId == entry.showId }
         val id = if (entry.id > 0) entry.id else existing?.id ?: nextId++
         val newEntry = entry.copy(id = id)
 
         entriesFlow.value = if (existing != null) {
-            entriesFlow.value.map { if (it.traktId == entry.traktId) newEntry else it }
+            entriesFlow.value.map { if (it.showId == entry.showId) newEntry else it }
         } else {
             entriesFlow.value + newEntry
         }
@@ -53,8 +53,8 @@ public class FakeFollowedShowsDao : FollowedShowsDao {
         entriesFlow.value = entriesFlow.value.filter { it.id != id }
     }
 
-    override fun deleteByTraktId(traktId: Long) {
-        entriesFlow.value = entriesFlow.value.filter { it.traktId != traktId }
+    override fun deleteByTraktId(showId: Long) {
+        entriesFlow.value = entriesFlow.value.filter { it.showId != showId }
     }
 
     public fun clear() {

--- a/data/followedshows/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/testing/FakeFollowedShowsRepository.kt
+++ b/data/followedshows/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/testing/FakeFollowedShowsRepository.kt
@@ -17,19 +17,19 @@ public class FakeFollowedShowsRepository : FollowedShowsRepository {
 
     override suspend fun getFollowedShows(): List<FollowedShowEntry> = entries.value
 
-    override suspend fun addFollowedShow(traktId: Long) {
-        _addedShowIds.add(traktId)
+    override suspend fun addFollowedShow(showId: Long) {
+        _addedShowIds.add(showId)
         val newEntry = FollowedShowEntry(
-            id = traktId,
-            traktId = traktId,
+            id = showId,
+            showId = showId,
             followedAt = Clock.System.now(),
         )
         entries.value += newEntry
     }
 
-    override suspend fun removeFollowedShow(traktId: Long) {
-        _removedShowIds.add(traktId)
-        entries.value = entries.value.filter { it.traktId != traktId }
+    override suspend fun removeFollowedShow(showId: Long) {
+        _removedShowIds.add(showId)
+        entries.value = entries.value.filter { it.showId != showId }
     }
 
     public fun setEntries(newEntries: List<FollowedShowEntry>) {

--- a/data/genre/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/genre/TraktGenreDao.kt
+++ b/data/genre/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/genre/TraktGenreDao.kt
@@ -10,7 +10,7 @@ public interface TraktGenreDao {
     public fun observeGenres(): Flow<List<TraktGenreEntity>>
     public fun getGenreSlugs(): List<String>
     public fun deleteAllGenres()
-    public fun upsertGenreShow(genreSlug: String, traktId: Long, pageOrder: Long, category: String)
+    public fun upsertGenreShow(genreSlug: String, showId: Long, pageOrder: Long, category: String)
     public fun observeShowsByGenreSlug(slug: String): Flow<List<ShowEntity>>
     public fun observeShowsByGenreSlugAndCategory(slug: String, category: String): Flow<List<ShowEntity>>
     public fun observeGenresWithShowsByCategory(category: String): Flow<List<GenreWithShowsEntity>>

--- a/data/genre/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/genre/DefaultTraktGenreDao.kt
+++ b/data/genre/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/genre/DefaultTraktGenreDao.kt
@@ -42,20 +42,20 @@ public class DefaultTraktGenreDao(
         genreQueries.deleteAll()
     }
 
-    override fun upsertGenreShow(genreSlug: String, traktId: Long, pageOrder: Long, category: String) {
-        val showId = showIdResolver.showIdForTraktId(traktId) ?: return
+    override fun upsertGenreShow(genreSlug: String, showId: Long, pageOrder: Long, category: String) {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return
         genreShowsQueries.upsert(
             genre_slug = genreSlug,
-            show_id = showId,
+            show_id = internalShowId,
             page_order = pageOrder,
             category = category,
         )
     }
 
     override fun observeShowsByGenreSlug(slug: String): Flow<List<ShowEntity>> =
-        genreShowsQueries.showsByGenreSlug(slug) { traktId, tmdbId, name, posterPath, overview, status, ratings, year, _ ->
+        genreShowsQueries.showsByGenreSlug(slug) { showId, tmdbId, name, posterPath, overview, status, ratings, year, _ ->
             ShowEntity(
-                traktId = traktId,
+                showId = showId,
                 tmdbId = tmdbId.id,
                 title = name,
                 posterPath = posterPath,
@@ -70,9 +70,9 @@ public class DefaultTraktGenreDao(
             .mapToList(dispatchers.io)
 
     override fun observeShowsByGenreSlugAndCategory(slug: String, category: String): Flow<List<ShowEntity>> =
-        genreShowsQueries.showsByGenreSlugAndCategory(slug, category) { traktId, tmdbId, name, posterPath, overview, status, ratings, year, _ ->
+        genreShowsQueries.showsByGenreSlugAndCategory(slug, category) { showId, tmdbId, name, posterPath, overview, status, ratings, year, _ ->
             ShowEntity(
-                traktId = traktId,
+                showId = showId,
                 tmdbId = tmdbId.id,
                 title = name,
                 posterPath = posterPath,
@@ -87,12 +87,12 @@ public class DefaultTraktGenreDao(
             .mapToList(dispatchers.io)
 
     override fun observeGenresWithShowsByCategory(category: String): Flow<List<GenreWithShowsEntity>> =
-        genreShowsQueries.genresWithShowsByCategory(category) { genreSlug, genreName, traktId, tmdbId, name, posterPath, overview, status, ratings, year, _ ->
+        genreShowsQueries.genresWithShowsByCategory(category) { genreSlug, genreName, showId, tmdbId, name, posterPath, overview, status, ratings, year, _ ->
             GenreShowRow(
                 genreSlug = genreSlug,
                 genreName = genreName,
                 show = ShowEntity(
-                    traktId = traktId,
+                    showId = showId,
                     tmdbId = tmdbId.id,
                     title = name,
                     posterPath = posterPath,

--- a/data/genre/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/genre/GenreShowsStore.kt
+++ b/data/genre/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/genre/GenreShowsStore.kt
@@ -102,7 +102,7 @@ public class GenreShowsStore(
 
                     response.forEach { showWithImages ->
                         val show = showWithImages.traktShow
-                        val traktId = show.ids.trakt
+                        val showId = show.ids.trakt
                         val tmdbId = showWithImages.tmdbId
                         val posterPath = showWithImages.tmdbPosterPath?.let {
                             formatterUtil.formatTmdbPosterPath(it)
@@ -112,12 +112,12 @@ public class GenreShowsStore(
                         }
 
                         tvShowsDao.upsertMerging(
-                            show.toTvshow(traktId, tmdbId, posterPath, backdropPath, dateTimeProvider),
+                            show.toTvshow(showId, tmdbId, posterPath, backdropPath, dateTimeProvider),
                         )
 
                         traktGenreDao.upsertGenreShow(
                             genreSlug = key.genreSlug,
-                            traktId = traktId,
+                            showId = showId,
                             pageOrder = showWithImages.pageOrder.toLong(),
                             category = key.category.name,
                         )
@@ -142,13 +142,13 @@ internal data class GenreShowWithImages(
 )
 
 private fun TraktShowResponse.toTvshow(
-    traktId: Long,
+    showId: Long,
     tmdbId: Long,
     posterPath: String?,
     backdropPath: String?,
     dateTimeProvider: DateTimeProvider,
 ): ShowToPersist = ShowToPersist(
-    traktId = Id(traktId),
+    showId = Id(showId),
     tmdbId = Id(tmdbId),
     name = title,
     overview = overview ?: "",

--- a/data/library/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/model/LibraryItem.kt
+++ b/data/library/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/model/LibraryItem.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.data.library.model
 
 public data class LibraryItem(
-    val traktId: Long,
+    val showId: Long,
     val tmdbId: Long?,
     val title: String,
     val posterPath: String?,

--- a/data/library/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/DefaultLibraryRepository.kt
+++ b/data/library/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/DefaultLibraryRepository.kt
@@ -127,7 +127,7 @@ public class DefaultLibraryRepository(
 
     private fun LibraryShows.toLibraryItem(watchProviders: List<WatchProvider>): LibraryItem =
         LibraryItem(
-            traktId = show_trakt_id,
+            showId = show_trakt_id,
             tmdbId = show_tmdb_id.id,
             title = title,
             posterPath = poster_path,
@@ -189,10 +189,10 @@ public class DefaultLibraryRepository(
         val pendingUploads = followedShowsDao.entriesWithUploadPendingAction()
         if (pendingUploads.isEmpty()) return PendingActionOutcome.CONTINUE
 
-        val traktIds = pendingUploads.map { it.traktId }
-        logger.debug(TAG, "Processing ${traktIds.size} pending uploads")
+        val showIds = pendingUploads.map { it.showId }
+        logger.debug(TAG, "Processing ${showIds.size} pending uploads")
 
-        return when (val response = traktListDataSource.addShowsToWatchListByTraktIds(traktIds)) {
+        return when (val response = traktListDataSource.addShowsToWatchListByTraktIds(showIds)) {
             is ApiResponse.Success -> {
                 val notFoundCount = response.body.notFound.shows.size
                 transactionRunner {
@@ -206,7 +206,7 @@ public class DefaultLibraryRepository(
                 PendingActionOutcome.CONTINUE
             }
             is ApiResponse.Unauthenticated -> PendingActionOutcome.BACK_OFF
-            is ApiResponse.Error -> handleBatchError(action = "upload", traktIds = traktIds, error = response)
+            is ApiResponse.Error -> handleBatchError(action = "upload", showIds = showIds, error = response)
         }
     }
 
@@ -214,10 +214,10 @@ public class DefaultLibraryRepository(
         val pendingDeletes = followedShowsDao.entriesWithDeletePendingAction()
         if (pendingDeletes.isEmpty()) return PendingActionOutcome.CONTINUE
 
-        val traktIds = pendingDeletes.map { it.traktId }
-        logger.debug(TAG, "Processing ${traktIds.size} pending deletes")
+        val showIds = pendingDeletes.map { it.showId }
+        logger.debug(TAG, "Processing ${showIds.size} pending deletes")
 
-        return when (val response = traktListDataSource.removeShowsFromWatchListByTraktIds(traktIds)) {
+        return when (val response = traktListDataSource.removeShowsFromWatchListByTraktIds(showIds)) {
             is ApiResponse.Success -> {
                 val notFoundCount = response.body.notFound.shows.size
                 transactionRunner {
@@ -231,19 +231,19 @@ public class DefaultLibraryRepository(
                 PendingActionOutcome.CONTINUE
             }
             is ApiResponse.Unauthenticated -> PendingActionOutcome.BACK_OFF
-            is ApiResponse.Error -> handleBatchError(action = "delete", traktIds = traktIds, error = response)
+            is ApiResponse.Error -> handleBatchError(action = "delete", showIds = showIds, error = response)
         }
     }
 
     private fun handleBatchError(
         action: String,
-        traktIds: List<Long>,
+        showIds: List<Long>,
         error: ApiResponse.Error<*>,
     ): PendingActionOutcome {
         val message = error.toErrorMessage()
         return when (val syncError = error.toSyncError()) {
             is SyncError.Retryable -> {
-                logger.error(TAG, "Backing off $action for ${traktIds.size} shows: $message ($syncError)")
+                logger.error(TAG, "Backing off $action for ${showIds.size} shows: $message ($syncError)")
                 syncObserver.log(
                     SyncStateError.BackgroundSyncFailed(
                         operationId = "$TAG:$action",
@@ -253,7 +253,7 @@ public class DefaultLibraryRepository(
                 PendingActionOutcome.BACK_OFF
             }
             is SyncError.Permanent -> {
-                logger.error(TAG, "$action permanently failed for ${traktIds.size} shows: $message ($syncError)")
+                logger.error(TAG, "$action permanently failed for ${showIds.size} shows: $message ($syncError)")
                 if (syncError is SyncError.Permanent.AccountLimitExceeded) {
                     syncObserver.log(
                         SyncStateError.AccountLimitExceeded(
@@ -272,7 +272,7 @@ public class DefaultLibraryRepository(
                 PendingActionOutcome.BACK_OFF
             }
             is SyncError.Unknown -> {
-                logger.error(TAG, "$action failed for ${traktIds.size} shows: $message")
+                logger.error(TAG, "$action failed for ${showIds.size} shows: $message")
                 PendingActionOutcome.CONTINUE
             }
         }

--- a/data/library/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/DefaultLibraryRepository.kt
+++ b/data/library/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/DefaultLibraryRepository.kt
@@ -192,7 +192,7 @@ public class DefaultLibraryRepository(
         val showIds = pendingUploads.map { it.showId }
         logger.debug(TAG, "Processing ${showIds.size} pending uploads")
 
-        return when (val response = traktListDataSource.addShowsToWatchListByTraktIds(showIds)) {
+        return when (val response = traktListDataSource.addShowsToWatchListByIds(showIds)) {
             is ApiResponse.Success -> {
                 val notFoundCount = response.body.notFound.shows.size
                 transactionRunner {
@@ -217,7 +217,7 @@ public class DefaultLibraryRepository(
         val showIds = pendingDeletes.map { it.showId }
         logger.debug(TAG, "Processing ${showIds.size} pending deletes")
 
-        return when (val response = traktListDataSource.removeShowsFromWatchListByTraktIds(showIds)) {
+        return when (val response = traktListDataSource.removeShowsFromWatchListByIds(showIds)) {
             is ApiResponse.Success -> {
                 val notFoundCount = response.body.notFound.shows.size
                 transactionRunner {

--- a/data/library/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/LibraryStore.kt
+++ b/data/library/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/LibraryStore.kt
@@ -94,7 +94,7 @@ public class LibraryStore(
                 }
 
                 currentEntries.forEach { localEntry ->
-                    if (localEntry.traktId !in networkTraktIds) {
+                    if (localEntry.showId !in networkTraktIds) {
                         followedShowsDao.deleteById(localEntry.id)
                     }
                 }
@@ -134,14 +134,14 @@ private data class FollowedShowWithImages(
 )
 
 private fun TraktFollowedShowResponse.toFollowedShowEntry(): FollowedShowEntry = FollowedShowEntry(
-    traktId = show.ids.trakt,
+    showId = show.ids.trakt,
     tmdbId = show.ids.tmdb,
     followedAt = Instant.parse(listedAt),
     pendingAction = PendingAction.NOTHING,
 )
 
 private fun TraktFollowedShowResponse.toTvshow(posterPath: String?, backdropPath: String?): ShowToPersist = ShowToPersist(
-    traktId = Id(show.ids.trakt),
+    showId = Id(show.ids.trakt),
     tmdbId = Id(show.ids.tmdb),
     name = show.title,
     overview = "",

--- a/data/popularshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/popularshows/implementation/DefaultPopularShowsDao.kt
+++ b/data/popularshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/popularshows/implementation/DefaultPopularShowsDao.kt
@@ -41,9 +41,9 @@ public class DefaultPopularShowsDao(
 
     override fun observePopularShows(page: Long): Flow<List<ShowEntity>> =
         popularShowsQueries
-            .entriesInPage(Id(page)) { traktId, tmdbId, pageId, name, posterPath, overview, inLibrary ->
+            .entriesInPage(Id(page)) { showId, tmdbId, pageId, name, posterPath, overview, inLibrary ->
                 ShowEntity(
-                    traktId = traktId,
+                    showId = showId,
                     tmdbId = tmdbId.id,
                     page = pageId.id,
                     title = name,
@@ -64,9 +64,9 @@ public class DefaultPopularShowsDao(
                 popularShowsQueries.pagedPopularShows(
                     limit = limit,
                     offset = offset,
-                ) { traktId, tmdbId, page, title, imageUrl, inLib ->
+                ) { showId, tmdbId, page, title, imageUrl, inLib ->
                     ShowEntity(
-                        traktId = traktId,
+                        showId = showId,
                         tmdbId = tmdbId.id,
                         page = page.id,
                         title = title,

--- a/data/popularshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/popularshows/implementation/PopularShowsStore.kt
+++ b/data/popularshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/popularshows/implementation/PopularShowsStore.kt
@@ -89,7 +89,7 @@ public class PopularShowsStore(
 
                     response.forEach { showWithImages ->
                         val show = showWithImages.traktShow
-                        val traktId = show.ids.trakt
+                        val showId = show.ids.trakt
                         val tmdbId = showWithImages.tmdbId
                         val posterPath = showWithImages.tmdbPosterPath?.let {
                             formatterUtil.formatTmdbPosterPath(it)
@@ -98,13 +98,13 @@ public class PopularShowsStore(
                             formatterUtil.formatTmdbPosterPath(it)
                         }
 
-                        tvShowsDao.upsertMerging(show.toTvshow(traktId, tmdbId, posterPath, backdropPath, dateTimeProvider))
+                        tvShowsDao.upsertMerging(show.toTvshow(showId, tmdbId, posterPath, backdropPath, dateTimeProvider))
 
-                        val showId = showIdResolver.showIdForTraktId(traktId) ?: return@forEach
+                        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@forEach
 
                         popularShowsDao.upsert(
                             Popular_shows(
-                                show_id = showId,
+                                show_id = internalShowId,
                                 tmdb_id = Id(tmdbId),
                                 page = Id(page),
                                 name = show.title,
@@ -143,13 +143,13 @@ private data class PopularShowWithImages(
 )
 
 private fun TraktShowResponse.toTvshow(
-    traktId: Long,
+    showId: Long,
     tmdbId: Long,
     posterPath: String?,
     backdropPath: String?,
     dateTimeProvider: DateTimeProvider,
 ): ShowToPersist = ShowToPersist(
-    traktId = Id(traktId),
+    showId = Id(showId),
     tmdbId = Id(tmdbId),
     name = title,
     overview = overview ?: "",

--- a/data/popularshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/popularshows/implementation/DefaultPopularShowsDaoTest.kt
+++ b/data/popularshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/popularshows/implementation/DefaultPopularShowsDaoTest.kt
@@ -56,7 +56,7 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `should insert popular shows`() = runTest {
         // Given - first insert a show into tvshow table
-        val showId = seedShow(traktId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
+        val showId = seedShow(showId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
 
         val popularShow = Popular_shows(
             show_id = showId,
@@ -79,7 +79,7 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
         dao.observePopularShows(page = 1).test {
             val shows = awaitItem()
             shows.size shouldBe 3
-            shows.any { it.traktId == 999L } shouldBe true
+            shows.any { it.showId == 999L } shouldBe true
             cancelAndConsumeRemainingEvents()
         }
     }
@@ -104,7 +104,7 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
         dao.observePopularShows(page = 2).test {
             val shows = awaitItem()
             shows.size shouldBe 1 // Still returns all shows
-            val updatedShow = shows.find { it.traktId == 1L }
+            val updatedShow = shows.find { it.showId == 1L }
             updatedShow?.page shouldBe 2L
             cancelAndConsumeRemainingEvents()
         }
@@ -138,7 +138,7 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
         dao.observePopularShows(page = 3).test {
             val shows = awaitItem()
             shows.size shouldBe 1
-            val updatedShow = shows.find { it.traktId == 1L }
+            val updatedShow = shows.find { it.showId == 1L }
             updatedShow?.page shouldBe 3L
             cancelAndConsumeRemainingEvents()
         }
@@ -205,13 +205,13 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
             shows.size shouldBe 2
 
             // Verify show data is correctly returned from stable query
-            val show1 = shows.find { it.traktId == 1L }
+            val show1 = shows.find { it.showId == 1L }
             show1?.title shouldBe "Test Show 1"
             show1?.posterPath shouldBe "/test1.jpg"
             show1?.overview shouldBe "Test overview 1"
             show1?.inLibrary shouldBe false // Always false from stable query
 
-            val show2 = shows.find { it.traktId == 2L }
+            val show2 = shows.find { it.showId == 2L }
             show2?.title shouldBe "Test Show 2"
             show2?.posterPath shouldBe "/test2.jpg"
             show2?.overview shouldBe "Test overview 2"
@@ -224,7 +224,7 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `stable query should not return shows with null names`() = runTest {
         // Given - insert a show without name (simulating pre-migration data)
-        val showId = seedShow(traktId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
+        val showId = seedShow(showId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
         val _ = popularShowsQueries.insert(
             showId = showId,
             tmdbId = Id<TmdbId>(999),
@@ -240,7 +240,7 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
             val shows = awaitItem()
             // Should only return shows with non-null names (the 2 from setup)
             shows.size shouldBe 2
-            shows.none { it.traktId == 999L } shouldBe true
+            shows.none { it.showId == 999L } shouldBe true
             cancelAndConsumeRemainingEvents()
         }
     }
@@ -248,7 +248,7 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `stable query should filter by page correctly`() = runTest {
         // Given - add shows to different pages
-        val showId = seedShow(traktId = 999, name = "Page 2 Show", posterPath = "/page2.jpg")
+        val showId = seedShow(showId = 999, name = "Page 2 Show", posterPath = "/page2.jpg")
         val _ = popularShowsQueries.insert(
             showId = showId,
             tmdbId = Id<TmdbId>(999),
@@ -298,7 +298,7 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
             initialShows.size shouldBe 2
 
             // When - add a new show
-            val showId = seedShow(traktId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
+            val showId = seedShow(showId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
             val newShow = Popular_shows(
                 show_id = showId,
                 tmdb_id = Id<TmdbId>(999),
@@ -313,7 +313,7 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
             // Then - should emit updated list
             val updatedShows = awaitItem()
             updatedShows.size shouldBe 3
-            updatedShows.any { it.traktId == 999L && it.title == "New Reactive Show" } shouldBe true
+            updatedShows.any { it.showId == 999L && it.title == "New Reactive Show" } shouldBe true
 
             cancelAndConsumeRemainingEvents()
         }
@@ -321,7 +321,7 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `should handle COALESCE for empty names correctly`() = runTest {
-        val showId = seedShow(traktId = 888, name = "Empty Name Show", posterPath = "/empty.jpg")
+        val showId = seedShow(showId = 888, name = "Empty Name Show", posterPath = "/empty.jpg")
         database.popularShowsQueries.transaction {
             val _ = database.popularShowsQueries.insert(
                 showId = showId,
@@ -336,15 +336,15 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
 
         dao.observePopularShows(page = 1).test {
             val shows = awaitItem()
-            val emptyNameShow = shows.find { it.traktId == 888L }
+            val emptyNameShow = shows.find { it.showId == 888L }
             emptyNameShow?.title shouldBe "" // COALESCE should return empty string
             cancelAndConsumeRemainingEvents()
         }
     }
 
-    private fun seedShow(traktId: Long, name: String, posterPath: String): Id<ShowId> {
+    private fun seedShow(showId: Long, name: String, posterPath: String): Id<ShowId> {
         val _ = database.tvShowQueries.upsert(
-            tmdb_id = Id<TmdbId>(traktId),
+            tmdb_id = Id<TmdbId>(showId),
             name = name,
             overview = "$name overview",
             language = "en",
@@ -358,7 +358,7 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
             poster_path = posterPath,
             backdrop_path = "/new_backdrop.jpg",
         )
-        return showIdForTraktId(traktId)
+        return showIdForTraktId(showId)
     }
 
     private fun insertTestShows() {

--- a/data/recommendedshows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/recommendedshows/api/RecommendedShowsDao.kt
+++ b/data/recommendedshows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/recommendedshows/api/RecommendedShowsDao.kt
@@ -4,9 +4,9 @@ import com.thomaskioko.tvmaniac.db.RecommendedShows
 import kotlinx.coroutines.flow.Flow
 
 public interface RecommendedShowsDao {
-    public fun upsert(showTraktId: Long, showTmdbId: Long, recommendedShowTraktId: Long)
+    public fun upsert(showId: Long, showTmdbId: Long, recommendedShowTraktId: Long)
 
-    public fun observeRecommendedShows(showTraktId: Long): Flow<List<RecommendedShows>>
+    public fun observeRecommendedShows(showId: Long): Flow<List<RecommendedShows>>
 
     public fun delete(id: Long)
 

--- a/data/recommendedshows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/recommendedshows/api/RecommendedShowsParams.kt
+++ b/data/recommendedshows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/recommendedshows/api/RecommendedShowsParams.kt
@@ -2,5 +2,5 @@ package com.thomaskioko.tvmaniac.data.recommendedshows.api
 
 public data class RecommendedShowsParams(
     val page: Long,
-    val traktId: Long,
+    val showId: Long,
 )

--- a/data/recommendedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/recommendedshows/implementation/DefaultRecommendedShowsDao.kt
+++ b/data/recommendedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/recommendedshows/implementation/DefaultRecommendedShowsDao.kt
@@ -20,20 +20,20 @@ public class DefaultRecommendedShowsDao(
     private val showIdResolver: ShowIdResolver,
     private val dispatchers: AppCoroutineDispatchers,
 ) : RecommendedShowsDao {
-    override fun upsert(showTraktId: Long, showTmdbId: Long, recommendedShowTraktId: Long) {
-        val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return
+    override fun upsert(showId: Long, showTmdbId: Long, recommendedShowTraktId: Long) {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return
         database.recommendedShowsQueries.transaction {
             database.recommendedShowsQueries.upsert(
-                show_id = showId,
+                show_id = internalShowId,
                 tmdb_id = Id(showTmdbId),
                 recommended_show_trakt_id = Id(recommendedShowTraktId),
             )
         }
     }
 
-    override fun observeRecommendedShows(showTraktId: Long): Flow<List<RecommendedShows>> {
+    override fun observeRecommendedShows(showId: Long): Flow<List<RecommendedShows>> {
         return database.recommendedShowsQueries
-            .recommendedShows(Id(showTraktId))
+            .recommendedShows(Id(showId))
             .asFlow()
             .mapToList(dispatchers.io)
     }

--- a/data/recommendedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/recommendedshows/implementation/DefaultRecommendedShowsRepository.kt
+++ b/data/recommendedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/recommendedshows/implementation/DefaultRecommendedShowsRepository.kt
@@ -25,7 +25,7 @@ public class DefaultRecommendedShowsRepository(
         id: Long,
         forceRefresh: Boolean,
     ) {
-        val key = RecommendedShowsParams(traktId = id, page = DEFAULT_API_PAGE)
+        val key = RecommendedShowsParams(showId = id, page = DEFAULT_API_PAGE)
 
         when {
             forceRefresh -> store.fresh(key)

--- a/data/recommendedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/recommendedshows/implementation/RecommendedShowsStore.kt
+++ b/data/recommendedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/recommendedshows/implementation/RecommendedShowsStore.kt
@@ -46,7 +46,7 @@ public class RecommendedShowsStore(
     fetcher = Fetcher.of { param: RecommendedShowsParams ->
         coroutineScope {
             traktRemoteDataSource.getRelatedShows(
-                traktId = param.traktId,
+                traktId = param.showId,
                 page = param.page.toInt(),
             ).getOrThrow()
                 .mapNotNull { show ->
@@ -68,31 +68,31 @@ public class RecommendedShowsStore(
         }
     },
     sourceOfTruth = SourceOfTruth.of<RecommendedShowsParams, List<RecommendedShowResult>, List<RecommendedShows>>(
-        reader = { param: RecommendedShowsParams -> recommendedShowsDao.observeRecommendedShows(param.traktId) },
+        reader = { param: RecommendedShowsParams -> recommendedShowsDao.observeRecommendedShows(param.showId) },
         writer = { param: RecommendedShowsParams, response ->
             withContext(dispatchers.databaseWrite) {
                 databaseTransactionRunner {
                     response.forEachIndexed { _, result ->
-                        val traktId = result.traktShow.ids.trakt
+                        val showId = result.traktShow.ids.trakt
                         val tmdbId = result.tmdbId
 
-                        tvShowsDao.upsertMerging(result.toTvshow(traktId, tmdbId, formatterUtil, dateTimeProvider))
+                        tvShowsDao.upsertMerging(result.toTvshow(showId, tmdbId, formatterUtil, dateTimeProvider))
 
                         recommendedShowsDao.upsert(
-                            showTraktId = traktId,
+                            showId = showId,
                             showTmdbId = tmdbId,
-                            recommendedShowTraktId = param.traktId,
+                            recommendedShowTraktId = param.showId,
                         )
                     }
                 }
 
                 requestManagerRepository.upsert(
-                    entityId = param.traktId,
+                    entityId = param.showId,
                     requestType = RECOMMENDED_SHOWS.name,
                 )
             }
         },
-        delete = { param -> recommendedShowsDao.delete(param.traktId) },
+        delete = { param -> recommendedShowsDao.delete(param.showId) },
         deleteAll = recommendedShowsDao::deleteAll,
     ).usingDispatchers(
         readDispatcher = dispatchers.databaseRead,
@@ -101,9 +101,9 @@ public class RecommendedShowsStore(
 ).validator(
     Validator.by { cachedData ->
         withContext(dispatchers.io) {
-            val showTraktId = cachedData.firstOrNull()?.show_trakt_id ?: return@withContext false
+            val showId = cachedData.firstOrNull()?.show_trakt_id ?: return@withContext false
             !requestManagerRepository.isRequestExpired(
-                entityId = showTraktId,
+                entityId = showId,
                 requestType = RECOMMENDED_SHOWS.name,
                 threshold = RECOMMENDED_SHOWS.duration,
             )
@@ -112,7 +112,7 @@ public class RecommendedShowsStore(
 ).build()
 
 private fun RecommendedShowResult.toTvshow(
-    traktId: Long,
+    showId: Long,
     tmdbId: Long,
     formatterUtil: FormatterUtil,
     dateTimeProvider: DateTimeProvider,
@@ -121,7 +121,7 @@ private fun RecommendedShowResult.toTvshow(
     val trakt = traktShow
     val dateString = tmdb?.firstAirDate ?: trakt.firstAirDate
     return ShowToPersist(
-        traktId = Id(traktId),
+        showId = Id(showId),
         tmdbId = Id(tmdbId),
         name = tmdb?.name ?: trakt.title,
         overview = tmdb?.overview ?: trakt.overview ?: "",

--- a/data/recommendedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/recommendedshows/implementation/RecommendedShowsStore.kt
+++ b/data/recommendedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/recommendedshows/implementation/RecommendedShowsStore.kt
@@ -46,7 +46,7 @@ public class RecommendedShowsStore(
     fetcher = Fetcher.of { param: RecommendedShowsParams ->
         coroutineScope {
             traktRemoteDataSource.getRelatedShows(
-                traktId = param.showId,
+                showId = param.showId,
                 page = param.page.toInt(),
             ).getOrThrow()
                 .mapNotNull { show ->

--- a/data/search/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/search/implementation/SearchShowStore.kt
+++ b/data/search/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/search/implementation/SearchShowStore.kt
@@ -71,7 +71,7 @@ public class SearchShowStore(
 private fun SearchShowResult.toTvshow(formatterUtil: FormatterUtil, dateTimeProvider: DateTimeProvider): ShowToPersist {
     val tmdb = tmdbDetails
     return ShowToPersist(
-        traktId = Id(traktShow.ids.trakt),
+        showId = Id(traktShow.ids.trakt),
         tmdbId = Id(tmdbId),
         name = traktShow.title,
         overview = traktShow.overview ?: "",

--- a/data/seasondetails/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/api/SeasonDetailsDao.kt
+++ b/data/seasondetails/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/api/SeasonDetailsDao.kt
@@ -7,13 +7,13 @@ import com.thomaskioko.tvmaniac.db.SeasonImages
 import kotlinx.coroutines.flow.Flow
 
 public interface SeasonDetailsDao {
-    public fun observeSeasonDetails(showTraktId: Long, seasonNumber: Long): Flow<List<SeasonDetails>>
+    public fun observeSeasonDetails(showId: Long, seasonNumber: Long): Flow<List<SeasonDetails>>
 
-    public fun observeSeasonWithShowInfo(showTraktId: Long, seasonNumber: Long): Flow<GetSeasonWithShowInfo?>
+    public fun observeSeasonWithShowInfo(showId: Long, seasonNumber: Long): Flow<GetSeasonWithShowInfo?>
 
     public fun observeEpisodesBySeasonId(seasonId: Long): Flow<List<EpisodesBySeasonId>>
 
-    public fun delete(showTraktId: Long)
+    public fun delete(showId: Long)
 
     public fun deleteAll()
 

--- a/data/seasondetails/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/api/SeasonDetailsParam.kt
+++ b/data/seasondetails/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/api/SeasonDetailsParam.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.seasondetails.api
 
 public data class SeasonDetailsParam(
-    val showTraktId: Long,
+    val showId: Long,
     val seasonId: Long,
     val seasonNumber: Long,
 )

--- a/data/seasondetails/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/api/SeasonDetailsRepository.kt
+++ b/data/seasondetails/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/api/SeasonDetailsRepository.kt
@@ -12,12 +12,12 @@ public interface SeasonDetailsRepository {
     )
 
     public suspend fun syncShowSeasonDetails(
-        showTraktId: Long,
+        showId: Long,
         forceRefresh: Boolean = false,
     )
 
     public suspend fun syncPreviousSeasonsEpisodes(
-        showTraktId: Long,
+        showId: Long,
         beforeSeasonNumber: Long,
         forceRefresh: Boolean = false,
     )
@@ -28,5 +28,5 @@ public interface SeasonDetailsRepository {
 
     public fun observeSeasonImages(id: Long): Flow<List<SeasonImages>>
 
-    public fun observeContinueTrackingEpisodes(showTraktId: Long): Flow<ContinueTrackingResult?>
+    public fun observeContinueTrackingEpisodes(showId: Long): Flow<ContinueTrackingResult?>
 }

--- a/data/seasondetails/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/api/model/SeasonDetailsWithEpisodes.kt
+++ b/data/seasondetails/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/api/model/SeasonDetailsWithEpisodes.kt
@@ -2,7 +2,7 @@ package com.thomaskioko.tvmaniac.seasondetails.api.model
 
 public data class SeasonDetailsWithEpisodes(
     val seasonId: Long,
-    val showTraktId: Long,
+    val showId: Long,
     val showTmdbId: Long,
     val name: String,
     val showTitle: String,

--- a/data/seasondetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/implementation/DefaultSeasonDetailsDao.kt
+++ b/data/seasondetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/implementation/DefaultSeasonDetailsDao.kt
@@ -33,21 +33,21 @@ public class DefaultSeasonDetailsDao(
         get() = database.episodesQueries
 
     override fun observeSeasonDetails(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
     ): Flow<List<SeasonDetails>> {
-        val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return flowOf(emptyList())
-        return seasonQueries.seasonDetails(showId = showId, seasonNumber = seasonNumber)
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return flowOf(emptyList())
+        return seasonQueries.seasonDetails(showId = internalShowId, seasonNumber = seasonNumber)
             .asFlow()
             .mapToList(dispatcher.io)
     }
 
     override fun observeSeasonWithShowInfo(
-        showTraktId: Long,
+        showId: Long,
         seasonNumber: Long,
     ): Flow<GetSeasonWithShowInfo?> {
-        val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return flowOf(null)
-        return seasonQueries.getSeasonWithShowInfo(showId = showId, seasonNumber = seasonNumber)
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return flowOf(null)
+        return seasonQueries.getSeasonWithShowInfo(showId = internalShowId, seasonNumber = seasonNumber)
             .asFlow()
             .mapToOneOrNull(dispatcher.io)
     }
@@ -57,9 +57,9 @@ public class DefaultSeasonDetailsDao(
             .asFlow()
             .mapToList(dispatcher.io)
 
-    override fun delete(showTraktId: Long) {
-        val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return
-        seasonQueries.delete(showId)
+    override fun delete(showId: Long) {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return
+        seasonQueries.delete(internalShowId)
     }
 
     override fun deleteAll() {

--- a/data/seasondetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/implementation/DefaultSeasonDetailsRepository.kt
+++ b/data/seasondetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/implementation/DefaultSeasonDetailsRepository.kt
@@ -59,11 +59,11 @@ public class DefaultSeasonDetailsRepository(
     }
 
     override suspend fun syncShowSeasonDetails(
-        showTraktId: Long,
+        showId: Long,
         forceRefresh: Boolean,
     ) {
         val isCacheValid = !requestManagerRepository.isRequestExpired(
-            entityId = showTraktId,
+            entityId = showId,
             requestType = RequestTypeConfig.SHOW_SEASON_DETAILS_SYNC.name,
             threshold = RequestTypeConfig.SHOW_SEASON_DETAILS_SYNC.duration,
         )
@@ -73,14 +73,14 @@ public class DefaultSeasonDetailsRepository(
         }
 
         val includeSpecials = datastoreRepository.getIncludeSpecials()
-        val seasons = seasonsRepository.getSeasonsByShowId(showTraktId, includeSpecials)
+        val seasons = seasonsRepository.getSeasonsByShowId(showId, includeSpecials)
 
         if (seasons.isEmpty()) return
 
         seasons.forEach { season ->
             fetchSeasonDetails(
                 param = SeasonDetailsParam(
-                    showTraktId = showTraktId,
+                    showId = showId,
                     seasonId = season.season_id.id,
                     seasonNumber = season.season_number,
                 ),
@@ -89,23 +89,23 @@ public class DefaultSeasonDetailsRepository(
         }
 
         requestManagerRepository.upsert(
-            entityId = showTraktId,
+            entityId = showId,
             requestType = RequestTypeConfig.SHOW_SEASON_DETAILS_SYNC.name,
         )
     }
 
     override suspend fun syncPreviousSeasonsEpisodes(
-        showTraktId: Long,
+        showId: Long,
         beforeSeasonNumber: Long,
         forceRefresh: Boolean,
     ) {
-        val seasons = seasonsRepository.getSeasonsByShowId(showTraktId)
+        val seasons = seasonsRepository.getSeasonsByShowId(showId)
         val previousSeasons = seasons.filter { it.season_number in 1..<beforeSeasonNumber }
         previousSeasons.forEach { season ->
             currentCoroutineContext().ensureActive()
             fetchSeasonDetails(
                 SeasonDetailsParam(
-                    showTraktId = showTraktId,
+                    showId = showId,
                     seasonId = season.season_id.id,
                     seasonNumber = season.season_number,
                 ),
@@ -118,7 +118,7 @@ public class DefaultSeasonDetailsRepository(
     override fun observeSeasonDetails(
         param: SeasonDetailsParam,
     ): Flow<SeasonDetailsWithEpisodes> =
-        dao.observeSeasonWithShowInfo(param.showTraktId, param.seasonNumber)
+        dao.observeSeasonWithShowInfo(param.showId, param.seasonNumber)
             .filterNotNull()
             .flatMapLatest { season ->
                 dao.observeEpisodesBySeasonId(season.season_id.id)
@@ -129,17 +129,17 @@ public class DefaultSeasonDetailsRepository(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun observeContinueTrackingEpisodes(
-        showTraktId: Long,
+        showId: Long,
     ): Flow<ContinueTrackingResult?> =
         datastoreRepository.observeIncludeSpecials()
             .flatMapLatest { includeSpecials ->
-                episodesDao.observeNextEpisodeForShow(showTraktId, includeSpecials)
+                episodesDao.observeNextEpisodeForShow(showId, includeSpecials)
             }
             .flatMapLatest { nextEpisode ->
                 if (nextEpisode == null) return@flatMapLatest flowOf(null)
 
                 val param = SeasonDetailsParam(
-                    showTraktId = showTraktId,
+                    showId = showId,
                     seasonId = nextEpisode.season_id.id,
                     seasonNumber = nextEpisode.season_number,
                 )
@@ -164,7 +164,7 @@ public class DefaultSeasonDetailsRepository(
             name = season.season_title,
             seasonNumber = season.season_number,
             seasonOverview = season.season_overview,
-            showTraktId = season.show_trakt_id,
+            showId = season.show_trakt_id,
             showTmdbId = season.show_tmdb_id.id,
             showTitle = season.show_title,
             imageUrl = season.season_image_url,

--- a/data/seasondetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/implementation/SeasonDetailsStore.kt
+++ b/data/seasondetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/implementation/SeasonDetailsStore.kt
@@ -50,7 +50,7 @@ public class SeasonDetailsStore(
 ) : Store<SeasonDetailsParam, List<SeasonDetails>> by storeBuilder(
     fetcher = Fetcher.of { params: SeasonDetailsParam ->
         coroutineScope {
-            val showTmdbId = tvShowsDao.getTmdbIdByTraktId(params.showId)
+            val showTmdbId = tvShowsDao.getTmdbIdByShowId(params.showId)
 
             val traktSeason = async {
                 traktRemoteDataSource.getShowSeasonEpisodes(params.showId, params.seasonNumber.toInt()).getOrThrow()

--- a/data/seasondetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/implementation/SeasonDetailsStore.kt
+++ b/data/seasondetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/implementation/SeasonDetailsStore.kt
@@ -50,10 +50,10 @@ public class SeasonDetailsStore(
 ) : Store<SeasonDetailsParam, List<SeasonDetails>> by storeBuilder(
     fetcher = Fetcher.of { params: SeasonDetailsParam ->
         coroutineScope {
-            val showTmdbId = tvShowsDao.getTmdbIdByTraktId(params.showTraktId)
+            val showTmdbId = tvShowsDao.getTmdbIdByTraktId(params.showId)
 
             val traktSeason = async {
-                traktRemoteDataSource.getShowSeasonEpisodes(params.showTraktId, params.seasonNumber.toInt()).getOrThrow()
+                traktRemoteDataSource.getShowSeasonEpisodes(params.showId, params.seasonNumber.toInt()).getOrThrow()
             }.await()
             val tmdbSeason = async {
                 showTmdbId?.let {
@@ -72,13 +72,13 @@ public class SeasonDetailsStore(
     sourceOfTruth = SourceOfTruth.of<SeasonDetailsParam, SeasonDetailsResponse, List<SeasonDetails>>(
         reader = { params: SeasonDetailsParam ->
             seasonDetailsDao.observeSeasonDetails(
-                params.showTraktId,
+                params.showId,
                 params.seasonNumber,
             )
         },
         writer = { params: SeasonDetailsParam, response ->
             databaseTransactionRunner {
-                val showId = showIdResolver.showIdForTraktId(params.showTraktId)
+                val showId = showIdResolver.showIdForTraktId(params.showId)
                     ?: return@databaseTransactionRunner
 
                 val tmdbEpisodeImages = response.tmdbEpisodes.associate {

--- a/data/seasondetails/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/testing/FakeSeasonDetailsRepository.kt
+++ b/data/seasondetails/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/testing/FakeSeasonDetailsRepository.kt
@@ -15,7 +15,7 @@ public class FakeSeasonDetailsRepository : SeasonDetailsRepository {
     private val seasonsResult = MutableStateFlow(
         SeasonDetailsWithEpisodes(
             seasonId = 0,
-            showTraktId = 0,
+            showId = 0,
             showTmdbId = 0,
             name = "",
             showTitle = "",
@@ -66,14 +66,14 @@ public class FakeSeasonDetailsRepository : SeasonDetailsRepository {
     }
 
     override suspend fun syncShowSeasonDetails(
-        showTraktId: Long,
+        showId: Long,
         forceRefresh: Boolean,
     ) {
-        syncedShowIds.add(showTraktId)
+        syncedShowIds.add(showId)
     }
 
     override suspend fun syncPreviousSeasonsEpisodes(
-        showTraktId: Long,
+        showId: Long,
         beforeSeasonNumber: Long,
         forceRefresh: Boolean,
     ) {
@@ -83,6 +83,6 @@ public class FakeSeasonDetailsRepository : SeasonDetailsRepository {
 
     override fun observeSeasonImages(id: Long): Flow<List<SeasonImages>> = flowOf(emptyList())
 
-    override fun observeContinueTrackingEpisodes(showTraktId: Long): Flow<ContinueTrackingResult?> =
+    override fun observeContinueTrackingEpisodes(showId: Long): Flow<ContinueTrackingResult?> =
         continueTrackingResult.asStateFlow()
 }

--- a/data/seasons/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/api/FollowedShowSeason.kt
+++ b/data/seasons/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/api/FollowedShowSeason.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.seasons.api
 
 public data class FollowedShowSeason(
-    val showTraktId: Long,
+    val showId: Long,
     val seasonId: Long,
     val seasonNumber: Long,
 )

--- a/data/seasons/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/api/SeasonsDao.kt
+++ b/data/seasons/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/api/SeasonsDao.kt
@@ -12,17 +12,17 @@ public interface SeasonsDao {
 
     public fun upsert(entityList: List<Season>)
 
-    public fun fetchShowSeasons(showTraktId: Long, includeSpecials: Boolean = true): List<ShowSeasons>
+    public fun fetchShowSeasons(showId: Long, includeSpecials: Boolean = true): List<ShowSeasons>
 
-    public fun observeSeasonsByShowTraktId(showTraktId: Long, includeSpecials: Boolean = true): Flow<List<ShowSeasons>>
+    public fun observeSeasonsByShowTraktId(showId: Long, includeSpecials: Boolean = true): Flow<List<ShowSeasons>>
 
-    public suspend fun getSeasonByShowAndNumber(showTraktId: Long, seasonNumber: Long): GetSeasonByShowAndNumber?
+    public suspend fun getSeasonByShowAndNumber(showId: Long, seasonNumber: Long): GetSeasonByShowAndNumber?
 
     public suspend fun getLatestSeasonPerFollowedShow(): List<LatestSeasonPerFollowedShow>
 
     public fun updateImageUrl(seasonId: Long, imageUrl: String)
 
-    public fun delete(showTraktId: Long)
+    public fun delete(showId: Long)
 
     public fun deleteAll()
 }

--- a/data/seasons/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/api/SeasonsDao.kt
+++ b/data/seasons/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/api/SeasonsDao.kt
@@ -14,7 +14,7 @@ public interface SeasonsDao {
 
     public fun fetchShowSeasons(showId: Long, includeSpecials: Boolean = true): List<ShowSeasons>
 
-    public fun observeSeasonsByShowTraktId(showId: Long, includeSpecials: Boolean = true): Flow<List<ShowSeasons>>
+    public fun observeSeasonsByShowId(showId: Long, includeSpecials: Boolean = true): Flow<List<ShowSeasons>>
 
     public suspend fun getSeasonByShowAndNumber(showId: Long, seasonNumber: Long): GetSeasonByShowAndNumber?
 

--- a/data/seasons/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/api/SeasonsEpisodesSyncRepository.kt
+++ b/data/seasons/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/api/SeasonsEpisodesSyncRepository.kt
@@ -1,5 +1,5 @@
 package com.thomaskioko.tvmaniac.seasons.api
 
 public interface SeasonsEpisodesSyncRepository {
-    public suspend fun syncSeasonsWithEpisodes(showTraktId: Long, forceRefresh: Boolean = false)
+    public suspend fun syncSeasonsWithEpisodes(showId: Long, forceRefresh: Boolean = false)
 }

--- a/data/seasons/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/implementation/DefaultSeasonsDao.kt
+++ b/data/seasons/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/implementation/DefaultSeasonsDao.kt
@@ -47,7 +47,7 @@ public class DefaultSeasonsDao(
         entityList.forEach { upsert(it) }
     }
 
-    override fun observeSeasonsByShowTraktId(showId: Long, includeSpecials: Boolean): Flow<List<ShowSeasons>> {
+    override fun observeSeasonsByShowId(showId: Long, includeSpecials: Boolean): Flow<List<ShowSeasons>> {
         val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return flowOf(emptyList())
         return seasonQueries.showSeasons(
             showId = internalShowId,

--- a/data/seasons/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/implementation/DefaultSeasonsDao.kt
+++ b/data/seasons/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/implementation/DefaultSeasonsDao.kt
@@ -47,27 +47,27 @@ public class DefaultSeasonsDao(
         entityList.forEach { upsert(it) }
     }
 
-    override fun observeSeasonsByShowTraktId(showTraktId: Long, includeSpecials: Boolean): Flow<List<ShowSeasons>> {
-        val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return flowOf(emptyList())
+    override fun observeSeasonsByShowTraktId(showId: Long, includeSpecials: Boolean): Flow<List<ShowSeasons>> {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return flowOf(emptyList())
         return seasonQueries.showSeasons(
-            showId = showId,
+            showId = internalShowId,
             includeSpecials = if (includeSpecials) 1L else 0L,
         ).asFlow().mapToList(dispatcher.io)
     }
 
-    override fun fetchShowSeasons(showTraktId: Long, includeSpecials: Boolean): List<ShowSeasons> {
-        val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return emptyList()
+    override fun fetchShowSeasons(showId: Long, includeSpecials: Boolean): List<ShowSeasons> {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return emptyList()
         return seasonQueries.showSeasons(
-            showId = showId,
+            showId = internalShowId,
             includeSpecials = if (includeSpecials) 1L else 0L,
         ).executeAsList()
     }
 
-    override suspend fun getSeasonByShowAndNumber(showTraktId: Long, seasonNumber: Long): GetSeasonByShowAndNumber? =
+    override suspend fun getSeasonByShowAndNumber(showId: Long, seasonNumber: Long): GetSeasonByShowAndNumber? =
         withContext(dispatcher.databaseRead) {
-            val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return@withContext null
+            val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@withContext null
             seasonQueries.getSeasonByShowAndNumber(
-                showId = showId,
+                showId = internalShowId,
                 seasonNumber = seasonNumber,
             ).executeAsOneOrNull()
         }
@@ -81,9 +81,9 @@ public class DefaultSeasonsDao(
         seasonQueries.updateImageUrl(image_url = imageUrl, id = Id(seasonId))
     }
 
-    override fun delete(showTraktId: Long) {
-        val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return
-        seasonQueries.delete(showId)
+    override fun delete(showId: Long) {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return
+        seasonQueries.delete(internalShowId)
     }
 
     override fun deleteAll() {

--- a/data/seasons/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/implementation/DefaultSeasonsEpisodesSyncRepository.kt
+++ b/data/seasons/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/implementation/DefaultSeasonsEpisodesSyncRepository.kt
@@ -13,10 +13,10 @@ public class DefaultSeasonsEpisodesSyncRepository(
     private val store: SeasonsWithEpisodesStore,
 ) : SeasonsEpisodesSyncRepository {
 
-    override suspend fun syncSeasonsWithEpisodes(showTraktId: Long, forceRefresh: Boolean) {
+    override suspend fun syncSeasonsWithEpisodes(showId: Long, forceRefresh: Boolean) {
         when {
-            forceRefresh -> store.fresh(showTraktId)
-            else -> store.get(showTraktId)
+            forceRefresh -> store.fresh(showId)
+            else -> store.get(showId)
         }
     }
 }

--- a/data/seasons/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/implementation/DefaultSeasonsRepository.kt
+++ b/data/seasons/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/implementation/DefaultSeasonsRepository.kt
@@ -23,7 +23,7 @@ public class DefaultSeasonsRepository(
     override fun observeSeasonsByShowId(id: Long): Flow<List<ShowSeasons>> {
         return datastoreRepository.observeIncludeSpecials()
             .flatMapLatest { includeSpecials ->
-                seasonsDao.observeSeasonsByShowTraktId(id, includeSpecials)
+                seasonsDao.observeSeasonsByShowId(id, includeSpecials)
             }
     }
 

--- a/data/seasons/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/implementation/DefaultSeasonsRepository.kt
+++ b/data/seasons/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/implementation/DefaultSeasonsRepository.kt
@@ -34,7 +34,7 @@ public class DefaultSeasonsRepository(
     override suspend fun getLatestSeasonsForFollowedShows(): List<FollowedShowSeason> {
         return seasonsDao.getLatestSeasonPerFollowedShow().map { row ->
             FollowedShowSeason(
-                showTraktId = row.show_trakt_id,
+                showId = row.show_trakt_id,
                 seasonId = row.season_id.id,
                 seasonNumber = row.season_number,
             )

--- a/data/seasons/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/implementation/SeasonsWithEpisodesStore.kt
+++ b/data/seasons/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/implementation/SeasonsWithEpisodesStore.kt
@@ -40,7 +40,7 @@ public class SeasonsWithEpisodesStore(
     },
     sourceOfTruth = SourceOfTruth.of<Long, List<TraktSeasonEpisodesResponse>, List<ShowSeasons>>(
         reader = { showId ->
-            seasonsDao.observeSeasonsByShowTraktId(showId)
+            seasonsDao.observeSeasonsByShowId(showId)
         },
         writer = { showId, seasons ->
             val internalShowId = showIdResolver.showIdForTraktId(showId)

--- a/data/seasons/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/implementation/SeasonsWithEpisodesStore.kt
+++ b/data/seasons/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/implementation/SeasonsWithEpisodesStore.kt
@@ -35,16 +35,16 @@ public class SeasonsWithEpisodesStore(
     private val databaseTransactionRunner: DatabaseTransactionRunner,
     private val dispatchers: AppCoroutineDispatchers,
 ) : Store<Long, List<ShowSeasons>> by storeBuilder(
-    fetcher = Fetcher.of { showTraktId: Long ->
-        traktRemoteDataSource.getSeasonsWithEpisodes(showTraktId).getOrThrow()
+    fetcher = Fetcher.of { showId: Long ->
+        traktRemoteDataSource.getSeasonsWithEpisodes(showId).getOrThrow()
     },
     sourceOfTruth = SourceOfTruth.of<Long, List<TraktSeasonEpisodesResponse>, List<ShowSeasons>>(
-        reader = { showTraktId ->
-            seasonsDao.observeSeasonsByShowTraktId(showTraktId)
+        reader = { showId ->
+            seasonsDao.observeSeasonsByShowTraktId(showId)
         },
-        writer = { showTraktId, seasons ->
-            val showId = showIdResolver.showIdForTraktId(showTraktId)
-            if (showId != null) {
+        writer = { showId, seasons ->
+            val internalShowId = showIdResolver.showIdForTraktId(showId)
+            if (internalShowId != null) {
                 databaseTransactionRunner {
                     seasons.forEach { seasonResponse ->
                         val seasonId = seasonResponse.ids.trakt.toLong()
@@ -52,7 +52,7 @@ public class SeasonsWithEpisodesStore(
                         seasonsDao.upsert(
                             Season(
                                 id = Id(seasonId),
-                                show_id = showId,
+                                show_id = internalShowId,
                                 season_number = seasonResponse.number.toLong(),
                                 episode_count = seasonResponse.episodeCount.toLong(),
                                 title = seasonResponse.title ?: "Season ${seasonResponse.number}",
@@ -66,7 +66,7 @@ public class SeasonsWithEpisodesStore(
                                 Episode(
                                     id = Id(episodeResponse.ids.trakt.toLong()),
                                     season_id = Id(seasonId),
-                                    show_id = showId,
+                                    show_id = internalShowId,
                                     episode_number = episodeResponse.episodeNumber.toLong(),
                                     title = episodeResponse.title,
                                     overview = episodeResponse.overview ?: "",
@@ -82,7 +82,7 @@ public class SeasonsWithEpisodesStore(
                     }
 
                     requestManagerRepository.upsert(
-                        entityId = showTraktId,
+                        entityId = showId,
                         requestType = SEASONS_EPISODES_SYNC.name,
                     )
                 }

--- a/data/seasons/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/testing/FakeSeasonsEpisodesSyncRepository.kt
+++ b/data/seasons/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasons/testing/FakeSeasonsEpisodesSyncRepository.kt
@@ -14,8 +14,8 @@ public class FakeSeasonsEpisodesSyncRepository : SeasonsEpisodesSyncRepository {
         error = throwable
     }
 
-    override suspend fun syncSeasonsWithEpisodes(showTraktId: Long, forceRefresh: Boolean) {
+    override suspend fun syncSeasonsWithEpisodes(showId: Long, forceRefresh: Boolean) {
         error?.let { throw it }
-        _syncedShowIds.add(showTraktId)
+        _syncedShowIds.add(showId)
     }
 }

--- a/data/showdetails/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/showdetails/api/ShowDetailsDao.kt
+++ b/data/showdetails/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/showdetails/api/ShowDetailsDao.kt
@@ -4,7 +4,7 @@ import com.thomaskioko.tvmaniac.db.TvshowDetails
 import kotlinx.coroutines.flow.Flow
 
 public interface ShowDetailsDao {
-    public fun observeTvShowByTraktId(showId: Long): Flow<TvshowDetails?>
+    public fun observeTvShowByShowId(showId: Long): Flow<TvshowDetails?>
 
     public fun getTvShow(showId: Long): TvshowDetails
 

--- a/data/showdetails/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/showdetails/api/ShowDetailsDao.kt
+++ b/data/showdetails/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/showdetails/api/ShowDetailsDao.kt
@@ -4,11 +4,11 @@ import com.thomaskioko.tvmaniac.db.TvshowDetails
 import kotlinx.coroutines.flow.Flow
 
 public interface ShowDetailsDao {
-    public fun observeTvShowByTraktId(traktId: Long): Flow<TvshowDetails?>
+    public fun observeTvShowByTraktId(showId: Long): Flow<TvshowDetails?>
 
-    public fun getTvShow(traktId: Long): TvshowDetails
+    public fun getTvShow(showId: Long): TvshowDetails
 
-    public fun getTvShowOrNull(traktId: Long): TvshowDetails?
+    public fun getTvShowOrNull(showId: Long): TvshowDetails?
 
-    public fun deleteTvShow(traktId: Long)
+    public fun deleteTvShow(showId: Long)
 }

--- a/data/showdetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/showdetails/implementation/DefaultShowDetailsDao.kt
+++ b/data/showdetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/showdetails/implementation/DefaultShowDetailsDao.kt
@@ -19,16 +19,16 @@ public class DefaultShowDetailsDao(
 ) : ShowDetailsDao {
     private val tvShowQueries = database.tvShowQueries
 
-    override fun observeTvShowByTraktId(traktId: Long): Flow<TvshowDetails?> =
-        tvShowQueries.tvshowDetails(traktId).asFlow().mapToOneOrNull(dispatchers.io)
+    override fun observeTvShowByTraktId(showId: Long): Flow<TvshowDetails?> =
+        tvShowQueries.tvshowDetails(showId).asFlow().mapToOneOrNull(dispatchers.io)
 
-    override fun getTvShow(traktId: Long): TvshowDetails =
-        tvShowQueries.tvshowDetails(traktId).executeAsOne()
+    override fun getTvShow(showId: Long): TvshowDetails =
+        tvShowQueries.tvshowDetails(showId).executeAsOne()
 
-    override fun getTvShowOrNull(traktId: Long): TvshowDetails? =
-        tvShowQueries.tvshowDetails(traktId).executeAsOneOrNull()
+    override fun getTvShowOrNull(showId: Long): TvshowDetails? =
+        tvShowQueries.tvshowDetails(showId).executeAsOneOrNull()
 
-    override fun deleteTvShow(traktId: Long) {
-        tvShowQueries.delete(traktId)
+    override fun deleteTvShow(showId: Long) {
+        tvShowQueries.delete(showId)
     }
 }

--- a/data/showdetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/showdetails/implementation/DefaultShowDetailsDao.kt
+++ b/data/showdetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/showdetails/implementation/DefaultShowDetailsDao.kt
@@ -19,7 +19,7 @@ public class DefaultShowDetailsDao(
 ) : ShowDetailsDao {
     private val tvShowQueries = database.tvShowQueries
 
-    override fun observeTvShowByTraktId(showId: Long): Flow<TvshowDetails?> =
+    override fun observeTvShowByShowId(showId: Long): Flow<TvshowDetails?> =
         tvShowQueries.tvshowDetails(showId).asFlow().mapToOneOrNull(dispatchers.io)
 
     override fun getTvShow(showId: Long): TvshowDetails =

--- a/data/showdetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/showdetails/implementation/DefaultShowDetailsRepository.kt
+++ b/data/showdetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/showdetails/implementation/DefaultShowDetailsRepository.kt
@@ -26,5 +26,5 @@ public class DefaultShowDetailsRepository(
     }
 
     override fun observeShowDetails(id: Long): Flow<TvshowDetails> =
-        dao.observeTvShowByTraktId(id).filterNotNull()
+        dao.observeTvShowByShowId(id).filterNotNull()
 }

--- a/data/showdetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/showdetails/implementation/ShowDetailsStore.kt
+++ b/data/showdetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/showdetails/implementation/ShowDetailsStore.kt
@@ -75,7 +75,7 @@ public class ShowDetailsStore(
         }
     },
     sourceOfTruth = SourceOfTruth.of<Long, ShowDetailsResponse, TvshowDetails>(
-        reader = { showId: Long -> showDetailsDao.observeTvShowByTraktId(showId) },
+        reader = { showId: Long -> showDetailsDao.observeTvShowByShowId(showId) },
         writer = { showId, response ->
             databaseTransactionRunner {
                 val show = response.traktShow

--- a/data/showdetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/showdetails/implementation/ShowDetailsStore.kt
+++ b/data/showdetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/showdetails/implementation/ShowDetailsStore.kt
@@ -42,26 +42,26 @@ public class ShowDetailsStore(
     private val databaseTransactionRunner: DatabaseTransactionRunner,
     private val dispatchers: AppCoroutineDispatchers,
 ) : Store<Long, TvshowDetails> by storeBuilder(
-    fetcher = Fetcher.of { traktId: Long ->
+    fetcher = Fetcher.of { showId: Long ->
         coroutineScope {
 
             // TODO:: Remove Get or throw and handle exception
             val showDetailsDeferred = async {
-                traktRemoteDataSource.getShowDetails(traktId).getOrThrow()
+                traktRemoteDataSource.getShowDetails(showId).getOrThrow()
             }
             val seasonsDeferred = async {
-                traktRemoteDataSource.getShowSeasons(traktId).getOrThrow()
+                traktRemoteDataSource.getShowSeasons(showId).getOrThrow()
             }
 
             val showDetails = showDetailsDeferred.await()
             val seasons = seasonsDeferred.await()
 
             val tmdbId = showDetails.ids.tmdb
-                ?: error("Show ${showDetails.title} (trakt: $traktId) has no TMDB ID")
+                ?: error("Show ${showDetails.title} (trakt: $showId) has no TMDB ID")
             val tmdbDetails = tmdbRemoteDataSource.getShowDetails(tmdbId).getOrThrow()
 
             requestManagerRepository.upsert(
-                entityId = traktId,
+                entityId = showId,
                 requestType = SHOW_DETAILS.name,
             )
 
@@ -75,15 +75,15 @@ public class ShowDetailsStore(
         }
     },
     sourceOfTruth = SourceOfTruth.of<Long, ShowDetailsResponse, TvshowDetails>(
-        reader = { traktId: Long -> showDetailsDao.observeTvShowByTraktId(traktId) },
-        writer = { traktId, response ->
+        reader = { showId: Long -> showDetailsDao.observeTvShowByTraktId(showId) },
+        writer = { showId, response ->
             databaseTransactionRunner {
                 val show = response.traktShow
                 val tmdbId = response.tmdbId
 
                 tvShowsDao.upsert(
                     ShowToPersist(
-                        traktId = Id(traktId),
+                        showId = Id(showId),
                         tmdbId = Id(tmdbId),
                         name = show.title,
                         overview = show.overview ?: "",
@@ -100,14 +100,14 @@ public class ShowDetailsStore(
                     ),
                 )
 
-                val showId = showIdResolver.showIdForTraktId(traktId)
+                val internalShowId = showIdResolver.showIdForTraktId(showId)
                     ?: return@databaseTransactionRunner
 
                 response.traktSeasons.forEach { season ->
                     seasonDao.upsert(
                         Season(
                             id = Id(season.ids.trakt.toLong()),
-                            show_id = showId,
+                            show_id = internalShowId,
                             season_number = season.number.toLong(),
                             episode_count = season.episodeCount.toLong(),
                             title = season.title,

--- a/data/shows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/api/MergeShowUtil.kt
+++ b/data/shows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/api/MergeShowUtil.kt
@@ -9,7 +9,7 @@ public fun mergeShows(
     if (local == null) return network
 
     return ShowToPersist(
-        traktId = network.traktId,
+        showId = network.showId,
         tmdbId = network.tmdbId,
         name = network.name,
         overview = network.overview.ifEmpty { local.overview },

--- a/data/shows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/api/ShowToPersist.kt
+++ b/data/shows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/api/ShowToPersist.kt
@@ -5,7 +5,7 @@ import com.thomaskioko.tvmaniac.db.TmdbId
 import com.thomaskioko.tvmaniac.db.TraktId
 
 public data class ShowToPersist(
-    val traktId: Id<TraktId>,
+    val showId: Id<TraktId>,
     val tmdbId: Id<TmdbId>,
     val name: String,
     val overview: String,

--- a/data/shows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/api/TvShowsDao.kt
+++ b/data/shows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/api/TvShowsDao.kt
@@ -18,9 +18,9 @@ public interface TvShowsDao {
 
     public fun upsertMerging(show: ShowToPersist)
 
-    public fun getShowsByTraktIds(showIds: List<Long>): List<ShowEntity>
+    public fun getShowsByIds(showIds: List<Long>): List<ShowEntity>
 
-    public fun getTmdbIdByTraktId(showId: Long): Long?
+    public fun getTmdbIdByShowId(showId: Long): Long?
 
-    public suspend fun existsByTraktId(showId: Long): Boolean
+    public suspend fun existsByShowId(showId: Long): Boolean
 }

--- a/data/shows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/api/TvShowsDao.kt
+++ b/data/shows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/api/TvShowsDao.kt
@@ -18,9 +18,9 @@ public interface TvShowsDao {
 
     public fun upsertMerging(show: ShowToPersist)
 
-    public fun getShowsByTraktIds(traktIds: List<Long>): List<ShowEntity>
+    public fun getShowsByTraktIds(showIds: List<Long>): List<ShowEntity>
 
-    public fun getTmdbIdByTraktId(traktId: Long): Long?
+    public fun getTmdbIdByTraktId(showId: Long): Long?
 
-    public suspend fun existsByTraktId(traktId: Long): Boolean
+    public suspend fun existsByTraktId(showId: Long): Boolean
 }

--- a/data/shows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/api/model/ShowEntity.kt
+++ b/data/shows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/api/model/ShowEntity.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.shows.api.model
 
 public data class ShowEntity(
-    val traktId: Long,
+    val showId: Long,
     val tmdbId: Long,
     val inLibrary: Boolean,
     val posterPath: String?,

--- a/data/shows/api/src/commonTest/kotlin/com/thomaskioko/tvmaniac/shows/api/TvShowCacheTest.kt
+++ b/data/shows/api/src/commonTest/kotlin/com/thomaskioko/tvmaniac/shows/api/TvShowCacheTest.kt
@@ -169,25 +169,25 @@ internal class TvShowCacheTest : BaseDatabaseTest() {
     private fun insertTestShows() {
         listOf(
             TestShow(
-                traktId = 1,
+                showId = 1,
                 tmdbId = 1,
                 name = "Breaking Bad",
                 overview = "A high school chemistry teacher turned meth dealer",
             ),
             TestShow(
-                traktId = 2,
+                showId = 2,
                 tmdbId = 2,
                 name = "The Walking Dead",
                 overview = "Zombie apocalypse drama",
             ),
             TestShow(
-                traktId = 3,
+                showId = 3,
                 tmdbId = 3,
                 name = "In the Dark",
                 overview = "Crime drama series",
             ),
             TestShow(
-                traktId = 4,
+                showId = 4,
                 tmdbId = 4,
                 name = "Theory of Everything",
                 overview = "Crime drama series",
@@ -208,12 +208,12 @@ internal class TvShowCacheTest : BaseDatabaseTest() {
                 episode_numbers = null,
                 season_numbers = null,
             )
-            showIdForTraktId(traktId = show.traktId, tmdbId = show.tmdbId)
+            showIdForTraktId(traktId = show.showId, tmdbId = show.tmdbId)
         }
     }
 
     private data class TestShow(
-        val traktId: Long,
+        val showId: Long,
         val tmdbId: Long,
         val name: String,
         val overview: String,

--- a/data/shows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/implementation/DefaultTvShowsDao.kt
+++ b/data/shows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/implementation/DefaultTvShowsDao.kt
@@ -62,7 +62,7 @@ public class DefaultTvShowsDao(
         externalIdQueries.insert(
             showId = showId,
             provider = Provider.TRAKT,
-            externalId = show.traktId.id.toString(),
+            externalId = show.showId.id.toString(),
         )
     }
 
@@ -78,9 +78,9 @@ public class DefaultTvShowsDao(
                 query,
                 query,
                 query,
-            ) { traktId, tmdbId, title, imageUrl, overview, status, voteAverage, year, inLibrary ->
+            ) { showId, tmdbId, title, imageUrl, overview, status, voteAverage, year, inLibrary ->
                 ShowEntity(
-                    traktId = traktId,
+                    showId = showId,
                     tmdbId = tmdbId.id,
                     title = title,
                     posterPath = imageUrl,
@@ -117,12 +117,12 @@ public class DefaultTvShowsDao(
         }
     }
 
-    override fun getShowsByTraktIds(traktIds: List<Long>): List<ShowEntity> {
-        if (traktIds.isEmpty()) return emptyList()
+    override fun getShowsByTraktIds(showIds: List<Long>): List<ShowEntity> {
+        if (showIds.isEmpty()) return emptyList()
 
-        return tvShowQueries.showsByTraktIds(traktIds) { traktId, tmdbId, name, posterPath, overview, inLibrary ->
+        return tvShowQueries.showsByTraktIds(showIds) { showId, tmdbId, name, posterPath, overview, inLibrary ->
             ShowEntity(
-                traktId = traktId,
+                showId = showId,
                 tmdbId = tmdbId.id,
                 title = name,
                 posterPath = posterPath,
@@ -132,12 +132,12 @@ public class DefaultTvShowsDao(
         }.executeAsList()
     }
 
-    override fun getTmdbIdByTraktId(traktId: Long): Long? {
-        return tvShowQueries.getTmdbIdByTraktId(traktId).executeAsOneOrNull()?.id
+    override fun getTmdbIdByTraktId(showId: Long): Long? {
+        return tvShowQueries.getTmdbIdByTraktId(showId).executeAsOneOrNull()?.id
     }
 
-    override suspend fun existsByTraktId(traktId: Long): Boolean =
+    override suspend fun existsByTraktId(showId: Long): Boolean =
         withContext(dispatchers.io) {
-            tvShowQueries.existsByTraktId(traktId).executeAsOne()
+            tvShowQueries.existsByTraktId(showId).executeAsOne()
         }
 }

--- a/data/shows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/implementation/DefaultTvShowsDao.kt
+++ b/data/shows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/implementation/DefaultTvShowsDao.kt
@@ -117,10 +117,10 @@ public class DefaultTvShowsDao(
         }
     }
 
-    override fun getShowsByTraktIds(showIds: List<Long>): List<ShowEntity> {
+    override fun getShowsByIds(showIds: List<Long>): List<ShowEntity> {
         if (showIds.isEmpty()) return emptyList()
 
-        return tvShowQueries.showsByTraktIds(showIds) { showId, tmdbId, name, posterPath, overview, inLibrary ->
+        return tvShowQueries.showsByIds(showIds) { showId, tmdbId, name, posterPath, overview, inLibrary ->
             ShowEntity(
                 showId = showId,
                 tmdbId = tmdbId.id,
@@ -132,12 +132,12 @@ public class DefaultTvShowsDao(
         }.executeAsList()
     }
 
-    override fun getTmdbIdByTraktId(showId: Long): Long? {
-        return tvShowQueries.getTmdbIdByTraktId(showId).executeAsOneOrNull()?.id
+    override fun getTmdbIdByShowId(showId: Long): Long? {
+        return tvShowQueries.getTmdbIdByShowId(showId).executeAsOneOrNull()?.id
     }
 
-    override suspend fun existsByTraktId(showId: Long): Boolean =
+    override suspend fun existsByShowId(showId: Long): Boolean =
         withContext(dispatchers.io) {
-            tvShowQueries.existsByTraktId(showId).executeAsOne()
+            tvShowQueries.existsByShowId(showId).executeAsOne()
         }
 }

--- a/data/shows/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/testing/FakeTvShowsDao.kt
+++ b/data/shows/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/testing/FakeTvShowsDao.kt
@@ -18,17 +18,17 @@ public class FakeTvShowsDao : TvShowsDao {
     public fun entries(): List<Tvshow> = state.value.values.toList()
 
     override fun upsert(show: ShowToPersist) {
-        state.value += (show.traktId.id to show.toTvshow())
+        state.value += (show.showId.id to show.toTvshow())
     }
 
     override fun upsert(list: List<ShowToPersist>) {
-        state.value += list.associate { it.traktId.id to it.toTvshow() }
+        state.value += list.associate { it.showId.id to it.toTvshow() }
     }
 
     override fun upsertMerging(show: ShowToPersist) {
-        val existing = state.value[show.traktId.id]
+        val existing = state.value[show.showId.id]
         val merged = mergeShows(local = existing, network = show)
-        state.value = state.value + (merged.traktId.id to merged.toTvshow())
+        state.value = state.value + (merged.showId.id to merged.toTvshow())
     }
 
     override fun observeShowsByQuery(query: String): Flow<List<ShowEntity>> =
@@ -43,11 +43,11 @@ public class FakeTvShowsDao : TvShowsDao {
         state.value = emptyMap()
     }
 
-    override fun getShowsByTraktIds(traktIds: List<Long>): List<ShowEntity> = emptyList()
+    override fun getShowsByTraktIds(showIds: List<Long>): List<ShowEntity> = emptyList()
 
-    override fun getTmdbIdByTraktId(traktId: Long): Long? = state.value[traktId]?.tmdb_id?.id
+    override fun getTmdbIdByTraktId(showId: Long): Long? = state.value[showId]?.tmdb_id?.id
 
-    override suspend fun existsByTraktId(traktId: Long): Boolean = traktId in state.value
+    override suspend fun existsByTraktId(showId: Long): Boolean = showId in state.value
 }
 
 private fun ShowToPersist.toTvshow(): Tvshow = Tvshow(

--- a/data/shows/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/testing/FakeTvShowsDao.kt
+++ b/data/shows/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/testing/FakeTvShowsDao.kt
@@ -43,11 +43,11 @@ public class FakeTvShowsDao : TvShowsDao {
         state.value = emptyMap()
     }
 
-    override fun getShowsByTraktIds(showIds: List<Long>): List<ShowEntity> = emptyList()
+    override fun getShowsByIds(showIds: List<Long>): List<ShowEntity> = emptyList()
 
-    override fun getTmdbIdByTraktId(showId: Long): Long? = state.value[showId]?.tmdb_id?.id
+    override fun getTmdbIdByShowId(showId: Long): Long? = state.value[showId]?.tmdb_id?.id
 
-    override suspend fun existsByTraktId(showId: Long): Boolean = showId in state.value
+    override suspend fun existsByShowId(showId: Long): Boolean = showId in state.value
 }
 
 private fun ShowToPersist.toTvshow(): Tvshow = Tvshow(

--- a/data/similar/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/api/SimilarShowsDao.kt
+++ b/data/similar/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/api/SimilarShowsDao.kt
@@ -5,9 +5,9 @@ import kotlinx.coroutines.flow.Flow
 
 public interface SimilarShowsDao {
 
-    public fun upsert(showTraktId: Long, showTmdbId: Long, similarShowTraktId: Long, pageOrder: Int = 0)
+    public fun upsert(showId: Long, showTmdbId: Long, similarShowTraktId: Long, pageOrder: Int = 0)
 
-    public fun observeSimilarShows(showTraktId: Long): Flow<List<SimilarShows>>
+    public fun observeSimilarShows(showId: Long): Flow<List<SimilarShows>>
 
     public fun delete(id: Long)
 

--- a/data/similar/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/api/SimilarShowsRepository.kt
+++ b/data/similar/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/api/SimilarShowsRepository.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 
 public interface SimilarShowsRepository {
     public suspend fun fetchSimilarShows(
-        traktId: Long,
+        showId: Long,
         forceRefresh: Boolean = false,
     )
 

--- a/data/similar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/implementation/DefaultSimilarShowsDao.kt
+++ b/data/similar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/implementation/DefaultSimilarShowsDao.kt
@@ -21,11 +21,11 @@ public class DefaultSimilarShowsDao(
     private val dispatchers: AppCoroutineDispatchers,
 ) : SimilarShowsDao {
 
-    override fun upsert(showTraktId: Long, showTmdbId: Long, similarShowTraktId: Long, pageOrder: Int) {
-        val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return
+    override fun upsert(showId: Long, showTmdbId: Long, similarShowTraktId: Long, pageOrder: Int) {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return
         database.similarShowsQueries.transaction {
             database.similarShowsQueries.insertOrReplace(
-                show_id = showId,
+                show_id = internalShowId,
                 tmdb_id = Id(showTmdbId),
                 similar_show_trakt_id = Id(similarShowTraktId),
                 page_order = pageOrder.toLong(),
@@ -33,9 +33,9 @@ public class DefaultSimilarShowsDao(
         }
     }
 
-    override fun observeSimilarShows(showTraktId: Long): Flow<List<SimilarShows>> {
+    override fun observeSimilarShows(showId: Long): Flow<List<SimilarShows>> {
         return database.similarShowsQueries
-            .similarShows(Id(showTraktId))
+            .similarShows(Id(showId))
             .asFlow()
             .mapToList(dispatchers.io)
     }

--- a/data/similar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/implementation/DefaultSimilarShowsRepository.kt
+++ b/data/similar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/implementation/DefaultSimilarShowsRepository.kt
@@ -17,8 +17,8 @@ public class DefaultSimilarShowsRepository(
     private val dao: SimilarShowsDao,
 ) : SimilarShowsRepository {
 
-    override suspend fun fetchSimilarShows(traktId: Long, forceRefresh: Boolean) {
-        val param = SimilarParams(showTraktId = traktId)
+    override suspend fun fetchSimilarShows(showId: Long, forceRefresh: Boolean) {
+        val param = SimilarParams(showId = showId)
 
         when {
             forceRefresh -> store.fresh(param)

--- a/data/similar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/implementation/SimilarParams.kt
+++ b/data/similar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/implementation/SimilarParams.kt
@@ -4,5 +4,5 @@ import com.thomaskioko.tvmaniac.tmdb.api.DEFAULT_API_PAGE
 
 public data class SimilarParams(
     val page: Long = DEFAULT_API_PAGE,
-    val showTraktId: Long,
+    val showId: Long,
 )

--- a/data/similar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/implementation/SimilarShowStore.kt
+++ b/data/similar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/implementation/SimilarShowStore.kt
@@ -42,7 +42,7 @@ public class SimilarShowStore(
     fetcher = Fetcher.of { param: SimilarParams ->
         coroutineScope {
             val results = traktRemoteDataSource.getRelatedShows(
-                traktId = param.showId,
+                showId = param.showId,
                 page = param.page.toInt(),
             ).getOrThrow()
                 .mapNotNull { show ->

--- a/data/similar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/implementation/SimilarShowStore.kt
+++ b/data/similar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/implementation/SimilarShowStore.kt
@@ -42,7 +42,7 @@ public class SimilarShowStore(
     fetcher = Fetcher.of { param: SimilarParams ->
         coroutineScope {
             val results = traktRemoteDataSource.getRelatedShows(
-                traktId = param.showTraktId,
+                traktId = param.showId,
                 page = param.page.toInt(),
             ).getOrThrow()
                 .mapNotNull { show ->
@@ -63,7 +63,7 @@ public class SimilarShowStore(
                 .awaitAll()
 
             requestManagerRepository.upsert(
-                entityId = param.showTraktId,
+                entityId = param.showId,
                 requestType = SIMILAR_SHOWS.name,
             )
 
@@ -71,27 +71,27 @@ public class SimilarShowStore(
         }
     },
     sourceOfTruth = SourceOfTruth.of<SimilarParams, List<SimilarShowResult>, List<SimilarShows>>(
-        reader = { param: SimilarParams -> similarShowsDao.observeSimilarShows(param.showTraktId) },
+        reader = { param: SimilarParams -> similarShowsDao.observeSimilarShows(param.showId) },
         writer = { param: SimilarParams, response ->
             withContext(dispatchers.databaseWrite) {
                 databaseTransactionRunner {
                     response.forEachIndexed { index, result ->
-                        val traktId = result.traktShow.ids.trakt
+                        val showId = result.traktShow.ids.trakt
                         val tmdbId = result.tmdbId
 
-                        tvShowsDao.upsertMerging(result.toTvshow(traktId, tmdbId, formatterUtil, dateTimeProvider))
+                        tvShowsDao.upsertMerging(result.toTvshow(showId, tmdbId, formatterUtil, dateTimeProvider))
 
                         similarShowsDao.upsert(
-                            showTraktId = traktId,
+                            showId = showId,
                             showTmdbId = tmdbId,
-                            similarShowTraktId = param.showTraktId,
+                            similarShowTraktId = param.showId,
                             pageOrder = index,
                         )
                     }
                 }
             }
         },
-        delete = { param -> similarShowsDao.delete(param.showTraktId) },
+        delete = { param -> similarShowsDao.delete(param.showId) },
         deleteAll = { databaseTransactionRunner(similarShowsDao::deleteAll) },
     ).usingDispatchers(
         readDispatcher = dispatchers.databaseRead,
@@ -111,7 +111,7 @@ public class SimilarShowStore(
 ).build()
 
 private fun SimilarShowResult.toTvshow(
-    traktId: Long,
+    showId: Long,
     tmdbId: Long,
     formatterUtil: FormatterUtil,
     dateTimeProvider: DateTimeProvider,
@@ -120,7 +120,7 @@ private fun SimilarShowResult.toTvshow(
     val trakt = traktShow
     val dateString = tmdb?.firstAirDate ?: trakt.firstAirDate
     return ShowToPersist(
-        traktId = Id(traktId),
+        showId = Id(showId),
         tmdbId = Id(tmdbId),
         name = tmdb?.name ?: trakt.title,
         overview = tmdb?.overview ?: trakt.overview ?: "",

--- a/data/similar/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/testing/FakeSimilarShowsRepository.kt
+++ b/data/similar/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/testing/FakeSimilarShowsRepository.kt
@@ -14,7 +14,7 @@ public class FakeSimilarShowsRepository : SimilarShowsRepository {
         similarShows.emit(result)
     }
 
-    override suspend fun fetchSimilarShows(traktId: Long, forceRefresh: Boolean) {
+    override suspend fun fetchSimilarShows(showId: Long, forceRefresh: Boolean) {
     }
 
     override fun observeSimilarShows(id: Long): Flow<List<SimilarShows>> = similarShows.asStateFlow()

--- a/data/start-watching/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/api/StartWatchingShow.kt
+++ b/data/start-watching/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/api/StartWatchingShow.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.startwatching.api
 
 public data class StartWatchingShow(
-    val traktId: Long,
+    val showId: Long,
     val tmdbId: Long,
     val title: String,
     val posterPath: String?,

--- a/data/start-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/implementation/DefaultStartWatchingDao.kt
+++ b/data/start-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/implementation/DefaultStartWatchingDao.kt
@@ -31,7 +31,7 @@ public class DefaultStartWatchingDao(
 
 private fun StartWatchingShows.toStartWatchingShow(): StartWatchingShow =
     StartWatchingShow(
-        traktId = show_trakt_id,
+        showId = show_trakt_id,
         tmdbId = show_tmdb_id.id,
         title = title,
         posterPath = poster_path,

--- a/data/start-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/implementation/StartWatchingWatchlistStore.kt
+++ b/data/start-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/implementation/StartWatchingWatchlistStore.kt
@@ -89,7 +89,7 @@ public class StartWatchingWatchlistStore(
                 }
 
                 currentEntries.forEach { localEntry ->
-                    if (localEntry.traktId !in networkTraktIds) {
+                    if (localEntry.showId !in networkTraktIds) {
                         followedShowsDao.deleteById(localEntry.id)
                     }
                 }
@@ -124,14 +124,14 @@ private data class FollowedShowWithImages(
 )
 
 private fun TraktFollowedShowResponse.toFollowedShowEntry(): FollowedShowEntry = FollowedShowEntry(
-    traktId = show.ids.trakt,
+    showId = show.ids.trakt,
     tmdbId = show.ids.tmdb,
     followedAt = Instant.parse(listedAt),
     pendingAction = PendingAction.NOTHING,
 )
 
 private fun TraktFollowedShowResponse.toTvshow(posterPath: String?, backdropPath: String?): ShowToPersist = ShowToPersist(
-    traktId = Id(show.ids.trakt),
+    showId = Id(show.ids.trakt),
     tmdbId = Id(show.ids.tmdb),
     name = show.title,
     overview = "",

--- a/data/start-watching/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/startwatching/implementation/DefaultStartWatchingDaoTest.kt
+++ b/data/start-watching/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/startwatching/implementation/DefaultStartWatchingDaoTest.kt
@@ -142,7 +142,7 @@ internal class DefaultStartWatchingDaoTest : BaseDatabaseTest() {
 
         dao.observeStartWatchingShows().test {
             val item = awaitItem().single()
-            item.traktId shouldBe 8
+            item.showId shouldBe 8
             item.episodeId shouldBe 801
             item.episodeTitle shouldBe "Pilot"
             item.seasonNumber shouldBe 1
@@ -153,7 +153,7 @@ internal class DefaultStartWatchingDaoTest : BaseDatabaseTest() {
     }
 
     private fun expectedShow(id: Long, title: String): StartWatchingShow =
-        StartWatchingShow(traktId = id, tmdbId = id, title = title, posterPath = "/$id.jpg", year = "2020-01-01", inLibrary = true)
+        StartWatchingShow(showId = id, tmdbId = id, title = title, posterPath = "/$id.jpg", year = "2020-01-01", inLibrary = true)
 
     private fun insertReleasedShow(id: Long, name: String) {
         insertShow(id, name)

--- a/data/topratedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/toprated/data/implementation/DefaultTopRatedShowsDao.kt
+++ b/data/topratedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/toprated/data/implementation/DefaultTopRatedShowsDao.kt
@@ -45,9 +45,9 @@ public class DefaultTopRatedShowsDao(
 
     override fun observeTopRatedShows(page: Long): Flow<List<ShowEntity>> =
         topRatedShowsQueries
-            .entriesInPage(Id(page)) { traktId, tmdbId, pageId, name, posterPath, overview, inLibrary ->
+            .entriesInPage(Id(page)) { showId, tmdbId, pageId, name, posterPath, overview, inLibrary ->
                 ShowEntity(
-                    traktId = traktId,
+                    showId = showId,
                     tmdbId = tmdbId.id,
                     page = pageId.id,
                     title = name,
@@ -68,9 +68,9 @@ public class DefaultTopRatedShowsDao(
                 topRatedShowsQueries.pagedTopRatedShows(
                     limit = limit,
                     offset = offset,
-                ) { traktId, tmdbId, page, title, imageUrl, inLib ->
+                ) { showId, tmdbId, page, title, imageUrl, inLib ->
                     ShowEntity(
-                        traktId = traktId,
+                        showId = showId,
                         tmdbId = tmdbId.id,
                         page = page.id,
                         title = title,

--- a/data/topratedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/toprated/data/implementation/TopRatedShowsStore.kt
+++ b/data/topratedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/toprated/data/implementation/TopRatedShowsStore.kt
@@ -89,7 +89,7 @@ public class TopRatedShowsStore(
 
                     response.forEach { showWithImages ->
                         val show = showWithImages.traktShow
-                        val traktId = show.ids.trakt
+                        val showId = show.ids.trakt
                         val tmdbId = showWithImages.tmdbId
                         val posterPath = showWithImages.tmdbPosterPath?.let {
                             formatterUtil.formatTmdbPosterPath(it)
@@ -98,13 +98,13 @@ public class TopRatedShowsStore(
                             formatterUtil.formatTmdbPosterPath(it)
                         }
 
-                        tvShowsDao.upsertMerging(show.toTvshow(traktId, tmdbId, posterPath, backdropPath, dateTimeProvider))
+                        tvShowsDao.upsertMerging(show.toTvshow(showId, tmdbId, posterPath, backdropPath, dateTimeProvider))
 
-                        val showId = showIdResolver.showIdForTraktId(traktId) ?: return@forEach
+                        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@forEach
 
                         topRatedShowsDao.upsert(
                             Toprated_shows(
-                                show_id = showId,
+                                show_id = internalShowId,
                                 tmdb_id = Id(tmdbId),
                                 page = Id(page),
                                 name = show.title,
@@ -135,13 +135,13 @@ public class TopRatedShowsStore(
 ).build()
 
 private fun TraktShowResponse.toTvshow(
-    traktId: Long,
+    showId: Long,
     tmdbId: Long,
     posterPath: String?,
     backdropPath: String?,
     dateTimeProvider: DateTimeProvider,
 ): ShowToPersist = ShowToPersist(
-    traktId = Id(traktId),
+    showId = Id(showId),
     tmdbId = Id(tmdbId),
     name = title,
     overview = overview ?: "",

--- a/data/topratedshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/toprated/data/implementation/DefaultTopRatedShowsDaoTest.kt
+++ b/data/topratedshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/toprated/data/implementation/DefaultTopRatedShowsDaoTest.kt
@@ -55,7 +55,7 @@ internal class DefaultTopRatedShowsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `should insert top rated shows`() = runTest {
-        val showId = seedShow(traktId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
+        val showId = seedShow(showId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
 
         val topRatedShow = Toprated_shows(
             show_id = showId,
@@ -74,7 +74,7 @@ internal class DefaultTopRatedShowsDaoTest : BaseDatabaseTest() {
         dao.observeTopRatedShows(page = 1).test {
             val shows = awaitItem()
             shows.size shouldBe 3
-            shows.any { it.traktId == 999L } shouldBe true
+            shows.any { it.showId == 999L } shouldBe true
             cancelAndConsumeRemainingEvents()
         }
     }
@@ -89,13 +89,13 @@ internal class DefaultTopRatedShowsDaoTest : BaseDatabaseTest() {
             shows.size shouldBe 2
 
             // Verify show data is correctly returned from stable query
-            val show1 = shows.find { it.traktId == 1L }
+            val show1 = shows.find { it.showId == 1L }
             show1?.title shouldBe "Test Show 1"
             show1?.posterPath shouldBe "/test1.jpg"
             show1?.overview shouldBe "Test overview 1"
             show1?.inLibrary shouldBe false // Always false from stable query
 
-            val show2 = shows.find { it.traktId == 2L }
+            val show2 = shows.find { it.showId == 2L }
             show2?.title shouldBe "Test Show 2"
             show2?.posterPath shouldBe "/test2.jpg"
             show2?.overview shouldBe "Test overview 2"
@@ -107,7 +107,7 @@ internal class DefaultTopRatedShowsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `stable query should not return shows with null names`() = runTest {
-        val showId = seedShow(traktId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
+        val showId = seedShow(showId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
         val _ = topRatedShowsQueries.insert(
             showId = showId,
             tmdbId = Id<TmdbId>(999),
@@ -121,14 +121,14 @@ internal class DefaultTopRatedShowsDaoTest : BaseDatabaseTest() {
         dao.observeTopRatedShows(page = 1).test {
             val shows = awaitItem()
             shows.size shouldBe 2
-            shows.none { it.traktId == 999L } shouldBe true
+            shows.none { it.showId == 999L } shouldBe true
             cancelAndConsumeRemainingEvents()
         }
     }
 
     @Test
     fun `stable query should filter by page correctly`() = runTest {
-        val showId = seedShow(traktId = 999, name = "Page 2 Show", posterPath = "/page2.jpg")
+        val showId = seedShow(showId = 999, name = "Page 2 Show", posterPath = "/page2.jpg")
         val _ = topRatedShowsQueries.insert(
             showId = showId,
             tmdbId = Id<TmdbId>(999),
@@ -185,7 +185,7 @@ internal class DefaultTopRatedShowsDaoTest : BaseDatabaseTest() {
             initialShows.size shouldBe 2
 
             // When - add a new show
-            val showId = seedShow(traktId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
+            val showId = seedShow(showId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
             val newShow = Toprated_shows(
                 show_id = showId,
                 tmdb_id = Id<TmdbId>(999),
@@ -200,15 +200,15 @@ internal class DefaultTopRatedShowsDaoTest : BaseDatabaseTest() {
             // Then - should emit updated list
             val updatedShows = awaitItem()
             updatedShows.size shouldBe 3
-            updatedShows.any { it.traktId == 999L && it.title == "New Reactive Show" } shouldBe true
+            updatedShows.any { it.showId == 999L && it.title == "New Reactive Show" } shouldBe true
 
             cancelAndConsumeRemainingEvents()
         }
     }
 
-    private fun seedShow(traktId: Long, name: String, posterPath: String): Id<ShowId> {
+    private fun seedShow(showId: Long, name: String, posterPath: String): Id<ShowId> {
         val _ = database.tvShowQueries.upsert(
-            tmdb_id = Id<TmdbId>(traktId),
+            tmdb_id = Id<TmdbId>(showId),
             name = name,
             overview = "$name overview",
             language = "en",
@@ -222,7 +222,7 @@ internal class DefaultTopRatedShowsDaoTest : BaseDatabaseTest() {
             poster_path = posterPath,
             backdrop_path = "/new_backdrop.jpg",
         )
-        return showIdForTraktId(traktId)
+        return showIdForTraktId(showId)
     }
 
     private fun insertTestShows() {

--- a/data/trailers/api/src/commonMain/kotlin/com.thomaskioko.tvmaniac.data.trailers.implementation/TrailerDao.kt
+++ b/data/trailers/api/src/commonMain/kotlin/com.thomaskioko.tvmaniac.data.trailers.implementation/TrailerDao.kt
@@ -8,9 +8,9 @@ public interface TrailerDao {
 
     public fun upsert(trailer: Trailers)
 
-    public fun getTrailersByShowTraktId(showTraktId: Long): List<SelectByShowTraktId>
+    public fun getTrailersByShowTraktId(showId: Long): List<SelectByShowTraktId>
 
-    public fun observeTrailersByShowTraktId(showTraktId: Long): Flow<List<SelectByShowTraktId>>
+    public fun observeTrailersByShowTraktId(showId: Long): Flow<List<SelectByShowTraktId>>
 
     public fun delete(id: Long)
 

--- a/data/trailers/api/src/commonMain/kotlin/com.thomaskioko.tvmaniac.data.trailers.implementation/TrailerDao.kt
+++ b/data/trailers/api/src/commonMain/kotlin/com.thomaskioko.tvmaniac.data.trailers.implementation/TrailerDao.kt
@@ -1,6 +1,6 @@
 package com.thomaskioko.tvmaniac.data.trailers.implementation
 
-import com.thomaskioko.tvmaniac.db.SelectByShowTraktId
+import com.thomaskioko.tvmaniac.db.SelectByShowId
 import com.thomaskioko.tvmaniac.db.Trailers
 import kotlinx.coroutines.flow.Flow
 
@@ -8,9 +8,9 @@ public interface TrailerDao {
 
     public fun upsert(trailer: Trailers)
 
-    public fun getTrailersByShowTraktId(showId: Long): List<SelectByShowTraktId>
+    public fun getTrailersByShowId(showId: Long): List<SelectByShowId>
 
-    public fun observeTrailersByShowTraktId(showId: Long): Flow<List<SelectByShowTraktId>>
+    public fun observeTrailersByShowId(showId: Long): Flow<List<SelectByShowId>>
 
     public fun delete(id: Long)
 

--- a/data/trailers/api/src/commonMain/kotlin/com.thomaskioko.tvmaniac.data.trailers.implementation/TrailerRepository.kt
+++ b/data/trailers/api/src/commonMain/kotlin/com.thomaskioko.tvmaniac.data.trailers.implementation/TrailerRepository.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.Flow
 public interface TrailerRepository {
     public fun isYoutubePlayerInstalled(): Flow<Boolean>
 
-    public fun observeTrailers(traktId: Long): Flow<List<SelectByShowTraktId>>
+    public fun observeTrailers(showId: Long): Flow<List<SelectByShowTraktId>>
 
-    public suspend fun fetchTrailers(traktId: Long, forceRefresh: Boolean = false)
+    public suspend fun fetchTrailers(showId: Long, forceRefresh: Boolean = false)
 }

--- a/data/trailers/api/src/commonMain/kotlin/com.thomaskioko.tvmaniac.data.trailers.implementation/TrailerRepository.kt
+++ b/data/trailers/api/src/commonMain/kotlin/com.thomaskioko.tvmaniac.data.trailers.implementation/TrailerRepository.kt
@@ -1,12 +1,12 @@
 package com.thomaskioko.tvmaniac.data.trailers.implementation
 
-import com.thomaskioko.tvmaniac.db.SelectByShowTraktId
+import com.thomaskioko.tvmaniac.db.SelectByShowId
 import kotlinx.coroutines.flow.Flow
 
 public interface TrailerRepository {
     public fun isYoutubePlayerInstalled(): Flow<Boolean>
 
-    public fun observeTrailers(showId: Long): Flow<List<SelectByShowTraktId>>
+    public fun observeTrailers(showId: Long): Flow<List<SelectByShowId>>
 
     public suspend fun fetchTrailers(showId: Long, forceRefresh: Boolean = false)
 }

--- a/data/trailers/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/trailers/implementation/DefaultTrailerDao.kt
+++ b/data/trailers/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/trailers/implementation/DefaultTrailerDao.kt
@@ -34,14 +34,14 @@ public class DefaultTrailerDao(
         )
     }
 
-    override fun getTrailersByShowTraktId(showTraktId: Long): List<SelectByShowTraktId> {
-        val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return emptyList()
-        return database.trailersQueries.selectByShowTraktId(showId).executeAsList()
+    override fun getTrailersByShowTraktId(showId: Long): List<SelectByShowTraktId> {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return emptyList()
+        return database.trailersQueries.selectByShowTraktId(internalShowId).executeAsList()
     }
 
-    override fun observeTrailersByShowTraktId(showTraktId: Long): Flow<List<SelectByShowTraktId>> {
-        val showId = showIdResolver.showIdForTraktId(showTraktId) ?: return flowOf(emptyList())
-        return database.trailersQueries.selectByShowTraktId(showId).asFlow().mapToList(dispatchers.io)
+    override fun observeTrailersByShowTraktId(showId: Long): Flow<List<SelectByShowTraktId>> {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return flowOf(emptyList())
+        return database.trailersQueries.selectByShowTraktId(internalShowId).asFlow().mapToList(dispatchers.io)
     }
 
     override fun delete(id: Long) {

--- a/data/trailers/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/trailers/implementation/DefaultTrailerDao.kt
+++ b/data/trailers/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/trailers/implementation/DefaultTrailerDao.kt
@@ -4,7 +4,7 @@ import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.db.Id
-import com.thomaskioko.tvmaniac.db.SelectByShowTraktId
+import com.thomaskioko.tvmaniac.db.SelectByShowId
 import com.thomaskioko.tvmaniac.db.ShowIdResolver
 import com.thomaskioko.tvmaniac.db.Trailers
 import com.thomaskioko.tvmaniac.db.TvManiacDatabase
@@ -34,14 +34,14 @@ public class DefaultTrailerDao(
         )
     }
 
-    override fun getTrailersByShowTraktId(showId: Long): List<SelectByShowTraktId> {
+    override fun getTrailersByShowId(showId: Long): List<SelectByShowId> {
         val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return emptyList()
-        return database.trailersQueries.selectByShowTraktId(internalShowId).executeAsList()
+        return database.trailersQueries.selectByShowId(internalShowId).executeAsList()
     }
 
-    override fun observeTrailersByShowTraktId(showId: Long): Flow<List<SelectByShowTraktId>> {
+    override fun observeTrailersByShowId(showId: Long): Flow<List<SelectByShowId>> {
         val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return flowOf(emptyList())
-        return database.trailersQueries.selectByShowTraktId(internalShowId).asFlow().mapToList(dispatchers.io)
+        return database.trailersQueries.selectByShowId(internalShowId).asFlow().mapToList(dispatchers.io)
     }
 
     override fun delete(id: Long) {

--- a/data/trailers/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/trailers/implementation/DefaultTrailerRepository.kt
+++ b/data/trailers/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/trailers/implementation/DefaultTrailerRepository.kt
@@ -19,14 +19,14 @@ public class DefaultTrailerRepository(
 
     override fun isYoutubePlayerInstalled(): Flow<Boolean> = appUtils.isYoutubePlayerInstalled()
 
-    override fun observeTrailers(traktId: Long): Flow<List<SelectByShowTraktId>> =
-        trailerDao.observeTrailersByShowTraktId(traktId)
+    override fun observeTrailers(showId: Long): Flow<List<SelectByShowTraktId>> =
+        trailerDao.observeTrailersByShowTraktId(showId)
 
-    override suspend fun fetchTrailers(traktId: Long, forceRefresh: Boolean) {
-        val isEmpty = trailerDao.getTrailersByShowTraktId(traktId).isEmpty()
+    override suspend fun fetchTrailers(showId: Long, forceRefresh: Boolean) {
+        val isEmpty = trailerDao.getTrailersByShowTraktId(showId).isEmpty()
         when {
-            forceRefresh || isEmpty -> trailerStore.fresh(traktId)
-            else -> trailerStore.get(traktId)
+            forceRefresh || isEmpty -> trailerStore.fresh(showId)
+            else -> trailerStore.get(showId)
         }
     }
 }

--- a/data/trailers/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/trailers/implementation/DefaultTrailerRepository.kt
+++ b/data/trailers/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/trailers/implementation/DefaultTrailerRepository.kt
@@ -1,6 +1,6 @@
 package com.thomaskioko.tvmaniac.data.trailers.implementation
 
-import com.thomaskioko.tvmaniac.db.SelectByShowTraktId
+import com.thomaskioko.tvmaniac.db.SelectByShowId
 import com.thomaskioko.tvmaniac.util.api.AppUtils
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
@@ -19,11 +19,11 @@ public class DefaultTrailerRepository(
 
     override fun isYoutubePlayerInstalled(): Flow<Boolean> = appUtils.isYoutubePlayerInstalled()
 
-    override fun observeTrailers(showId: Long): Flow<List<SelectByShowTraktId>> =
-        trailerDao.observeTrailersByShowTraktId(showId)
+    override fun observeTrailers(showId: Long): Flow<List<SelectByShowId>> =
+        trailerDao.observeTrailersByShowId(showId)
 
     override suspend fun fetchTrailers(showId: Long, forceRefresh: Boolean) {
-        val isEmpty = trailerDao.getTrailersByShowTraktId(showId).isEmpty()
+        val isEmpty = trailerDao.getTrailersByShowId(showId).isEmpty()
         when {
             forceRefresh || isEmpty -> trailerStore.fresh(showId)
             else -> trailerStore.get(showId)

--- a/data/trailers/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/trailers/implementation/TrailerStore.kt
+++ b/data/trailers/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/trailers/implementation/TrailerStore.kt
@@ -5,7 +5,7 @@ import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.storeBuilder
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.usingDispatchers
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.getOrThrow
 import com.thomaskioko.tvmaniac.db.DatabaseTransactionRunner
-import com.thomaskioko.tvmaniac.db.SelectByShowTraktId
+import com.thomaskioko.tvmaniac.db.SelectByShowId
 import com.thomaskioko.tvmaniac.db.ShowIdResolver
 import com.thomaskioko.tvmaniac.db.Trailers
 import com.thomaskioko.tvmaniac.resourcemanager.api.RequestManagerRepository
@@ -27,7 +27,7 @@ public class TrailerStore(
     private val requestManagerRepository: RequestManagerRepository,
     private val databaseTransactionRunner: DatabaseTransactionRunner,
     private val dispatchers: AppCoroutineDispatchers,
-) : Store<Long, List<SelectByShowTraktId>> by storeBuilder(
+) : Store<Long, List<SelectByShowId>> by storeBuilder(
     fetcher = Fetcher.of { showId: Long ->
         val videos = traktRemoteDataSource.getShowVideos(showId).getOrThrow()
         requestManagerRepository.upsert(
@@ -36,9 +36,9 @@ public class TrailerStore(
         )
         videos
     },
-    sourceOfTruth = SourceOfTruth.of<Long, List<TraktVideosResponse>, List<SelectByShowTraktId>>(
+    sourceOfTruth = SourceOfTruth.of<Long, List<TraktVideosResponse>, List<SelectByShowId>>(
         reader = { showId: Long ->
-            trailerDao.observeTrailersByShowTraktId(showId)
+            trailerDao.observeTrailersByShowId(showId)
         },
         writer = { showId, videos ->
             databaseTransactionRunner {

--- a/data/trailers/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/trailers/implementation/TrailerStore.kt
+++ b/data/trailers/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/trailers/implementation/TrailerStore.kt
@@ -28,21 +28,21 @@ public class TrailerStore(
     private val databaseTransactionRunner: DatabaseTransactionRunner,
     private val dispatchers: AppCoroutineDispatchers,
 ) : Store<Long, List<SelectByShowTraktId>> by storeBuilder(
-    fetcher = Fetcher.of { traktId: Long ->
-        val videos = traktRemoteDataSource.getShowVideos(traktId).getOrThrow()
+    fetcher = Fetcher.of { showId: Long ->
+        val videos = traktRemoteDataSource.getShowVideos(showId).getOrThrow()
         requestManagerRepository.upsert(
-            entityId = traktId,
+            entityId = showId,
             requestType = TRAILERS.name,
         )
         videos
     },
     sourceOfTruth = SourceOfTruth.of<Long, List<TraktVideosResponse>, List<SelectByShowTraktId>>(
-        reader = { traktId: Long ->
-            trailerDao.observeTrailersByShowTraktId(traktId)
+        reader = { showId: Long ->
+            trailerDao.observeTrailersByShowTraktId(showId)
         },
-        writer = { traktId, videos ->
+        writer = { showId, videos ->
             databaseTransactionRunner {
-                val showId = showIdResolver.showIdForTraktId(traktId)
+                val internalShowId = showIdResolver.showIdForTraktId(showId)
                     ?: return@databaseTransactionRunner
 
                 videos
@@ -52,7 +52,7 @@ public class TrailerStore(
                         trailerDao.upsert(
                             Trailers(
                                 id = youtubeKey,
-                                show_id = showId,
+                                show_id = internalShowId,
                                 youtube_url = video.url,
                                 name = video.title,
                                 site = video.site,
@@ -71,9 +71,9 @@ public class TrailerStore(
 ).validator(
     Validator.by { result ->
         withContext(dispatchers.io) {
-            val traktId = result.firstOrNull()?.show_trakt_id ?: return@withContext false
+            val showId = result.firstOrNull()?.show_trakt_id ?: return@withContext false
             !requestManagerRepository.isRequestExpired(
-                entityId = traktId,
+                entityId = showId,
                 requestType = TRAILERS.name,
                 threshold = TRAILERS.duration,
             )

--- a/data/trailers/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trailers/testing/FakeTrailerRepository.kt
+++ b/data/trailers/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trailers/testing/FakeTrailerRepository.kt
@@ -20,10 +20,10 @@ public class FakeTrailerRepository : TrailerRepository {
         youtubePlayerInstalled.send(installed)
     }
 
-    override fun observeTrailers(traktId: Long): Flow<List<SelectByShowTraktId>> = response.asStateFlow()
+    override fun observeTrailers(showId: Long): Flow<List<SelectByShowTraktId>> = response.asStateFlow()
 
     override fun isYoutubePlayerInstalled(): Flow<Boolean> = youtubePlayerInstalled.receiveAsFlow()
 
-    override suspend fun fetchTrailers(traktId: Long, forceRefresh: Boolean) {
+    override suspend fun fetchTrailers(showId: Long, forceRefresh: Boolean) {
     }
 }

--- a/data/trailers/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trailers/testing/FakeTrailerRepository.kt
+++ b/data/trailers/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trailers/testing/FakeTrailerRepository.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.trailers.testing
 
 import com.thomaskioko.tvmaniac.data.trailers.implementation.TrailerRepository
-import com.thomaskioko.tvmaniac.db.SelectByShowTraktId
+import com.thomaskioko.tvmaniac.db.SelectByShowId
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -10,9 +10,9 @@ import kotlinx.coroutines.flow.receiveAsFlow
 
 public class FakeTrailerRepository : TrailerRepository {
     private val youtubePlayerInstalled = Channel<Boolean>(Channel.UNLIMITED)
-    private var response = MutableStateFlow<List<SelectByShowTraktId>>(emptyList())
+    private var response = MutableStateFlow<List<SelectByShowId>>(emptyList())
 
-    public suspend fun setTrailerResult(result: List<SelectByShowTraktId>) {
+    public suspend fun setTrailerResult(result: List<SelectByShowId>) {
         response.emit(result)
     }
 
@@ -20,7 +20,7 @@ public class FakeTrailerRepository : TrailerRepository {
         youtubePlayerInstalled.send(installed)
     }
 
-    override fun observeTrailers(showId: Long): Flow<List<SelectByShowTraktId>> = response.asStateFlow()
+    override fun observeTrailers(showId: Long): Flow<List<SelectByShowId>> = response.asStateFlow()
 
     override fun isYoutubePlayerInstalled(): Flow<Boolean> = youtubePlayerInstalled.receiveAsFlow()
 

--- a/data/trailers/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trailers/testing/MockData.kt
+++ b/data/trailers/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trailers/testing/MockData.kt
@@ -1,10 +1,10 @@
 package com.thomaskioko.tvmaniac.trailers.testing
 
 import com.thomaskioko.tvmaniac.db.Id
-import com.thomaskioko.tvmaniac.db.SelectByShowTraktId
+import com.thomaskioko.tvmaniac.db.SelectByShowId
 
-public val trailers: List<SelectByShowTraktId> = listOf(
-    SelectByShowTraktId(
+public val trailers: List<SelectByShowId> = listOf(
+    SelectByShowId(
         trailer_id = "Fd43V",
         show_tmdb_id = Id(84958),
         show_trakt_id = 84958L,

--- a/data/traktlists/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/api/TraktListRepository.kt
+++ b/data/traktlists/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/api/TraktListRepository.kt
@@ -6,11 +6,11 @@ public interface TraktListRepository {
 
     public fun observeLists(): Flow<List<TraktListEntity>>
 
-    public fun observeListsForShow(traktShowId: Long): Flow<List<TraktList>>
+    public fun observeListsForShow(showId: Long): Flow<List<TraktList>>
 
     public suspend fun fetchUserLists(slug: String, forceRefresh: Boolean = false)
 
     public suspend fun createList(slug: String, name: String)
 
-    public suspend fun toggleShowInList(slug: String, listId: Long, traktShowId: Long, isCurrentlyInList: Boolean)
+    public suspend fun toggleShowInList(slug: String, listId: Long, showId: Long, isCurrentlyInList: Boolean)
 }

--- a/data/traktlists/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/api/TraktListShowDao.kt
+++ b/data/traktlists/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/api/TraktListShowDao.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.flow.Flow
 
 public interface TraktListShowDao {
 
-    public fun observeByShowTraktId(showId: Long): Flow<List<TraktListShowEntry>>
+    public fun observeByShowId(showId: Long): Flow<List<TraktListShowEntry>>
 
     public fun observeActiveCountByListId(): Flow<Map<Long, Long>>
 

--- a/data/traktlists/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/api/TraktListShowDao.kt
+++ b/data/traktlists/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/api/TraktListShowDao.kt
@@ -4,17 +4,17 @@ import kotlinx.coroutines.flow.Flow
 
 public interface TraktListShowDao {
 
-    public fun observeByShowTraktId(showTraktId: Long): Flow<List<TraktListShowEntry>>
+    public fun observeByShowTraktId(showId: Long): Flow<List<TraktListShowEntry>>
 
     public fun observeActiveCountByListId(): Flow<Map<Long, Long>>
 
-    public fun upsert(listId: Long, showTraktId: Long, listedAt: String, pendingAction: String)
+    public fun upsert(listId: Long, showId: Long, listedAt: String, pendingAction: String)
 
-    public fun upsertSynced(listId: Long, showTraktId: Long, listedAt: String)
+    public fun upsertSynced(listId: Long, showId: Long, listedAt: String)
 
     public fun deleteSyncedByListId(listId: Long)
 
-    public fun updatePendingAction(listId: Long, showTraktId: Long, pendingAction: String)
+    public fun updatePendingAction(listId: Long, showId: Long, pendingAction: String)
 
-    public fun deleteByListIdAndShowId(listId: Long, showTraktId: Long)
+    public fun deleteByListIdAndShowId(listId: Long, showId: Long)
 }

--- a/data/traktlists/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/api/TraktListShowEntry.kt
+++ b/data/traktlists/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/api/TraktListShowEntry.kt
@@ -2,7 +2,7 @@ package com.thomaskioko.tvmaniac.traktlists.api
 
 public data class TraktListShowEntry(
     val listId: Long,
-    val showTraktId: Long,
+    val showId: Long,
     val listedAt: String,
     val pendingAction: String,
 )

--- a/data/traktlists/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/DefaultTraktListRepository.kt
+++ b/data/traktlists/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/DefaultTraktListRepository.kt
@@ -38,7 +38,7 @@ public class DefaultTraktListRepository(
     override fun observeListsForShow(showId: Long): Flow<List<TraktList>> =
         combine(
             traktListDao.observeAll(),
-            traktListShowDao.observeByShowTraktId(showId),
+            traktListShowDao.observeByShowId(showId),
             traktListShowDao.observeActiveCountByListId(),
         ) { lists, showEntries, activeCounts ->
             val activeEntryListIds = showEntries

--- a/data/traktlists/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/DefaultTraktListRepository.kt
+++ b/data/traktlists/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/DefaultTraktListRepository.kt
@@ -35,10 +35,10 @@ public class DefaultTraktListRepository(
     override fun observeLists(): Flow<List<TraktListEntity>> =
         traktListDao.observeListsWithPosters().distinctUntilChanged()
 
-    override fun observeListsForShow(traktShowId: Long): Flow<List<TraktList>> =
+    override fun observeListsForShow(showId: Long): Flow<List<TraktList>> =
         combine(
             traktListDao.observeAll(),
-            traktListShowDao.observeByShowTraktId(traktShowId),
+            traktListShowDao.observeByShowTraktId(showId),
             traktListShowDao.observeActiveCountByListId(),
         ) { lists, showEntries, activeCounts ->
             val activeEntryListIds = showEntries
@@ -86,25 +86,25 @@ public class DefaultTraktListRepository(
         createTraktListStore.fresh(key = CreateTraktListParams(slug = slug, name = name))
     }
 
-    override suspend fun toggleShowInList(slug: String, listId: Long, traktShowId: Long, isCurrentlyInList: Boolean) {
+    override suspend fun toggleShowInList(slug: String, listId: Long, showId: Long, isCurrentlyInList: Boolean) {
         withContext(dispatchers.io) {
             if (isCurrentlyInList) {
                 traktListShowDao.updatePendingAction(
                     listId = listId,
-                    showTraktId = traktShowId,
+                    showId = showId,
                     pendingAction = PendingAction.DELETE.value,
                 )
-                when (traktListRemoteDataSource.removeShowFromList(slug, listId, traktShowId)) {
+                when (traktListRemoteDataSource.removeShowFromList(slug, listId, showId)) {
                     is ApiResponse.Success -> {
                         traktListShowDao.deleteByListIdAndShowId(
                             listId = listId,
-                            showTraktId = traktShowId,
+                            showId = showId,
                         )
                     }
                     else -> {
                         traktListShowDao.updatePendingAction(
                             listId = listId,
-                            showTraktId = traktShowId,
+                            showId = showId,
                             pendingAction = PendingAction.NOTHING.value,
                         )
                     }
@@ -112,22 +112,22 @@ public class DefaultTraktListRepository(
             } else {
                 traktListShowDao.upsert(
                     listId = listId,
-                    showTraktId = traktShowId,
+                    showId = showId,
                     listedAt = "",
                     pendingAction = PendingAction.UPLOAD.value,
                 )
-                when (traktListRemoteDataSource.addShowToList(slug, listId, traktShowId)) {
+                when (traktListRemoteDataSource.addShowToList(slug, listId, showId)) {
                     is ApiResponse.Success -> {
                         traktListShowDao.updatePendingAction(
                             listId = listId,
-                            showTraktId = traktShowId,
+                            showId = showId,
                             pendingAction = PendingAction.NOTHING.value,
                         )
                     }
                     else -> {
                         traktListShowDao.deleteByListIdAndShowId(
                             listId = listId,
-                            showTraktId = traktShowId,
+                            showId = showId,
                         )
                     }
                 }

--- a/data/traktlists/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/DefaultTraktListShowDao.kt
+++ b/data/traktlists/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/DefaultTraktListShowDao.kt
@@ -25,7 +25,7 @@ public class DefaultTraktListShowDao(
             .mapToList(dispatchers.io)
             .map { rows -> rows.associate { it.list_id to it.show_count } }
 
-    override fun observeByShowTraktId(showId: Long): Flow<List<TraktListShowEntry>> =
+    override fun observeByShowId(showId: Long): Flow<List<TraktListShowEntry>> =
         database.traktListShowsQueries.selectByShowTraktId(showId)
             .asFlow()
             .mapToList(dispatchers.io)

--- a/data/traktlists/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/DefaultTraktListShowDao.kt
+++ b/data/traktlists/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/DefaultTraktListShowDao.kt
@@ -25,34 +25,34 @@ public class DefaultTraktListShowDao(
             .mapToList(dispatchers.io)
             .map { rows -> rows.associate { it.list_id to it.show_count } }
 
-    override fun observeByShowTraktId(showTraktId: Long): Flow<List<TraktListShowEntry>> =
-        database.traktListShowsQueries.selectByShowTraktId(showTraktId)
+    override fun observeByShowTraktId(showId: Long): Flow<List<TraktListShowEntry>> =
+        database.traktListShowsQueries.selectByShowTraktId(showId)
             .asFlow()
             .mapToList(dispatchers.io)
             .map { rows ->
                 rows.map { row ->
                     TraktListShowEntry(
                         listId = row.list_id,
-                        showTraktId = row.show_trakt_id,
+                        showId = row.show_trakt_id,
                         listedAt = row.listed_at,
                         pendingAction = row.pending_action,
                     )
                 }
             }
 
-    override fun upsert(listId: Long, showTraktId: Long, listedAt: String, pendingAction: String) {
+    override fun upsert(listId: Long, showId: Long, listedAt: String, pendingAction: String) {
         database.traktListShowsQueries.upsert(
             list_id = listId,
-            show_trakt_id = showTraktId,
+            show_trakt_id = showId,
             listed_at = listedAt,
             pending_action = pendingAction,
         )
     }
 
-    override fun upsertSynced(listId: Long, showTraktId: Long, listedAt: String) {
+    override fun upsertSynced(listId: Long, showId: Long, listedAt: String) {
         database.traktListShowsQueries.upsertSynced(
             list_id = listId,
-            show_trakt_id = showTraktId,
+            show_trakt_id = showId,
             listed_at = listedAt,
         )
     }
@@ -61,18 +61,18 @@ public class DefaultTraktListShowDao(
         database.traktListShowsQueries.deleteSyncedByListId(list_id = listId)
     }
 
-    override fun updatePendingAction(listId: Long, showTraktId: Long, pendingAction: String) {
+    override fun updatePendingAction(listId: Long, showId: Long, pendingAction: String) {
         database.traktListShowsQueries.updatePendingAction(
             pending_action = pendingAction,
             list_id = listId,
-            show_trakt_id = showTraktId,
+            show_trakt_id = showId,
         )
     }
 
-    override fun deleteByListIdAndShowId(listId: Long, showTraktId: Long) {
+    override fun deleteByListIdAndShowId(listId: Long, showId: Long) {
         database.traktListShowsQueries.deleteByListIdAndShowId(
             list_id = listId,
-            show_trakt_id = showTraktId,
+            show_trakt_id = showId,
         )
     }
 }

--- a/data/traktlists/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/TraktListItemsStore.kt
+++ b/data/traktlists/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/TraktListItemsStore.kt
@@ -46,7 +46,7 @@ public class TraktListItemsStore(
                     if (item.type == TYPE_SHOW && show != null) {
                         traktListShowDao.upsertSynced(
                             listId = key.listId,
-                            showTraktId = show.ids.trakt,
+                            showId = show.ids.trakt,
                             listedAt = item.listedAt,
                         )
                     }

--- a/data/traktlists/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/DefaultTraktListRepositoryTest.kt
+++ b/data/traktlists/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/DefaultTraktListRepositoryTest.kt
@@ -122,7 +122,7 @@ internal class DefaultTraktListRepositoryTest : BaseDatabaseTest() {
 
         repository.fetchUserLists(slug = "sean", forceRefresh = true)
 
-        val entries = showDao.observeByShowTraktId(99L).first()
+        val entries = showDao.observeByShowId(99L).first()
         entries.size shouldBe 1
         entries[0].pendingAction shouldBe PendingAction.UPLOAD.value
         val counts = showDao.observeActiveCountByListId().first()
@@ -147,7 +147,7 @@ internal class DefaultTraktListRepositoryTest : BaseDatabaseTest() {
 
         repository.fetchUserLists(slug = "sean", forceRefresh = true)
 
-        val entries = showDao.observeByShowTraktId(20L).first()
+        val entries = showDao.observeByShowId(20L).first()
         entries.size shouldBe 1
         entries[0].pendingAction shouldBe PendingAction.DELETE.value
         val counts = showDao.observeActiveCountByListId().first()

--- a/data/traktlists/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/DefaultTraktListRepositoryTest.kt
+++ b/data/traktlists/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/DefaultTraktListRepositoryTest.kt
@@ -278,19 +278,19 @@ private class FakeRemoteDataSource : TraktListRemoteDataSource {
         tmdbId: Long,
     ): ApiResponse<TraktAddRemoveShowFromListResponse> = error("not used")
 
-    override suspend fun addShowToWatchListByTraktId(
+    override suspend fun addShowToWatchListById(
         showId: Long,
     ): ApiResponse<TraktAddShowToListResponse> = error("not used")
 
-    override suspend fun removeShowFromWatchListByTraktId(
+    override suspend fun removeShowFromWatchListById(
         showId: Long,
     ): ApiResponse<TraktAddRemoveShowFromListResponse> = error("not used")
 
-    override suspend fun addShowsToWatchListByTraktIds(
+    override suspend fun addShowsToWatchListByIds(
         showIds: List<Long>,
     ): ApiResponse<TraktAddShowToListResponse> = error("not used")
 
-    override suspend fun removeShowsFromWatchListByTraktIds(
+    override suspend fun removeShowsFromWatchListByIds(
         showIds: List<Long>,
     ): ApiResponse<TraktAddRemoveShowFromListResponse> = error("not used")
 

--- a/data/traktlists/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/DefaultTraktListRepositoryTest.kt
+++ b/data/traktlists/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/DefaultTraktListRepositoryTest.kt
@@ -96,8 +96,8 @@ internal class DefaultTraktListRepositoryTest : BaseDatabaseTest() {
         remoteDataSource.lists = listOf(traktListResponse(id = 1L, slug = "watchlist", itemCount = 2))
         remoteDataSource.itemsByListId = mapOf(
             1L to listOf(
-                traktListItemResponse(traktId = 10L),
-                traktListItemResponse(traktId = 20L),
+                traktListItemResponse(showId = 10L),
+                traktListItemResponse(showId = 20L),
             ),
         )
 
@@ -111,11 +111,11 @@ internal class DefaultTraktListRepositoryTest : BaseDatabaseTest() {
     fun `should preserve pending UPLOAD rows given items sync replaces synced rows`() = runTest {
         remoteDataSource.lists = listOf(traktListResponse(id = 1L, slug = "watchlist", itemCount = 1))
         remoteDataSource.itemsByListId = mapOf(
-            1L to listOf(traktListItemResponse(traktId = 10L)),
+            1L to listOf(traktListItemResponse(showId = 10L)),
         )
         showDao.upsert(
             listId = 1L,
-            showTraktId = 99L,
+            showId = 99L,
             listedAt = "",
             pendingAction = PendingAction.UPLOAD.value,
         )
@@ -134,13 +134,13 @@ internal class DefaultTraktListRepositoryTest : BaseDatabaseTest() {
         remoteDataSource.lists = listOf(traktListResponse(id = 1L, slug = "watchlist", itemCount = 2))
         remoteDataSource.itemsByListId = mapOf(
             1L to listOf(
-                traktListItemResponse(traktId = 10L),
-                traktListItemResponse(traktId = 20L),
+                traktListItemResponse(showId = 10L),
+                traktListItemResponse(showId = 20L),
             ),
         )
         showDao.upsert(
             listId = 1L,
-            showTraktId = 20L,
+            showId = 20L,
             listedAt = "",
             pendingAction = PendingAction.DELETE.value,
         )
@@ -162,16 +162,16 @@ internal class DefaultTraktListRepositoryTest : BaseDatabaseTest() {
         )
         remoteDataSource.itemsByListId = mapOf(
             1L to listOf(
-                traktListItemResponse(traktId = 10L),
-                traktListItemResponse(traktId = 20L),
-                traktListItemResponse(traktId = 30L),
+                traktListItemResponse(showId = 10L),
+                traktListItemResponse(showId = 20L),
+                traktListItemResponse(showId = 30L),
             ),
-            2L to listOf(traktListItemResponse(traktId = 10L)),
+            2L to listOf(traktListItemResponse(showId = 10L)),
         )
 
         repository.fetchUserLists(slug = "sean", forceRefresh = true)
 
-        val lists = repository.observeListsForShow(traktShowId = 10L).first()
+        val lists = repository.observeListsForShow(showId = 10L).first()
         lists.map { it.id to it.itemCount } shouldContainExactlyInAnyOrder listOf(
             1L to 3L,
             2L to 1L,
@@ -230,13 +230,13 @@ internal class DefaultTraktListRepositoryTest : BaseDatabaseTest() {
             updated_at = "2024-01-01T00:00:00.000Z",
         )
 
-    private fun traktListItemResponse(traktId: Long) = TraktListItemResponse(
+    private fun traktListItemResponse(showId: Long) = TraktListItemResponse(
         listedAt = "2024-01-01T00:00:00.000Z",
         type = "show",
         show = ShowResponse(
-            title = "Show $traktId",
+            title = "Show $showId",
             year = 2024,
-            ids = IdsResponse(slug = "show-$traktId", trakt = traktId, tmdb = traktId),
+            ids = IdsResponse(slug = "show-$showId", trakt = showId, tmdb = showId),
         ),
     )
 }
@@ -279,30 +279,30 @@ private class FakeRemoteDataSource : TraktListRemoteDataSource {
     ): ApiResponse<TraktAddRemoveShowFromListResponse> = error("not used")
 
     override suspend fun addShowToWatchListByTraktId(
-        traktId: Long,
+        showId: Long,
     ): ApiResponse<TraktAddShowToListResponse> = error("not used")
 
     override suspend fun removeShowFromWatchListByTraktId(
-        traktId: Long,
+        showId: Long,
     ): ApiResponse<TraktAddRemoveShowFromListResponse> = error("not used")
 
     override suspend fun addShowsToWatchListByTraktIds(
-        traktIds: List<Long>,
+        showIds: List<Long>,
     ): ApiResponse<TraktAddShowToListResponse> = error("not used")
 
     override suspend fun removeShowsFromWatchListByTraktIds(
-        traktIds: List<Long>,
+        showIds: List<Long>,
     ): ApiResponse<TraktAddRemoveShowFromListResponse> = error("not used")
 
     override suspend fun addShowToList(
         userSlug: String,
         listId: Long,
-        traktShowId: Long,
+        showId: Long,
     ): ApiResponse<TraktAddShowToListResponse> = error("not used")
 
     override suspend fun removeShowFromList(
         userSlug: String,
         listId: Long,
-        traktShowId: Long,
+        showId: Long,
     ): ApiResponse<TraktAddRemoveShowFromListResponse> = error("not used")
 }

--- a/data/traktlists/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/testing/FakeTraktListRepository.kt
+++ b/data/traktlists/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/testing/FakeTraktListRepository.kt
@@ -45,7 +45,7 @@ public class FakeTraktListRepository : TraktListRepository {
 
     override fun observeLists(): Flow<List<TraktListEntity>> = listsFlow.asStateFlow()
 
-    override fun observeListsForShow(traktShowId: Long): Flow<List<TraktList>> =
+    override fun observeListsForShow(showId: Long): Flow<List<TraktList>> =
         listsWithMembershipFlow.asStateFlow()
 
     override suspend fun fetchUserLists(slug: String, forceRefresh: Boolean) {
@@ -56,7 +56,7 @@ public class FakeTraktListRepository : TraktListRepository {
     override suspend fun createList(slug: String, name: String) {
     }
 
-    override suspend fun toggleShowInList(slug: String, listId: Long, traktShowId: Long, isCurrentlyInList: Boolean) {
+    override suspend fun toggleShowInList(slug: String, listId: Long, showId: Long, isCurrentlyInList: Boolean) {
         toggleShowInListInvocations += 1
         toggleGate?.await()
     }

--- a/data/trendingshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/implementation/DefaultTrendingShowsDao.kt
+++ b/data/trendingshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/implementation/DefaultTrendingShowsDao.kt
@@ -49,9 +49,9 @@ public class DefaultTrendingShowsDao(
                 trendingShowsQueries.pagedTrendingShows(
                     limit = limit,
                     offset = offset,
-                ) { traktId, tmdbId, page, title, imageUrl, inLib ->
+                ) { showId, tmdbId, page, title, imageUrl, inLib ->
                     ShowEntity(
-                        traktId = traktId,
+                        showId = showId,
                         tmdbId = tmdbId.id,
                         page = page.id,
                         title = title,
@@ -77,9 +77,9 @@ public class DefaultTrendingShowsDao(
 
     override fun observeTrendingShows(page: Long): Flow<List<ShowEntity>> =
         trendingShowsQueries
-            .entriesInPage(Id(page)) { traktId, tmdbId, pageId, name, posterPath, overview, inLibrary ->
+            .entriesInPage(Id(page)) { showId, tmdbId, pageId, name, posterPath, overview, inLibrary ->
                 ShowEntity(
-                    traktId = traktId,
+                    showId = showId,
                     tmdbId = tmdbId.id,
                     page = pageId.id,
                     title = name,

--- a/data/trendingshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/implementation/TrendingShowsStore.kt
+++ b/data/trendingshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/implementation/TrendingShowsStore.kt
@@ -90,7 +90,7 @@ public class TrendingShowsStore(
 
                     response.forEach { showWithImages ->
                         val show = showWithImages.traktShow.show
-                        val traktId = show.ids.trakt
+                        val showId = show.ids.trakt
                         val tmdbId = showWithImages.tmdbId
                         val posterPath = showWithImages.tmdbPosterPath?.let {
                             formatterUtil.formatTmdbPosterPath(it)
@@ -99,13 +99,13 @@ public class TrendingShowsStore(
                             formatterUtil.formatTmdbPosterPath(it)
                         }
 
-                        tvShowsDao.upsertMerging(show.toTvShow(traktId, tmdbId, posterPath, backdropPath, dateTimeProvider))
+                        tvShowsDao.upsertMerging(show.toTvShow(showId, tmdbId, posterPath, backdropPath, dateTimeProvider))
 
-                        val showId = showIdResolver.showIdForTraktId(traktId) ?: return@forEach
+                        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@forEach
 
                         trendingShowsDao.upsert(
                             Trending_shows(
-                                show_id = showId,
+                                show_id = internalShowId,
                                 tmdb_id = Id(tmdbId),
                                 page = Id(params.page),
                                 position = showWithImages.pageOrder.toLong(),
@@ -136,13 +136,13 @@ public class TrendingShowsStore(
 ).build()
 
 private fun TraktShowResponse.toTvShow(
-    traktId: Long,
+    showId: Long,
     tmdbId: Long,
     posterPath: String?,
     backdropPath: String?,
     dateTimeProvider: DateTimeProvider,
 ): ShowToPersist = ShowToPersist(
-    traktId = Id(traktId),
+    showId = Id(showId),
     tmdbId = Id(tmdbId),
     name = title,
     overview = overview ?: "",

--- a/data/trendingshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/discover/implementation/DefaultTrendingShowsDaoTest.kt
+++ b/data/trendingshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/discover/implementation/DefaultTrendingShowsDaoTest.kt
@@ -55,7 +55,7 @@ internal class DefaultTrendingShowsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `should insert trending shows`() = runTest {
-        val showId = seedShow(traktId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
+        val showId = seedShow(showId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
 
         val trendingShow = Trending_shows(
             show_id = showId,
@@ -72,7 +72,7 @@ internal class DefaultTrendingShowsDaoTest : BaseDatabaseTest() {
         dao.observeTrendingShows(page = 1).test {
             val shows = awaitItem()
             shows.size shouldBe 3
-            shows.any { it.traktId == 999L } shouldBe true
+            shows.any { it.showId == 999L } shouldBe true
             cancelAndConsumeRemainingEvents()
         }
     }
@@ -83,13 +83,13 @@ internal class DefaultTrendingShowsDaoTest : BaseDatabaseTest() {
             val shows = awaitItem()
             shows.size shouldBe 2
 
-            val show1 = shows.find { it.traktId == 1L }
+            val show1 = shows.find { it.showId == 1L }
             show1?.title shouldBe "Test Show 1"
             show1?.posterPath shouldBe "/test1.jpg"
             show1?.overview shouldBe "Test overview 1"
             show1?.inLibrary shouldBe false
 
-            val show2 = shows.find { it.traktId == 2L }
+            val show2 = shows.find { it.showId == 2L }
             show2?.title shouldBe "Test Show 2"
             show2?.posterPath shouldBe "/test2.jpg"
             show2?.overview shouldBe "Test overview 2"
@@ -102,7 +102,7 @@ internal class DefaultTrendingShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `stable query should not return shows with null names`() = runTest {
         // Given - insert a show without name (simulating pre-migration data)
-        val showId = seedShow(traktId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
+        val showId = seedShow(showId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
         val _ = trendingShowsQueries.insert(
             showId = showId,
             tmdbId = Id<TmdbId>(999),
@@ -117,7 +117,7 @@ internal class DefaultTrendingShowsDaoTest : BaseDatabaseTest() {
         dao.observeTrendingShows(page = 1).test {
             val shows = awaitItem()
             shows.size shouldBe 2
-            shows.none { it.traktId == 999L } shouldBe true
+            shows.none { it.showId == 999L } shouldBe true
             cancelAndConsumeRemainingEvents()
         }
     }
@@ -125,7 +125,7 @@ internal class DefaultTrendingShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `stable query should filter by page correctly`() = runTest {
         // Given - add shows to different pages
-        val showId = seedShow(traktId = 999, name = "Page 2 Show", posterPath = "/page2.jpg")
+        val showId = seedShow(showId = 999, name = "Page 2 Show", posterPath = "/page2.jpg")
         val _ = trendingShowsQueries.insert(
             showId = showId,
             tmdbId = Id<TmdbId>(999),
@@ -184,7 +184,7 @@ internal class DefaultTrendingShowsDaoTest : BaseDatabaseTest() {
             initialShows.size shouldBe 2
 
             // When - add a new show
-            val showId = seedShow(traktId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
+            val showId = seedShow(showId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
             val newShow = Trending_shows(
                 show_id = showId,
                 tmdb_id = Id<TmdbId>(999),
@@ -199,7 +199,7 @@ internal class DefaultTrendingShowsDaoTest : BaseDatabaseTest() {
             // Then - should emit updated list
             val updatedShows = awaitItem()
             updatedShows.size shouldBe 3
-            updatedShows.any { it.traktId == 999L && it.title == "New Reactive Show" } shouldBe true
+            updatedShows.any { it.showId == 999L && it.title == "New Reactive Show" } shouldBe true
 
             cancelAndConsumeRemainingEvents()
         }
@@ -218,7 +218,7 @@ internal class DefaultTrendingShowsDaoTest : BaseDatabaseTest() {
             // Then
             val updatedShows = awaitItem()
             updatedShows.size shouldBe 1
-            updatedShows.none { it.traktId == 1L } shouldBe true
+            updatedShows.none { it.showId == 1L } shouldBe true
 
             cancelAndConsumeRemainingEvents()
         }
@@ -245,7 +245,7 @@ internal class DefaultTrendingShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `stable query should handle COALESCE for empty names correctly`() = runTest {
         // Given - manually insert entry with empty string name to test COALESCE
-        val showId = seedShow(traktId = 888, name = "Empty Name Show", posterPath = "/empty.jpg")
+        val showId = seedShow(showId = 888, name = "Empty Name Show", posterPath = "/empty.jpg")
         database.trendingShowsQueries.transaction {
             // Insert with empty name directly
             val _ = database.trendingShowsQueries.insert(
@@ -263,15 +263,15 @@ internal class DefaultTrendingShowsDaoTest : BaseDatabaseTest() {
         dao.observeTrendingShows(page = 1).test {
             val shows = awaitItem()
             // Should include the show with empty name due to COALESCE
-            val emptyNameShow = shows.find { it.traktId == 888L }
+            val emptyNameShow = shows.find { it.showId == 888L }
             emptyNameShow?.title shouldBe "" // COALESCE should return empty string
             cancelAndConsumeRemainingEvents()
         }
     }
 
-    private fun seedShow(traktId: Long, name: String, posterPath: String): Id<ShowId> {
+    private fun seedShow(showId: Long, name: String, posterPath: String): Id<ShowId> {
         val _ = database.tvShowQueries.upsert(
-            tmdb_id = Id<TmdbId>(traktId),
+            tmdb_id = Id<TmdbId>(showId),
             name = name,
             overview = "$name overview",
             language = "en",
@@ -285,7 +285,7 @@ internal class DefaultTrendingShowsDaoTest : BaseDatabaseTest() {
             poster_path = posterPath,
             backdrop_path = "/new_backdrop.jpg",
         )
-        return showIdForTraktId(traktId)
+        return showIdForTraktId(showId)
     }
 
     private fun insertTestShows() {

--- a/data/upcomingshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/upcomingshows/implementation/DefaultUpcomingShowsDao.kt
+++ b/data/upcomingshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/upcomingshows/implementation/DefaultUpcomingShowsDao.kt
@@ -41,9 +41,9 @@ public class DefaultUpcomingShowsDao(
 
     override fun observeUpcomingShows(page: Long): Flow<List<ShowEntity>> =
         upcomingShowsQueries
-            .entriesInPage(Id(page)) { traktId, tmdbId, pageId, name, posterPath, overview, inLibrary ->
+            .entriesInPage(Id(page)) { showId, tmdbId, pageId, name, posterPath, overview, inLibrary ->
                 ShowEntity(
-                    traktId = traktId,
+                    showId = showId,
                     tmdbId = tmdbId.id,
                     page = pageId.id,
                     title = name,
@@ -64,9 +64,9 @@ public class DefaultUpcomingShowsDao(
                 upcomingShowsQueries.pagedUpcomingShows(
                     limit = limit,
                     offset = offset,
-                ) { traktId, tmdbId, page, title, imageUrl, inLib ->
+                ) { showId, tmdbId, page, title, imageUrl, inLib ->
                     ShowEntity(
-                        traktId = traktId,
+                        showId = showId,
                         tmdbId = tmdbId.id,
                         page = page.id,
                         title = title,

--- a/data/upcomingshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/upcomingshows/implementation/UpcomingShowsStore.kt
+++ b/data/upcomingshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/upcomingshows/implementation/UpcomingShowsStore.kt
@@ -92,16 +92,16 @@ public class UpcomingShowsStore(
 
                     response.forEachIndexed { index, result ->
                         val traktShow = result.traktShow ?: return@forEachIndexed
-                        val traktId = traktShow.ids.trakt
+                        val showId = traktShow.ids.trakt
                         val tmdbId = result.tmdbShow.id.toLong()
 
-                        tvShowsDao.upsertMerging(result.toTvshow(traktId, tmdbId, formatterUtil, dateTimeProvider))
+                        tvShowsDao.upsertMerging(result.toTvshow(showId, tmdbId, formatterUtil, dateTimeProvider))
 
-                        val showId = showIdResolver.showIdForTraktId(traktId) ?: return@forEachIndexed
+                        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return@forEachIndexed
 
                         upcomingShowsDao.upsert(
                             Upcoming_shows(
-                                show_id = showId,
+                                show_id = internalShowId,
                                 tmdb_id = Id(tmdbId),
                                 page = Id(params.page),
                                 name = result.tmdbShow.name,
@@ -130,7 +130,7 @@ public class UpcomingShowsStore(
 ).build()
 
 private fun UpcomingShowResult.toTvshow(
-    traktId: Long,
+    showId: Long,
     tmdbId: Long,
     formatterUtil: FormatterUtil,
     dateTimeProvider: DateTimeProvider,
@@ -139,7 +139,7 @@ private fun UpcomingShowResult.toTvshow(
     val trakt = traktShow
     val dateString = tmdb.firstAirDate ?: trakt?.firstAirDate
     return ShowToPersist(
-        traktId = Id(traktId),
+        showId = Id(showId),
         tmdbId = Id(tmdbId),
         name = tmdb.name,
         overview = tmdb.overview,

--- a/data/upcomingshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/upcomingshows/implementation/DefaultUpcomingShowsDaoTest.kt
+++ b/data/upcomingshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/upcomingshows/implementation/DefaultUpcomingShowsDaoTest.kt
@@ -56,7 +56,7 @@ internal class DefaultUpcomingShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `should insert upcoming shows`() = runTest {
         // Given - first insert a show into tvshow table
-        val showId = seedShow(traktId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
+        val showId = seedShow(showId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
 
         val upcomingShow = Upcoming_shows(
             show_id = showId,
@@ -75,7 +75,7 @@ internal class DefaultUpcomingShowsDaoTest : BaseDatabaseTest() {
         dao.observeUpcomingShows(page = 1).test {
             val shows = awaitItem()
             shows.size shouldBe 3
-            shows.any { it.traktId == 999L } shouldBe true
+            shows.any { it.showId == 999L } shouldBe true
             cancelAndConsumeRemainingEvents()
         }
     }
@@ -90,13 +90,13 @@ internal class DefaultUpcomingShowsDaoTest : BaseDatabaseTest() {
             shows.size shouldBe 2
 
             // Verify show data is correctly returned from stable query
-            val show1 = shows.find { it.traktId == 1L }
+            val show1 = shows.find { it.showId == 1L }
             show1?.title shouldBe "Test Show 1"
             show1?.posterPath shouldBe "/test1.jpg"
             show1?.overview shouldBe "Test overview 1"
             show1?.inLibrary shouldBe false // Always false from stable query
 
-            val show2 = shows.find { it.traktId == 2L }
+            val show2 = shows.find { it.showId == 2L }
             show2?.title shouldBe "Test Show 2"
             show2?.posterPath shouldBe "/test2.jpg"
             show2?.overview shouldBe "Test overview 2"
@@ -109,7 +109,7 @@ internal class DefaultUpcomingShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `stable query should not return shows with null names`() = runTest {
         // Given - insert a show without name (simulating pre-migration data)
-        val showId = seedShow(traktId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
+        val showId = seedShow(showId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
         val _ = upcomingShowsQueries.insert(
             showId = showId,
             tmdbId = Id<TmdbId>(999),
@@ -125,7 +125,7 @@ internal class DefaultUpcomingShowsDaoTest : BaseDatabaseTest() {
             val shows = awaitItem()
             // Should only return shows with non-null names (the 2 from setup)
             shows.size shouldBe 2
-            shows.none { it.traktId == 999L } shouldBe true
+            shows.none { it.showId == 999L } shouldBe true
             cancelAndConsumeRemainingEvents()
         }
     }
@@ -133,7 +133,7 @@ internal class DefaultUpcomingShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `stable query should filter by page correctly`() = runTest {
         // Given - add shows to different pages
-        val showId = seedShow(traktId = 999, name = "Page 2 Show", posterPath = "/page2.jpg")
+        val showId = seedShow(showId = 999, name = "Page 2 Show", posterPath = "/page2.jpg")
         val _ = upcomingShowsQueries.insert(
             showId = showId,
             tmdbId = Id<TmdbId>(999),
@@ -192,7 +192,7 @@ internal class DefaultUpcomingShowsDaoTest : BaseDatabaseTest() {
             initialShows.size shouldBe 2
 
             // When - add a new show
-            val showId = seedShow(traktId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
+            val showId = seedShow(showId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
             val newShow = Upcoming_shows(
                 show_id = showId,
                 tmdb_id = Id<TmdbId>(999),
@@ -207,7 +207,7 @@ internal class DefaultUpcomingShowsDaoTest : BaseDatabaseTest() {
             // Then - should emit updated list
             val updatedShows = awaitItem()
             updatedShows.size shouldBe 3
-            updatedShows.any { it.traktId == 999L && it.title == "New Reactive Show" } shouldBe true
+            updatedShows.any { it.showId == 999L && it.title == "New Reactive Show" } shouldBe true
 
             cancelAndConsumeRemainingEvents()
         }
@@ -226,7 +226,7 @@ internal class DefaultUpcomingShowsDaoTest : BaseDatabaseTest() {
             // Then
             val updatedShows = awaitItem()
             updatedShows.size shouldBe 1
-            updatedShows.none { it.traktId == 1L } shouldBe true
+            updatedShows.none { it.showId == 1L } shouldBe true
 
             cancelAndConsumeRemainingEvents()
         }
@@ -251,7 +251,7 @@ internal class DefaultUpcomingShowsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `stable query should handle COALESCE for empty names correctly`() = runTest {
-        val showId = seedShow(traktId = 888, name = "Empty Name Show", posterPath = "/empty.jpg")
+        val showId = seedShow(showId = 888, name = "Empty Name Show", posterPath = "/empty.jpg")
         database.upcomingShowsQueries.transaction {
             val _ = database.upcomingShowsQueries.insert(
                 showId = showId,
@@ -268,15 +268,15 @@ internal class DefaultUpcomingShowsDaoTest : BaseDatabaseTest() {
         dao.observeUpcomingShows(page = 1).test {
             val shows = awaitItem()
             // Should include the show with empty name due to COALESCE
-            val emptyNameShow = shows.find { it.traktId == 888L }
+            val emptyNameShow = shows.find { it.showId == 888L }
             emptyNameShow?.title shouldBe "" // COALESCE should return empty string
             cancelAndConsumeRemainingEvents()
         }
     }
 
-    private fun seedShow(traktId: Long, name: String, posterPath: String): Id<ShowId> {
+    private fun seedShow(showId: Long, name: String, posterPath: String): Id<ShowId> {
         val _ = database.tvShowQueries.upsert(
-            tmdb_id = Id<TmdbId>(traktId),
+            tmdb_id = Id<TmdbId>(showId),
             name = name,
             overview = "$name overview",
             language = "en",
@@ -290,7 +290,7 @@ internal class DefaultUpcomingShowsDaoTest : BaseDatabaseTest() {
             poster_path = posterPath,
             backdrop_path = "/new_backdrop.jpg",
         )
-        return showIdForTraktId(traktId)
+        return showIdForTraktId(showId)
     }
 
     private fun insertTestShows() {

--- a/data/upnext/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/upnext/api/model/CompletedShow.kt
+++ b/data/upnext/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/upnext/api/model/CompletedShow.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.upnext.api.model
 
 public data class CompletedShow(
-    val showTraktId: Long,
+    val showId: Long,
     val showTmdbId: Long?,
     val showName: String?,
     val showPoster: String?,

--- a/data/upnext/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/upnext/api/model/NextEpisodeWithShow.kt
+++ b/data/upnext/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/upnext/api/model/NextEpisodeWithShow.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.upnext.api.model
 
 public data class NextEpisodeWithShow(
-    val showTraktId: Long,
+    val showId: Long,
     val showTmdbId: Long?,
     val showName: String?,
     val showPoster: String?,

--- a/data/upnext/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/upnext/api/model/UpNextEpisode.kt
+++ b/data/upnext/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/upnext/api/model/UpNextEpisode.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.upnext.api.model
 
 public data class UpNextEpisode(
-    val showTraktId: Long,
+    val showId: Long,
     val showTmdbId: Long,
     val showName: String,
     val showPoster: String?,
@@ -33,7 +33,7 @@ public fun NextEpisodeWithShow.toUpNextEpisode(): UpNextEpisode? {
     val resolvedSeasonNumber = seasonNumber ?: return null
     val resolvedEpisodeNumber = episodeNumber ?: return null
     return UpNextEpisode(
-        showTraktId = showTraktId,
+        showId = showId,
         showTmdbId = tmdbId,
         showName = name,
         showPoster = showPoster,

--- a/data/watchproviders/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/api/WatchProviderDao.kt
+++ b/data/watchproviders/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/api/WatchProviderDao.kt
@@ -12,9 +12,9 @@ public interface WatchProviderDao {
 
     public fun observeWatchProviders(tmdbId: Long): Flow<List<WatchProviders>>
 
-    public fun observeWatchProvidersByTraktId(traktId: Long): Flow<List<WatchProvidersByTraktId>>
+    public fun observeWatchProvidersByTraktId(showId: Long): Flow<List<WatchProvidersByTraktId>>
 
-    public fun deleteByTraktId(traktId: Long)
+    public fun deleteByTraktId(showId: Long)
 
     public fun deleteAll()
 }

--- a/data/watchproviders/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/api/WatchProviderDao.kt
+++ b/data/watchproviders/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/api/WatchProviderDao.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.data.watchproviders.api
 
 import com.thomaskioko.tvmaniac.db.WatchProviders
-import com.thomaskioko.tvmaniac.db.WatchProvidersByTraktId
+import com.thomaskioko.tvmaniac.db.WatchProvidersByShowId
 import com.thomaskioko.tvmaniac.db.Watch_providers
 import kotlinx.coroutines.flow.Flow
 
@@ -12,9 +12,9 @@ public interface WatchProviderDao {
 
     public fun observeWatchProviders(tmdbId: Long): Flow<List<WatchProviders>>
 
-    public fun observeWatchProvidersByTraktId(showId: Long): Flow<List<WatchProvidersByTraktId>>
+    public fun observeWatchProvidersByShowId(showId: Long): Flow<List<WatchProvidersByShowId>>
 
-    public fun deleteByTraktId(showId: Long)
+    public fun deleteByShowId(showId: Long)
 
     public fun deleteAll()
 }

--- a/data/watchproviders/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/api/WatchProviderRepository.kt
+++ b/data/watchproviders/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/api/WatchProviderRepository.kt
@@ -5,9 +5,9 @@ import kotlinx.coroutines.flow.Flow
 
 public interface WatchProviderRepository {
     public suspend fun fetchWatchProviders(
-        traktId: Long,
+        showId: Long,
         forceRefresh: Boolean = false,
     )
 
-    public fun observeWatchProviders(traktId: Long): Flow<List<WatchProviders>>
+    public fun observeWatchProviders(showId: Long): Flow<List<WatchProviders>>
 }

--- a/data/watchproviders/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/implementation/DefaultWatchProviderDao.kt
+++ b/data/watchproviders/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/implementation/DefaultWatchProviderDao.kt
@@ -8,7 +8,7 @@ import com.thomaskioko.tvmaniac.db.Id
 import com.thomaskioko.tvmaniac.db.ShowIdResolver
 import com.thomaskioko.tvmaniac.db.TvManiacDatabase
 import com.thomaskioko.tvmaniac.db.WatchProviders
-import com.thomaskioko.tvmaniac.db.WatchProvidersByTraktId
+import com.thomaskioko.tvmaniac.db.WatchProvidersByShowId
 import com.thomaskioko.tvmaniac.db.Watch_providers
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
@@ -46,15 +46,15 @@ public class DefaultWatchProviderDao(
             .mapToList(dispatcher.io)
             .map { rows -> rows.dedupedByBrand { it.name } }
 
-    override fun observeWatchProvidersByTraktId(showId: Long): Flow<List<WatchProvidersByTraktId>> {
+    override fun observeWatchProvidersByShowId(showId: Long): Flow<List<WatchProvidersByShowId>> {
         val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return flowOf(emptyList())
-        return database.watchProvidersQueries.watchProvidersByTraktId(internalShowId)
+        return database.watchProvidersQueries.watchProvidersByShowId(internalShowId)
             .asFlow()
             .mapToList(dispatcher.io)
             .map { rows -> rows.dedupedByBrand { it.name } }
     }
 
-    override fun deleteByTraktId(showId: Long) {
+    override fun deleteByShowId(showId: Long) {
         val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return
         database.watchProvidersQueries.deleteByShowId(internalShowId)
     }

--- a/data/watchproviders/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/implementation/DefaultWatchProviderDao.kt
+++ b/data/watchproviders/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/implementation/DefaultWatchProviderDao.kt
@@ -46,17 +46,17 @@ public class DefaultWatchProviderDao(
             .mapToList(dispatcher.io)
             .map { rows -> rows.dedupedByBrand { it.name } }
 
-    override fun observeWatchProvidersByTraktId(traktId: Long): Flow<List<WatchProvidersByTraktId>> {
-        val showId = showIdResolver.showIdForTraktId(traktId) ?: return flowOf(emptyList())
-        return database.watchProvidersQueries.watchProvidersByTraktId(showId)
+    override fun observeWatchProvidersByTraktId(showId: Long): Flow<List<WatchProvidersByTraktId>> {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return flowOf(emptyList())
+        return database.watchProvidersQueries.watchProvidersByTraktId(internalShowId)
             .asFlow()
             .mapToList(dispatcher.io)
             .map { rows -> rows.dedupedByBrand { it.name } }
     }
 
-    override fun deleteByTraktId(traktId: Long) {
-        val showId = showIdResolver.showIdForTraktId(traktId) ?: return
-        database.watchProvidersQueries.deleteByShowId(showId)
+    override fun deleteByTraktId(showId: Long) {
+        val internalShowId = showIdResolver.showIdForTraktId(showId) ?: return
+        database.watchProvidersQueries.deleteByShowId(internalShowId)
     }
 
     override fun deleteAll() {

--- a/data/watchproviders/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/implementation/DefaultWatchProviderRepository.kt
+++ b/data/watchproviders/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/implementation/DefaultWatchProviderRepository.kt
@@ -19,15 +19,15 @@ public class DefaultWatchProviderRepository(
     private val dao: WatchProviderDao,
 ) : WatchProviderRepository {
 
-    override suspend fun fetchWatchProviders(traktId: Long, forceRefresh: Boolean) {
+    override suspend fun fetchWatchProviders(showId: Long, forceRefresh: Boolean) {
         when {
-            forceRefresh -> store.fresh(traktId)
-            else -> store.get(traktId)
+            forceRefresh -> store.fresh(showId)
+            else -> store.get(showId)
         }
     }
 
-    override fun observeWatchProviders(traktId: Long): Flow<List<WatchProviders>> =
-        dao.observeWatchProvidersByTraktId(traktId)
+    override fun observeWatchProviders(showId: Long): Flow<List<WatchProviders>> =
+        dao.observeWatchProvidersByTraktId(showId)
             .map { providers -> providers.map { it.toWatchProviders() } }
 
     private fun WatchProvidersByTraktId.toWatchProviders(): WatchProviders =

--- a/data/watchproviders/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/implementation/DefaultWatchProviderRepository.kt
+++ b/data/watchproviders/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/implementation/DefaultWatchProviderRepository.kt
@@ -3,7 +3,7 @@ package com.thomaskioko.tvmaniac.data.watchproviders.implementation
 import com.thomaskioko.tvmaniac.data.watchproviders.api.WatchProviderDao
 import com.thomaskioko.tvmaniac.data.watchproviders.api.WatchProviderRepository
 import com.thomaskioko.tvmaniac.db.WatchProviders
-import com.thomaskioko.tvmaniac.db.WatchProvidersByTraktId
+import com.thomaskioko.tvmaniac.db.WatchProvidersByShowId
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
@@ -27,10 +27,10 @@ public class DefaultWatchProviderRepository(
     }
 
     override fun observeWatchProviders(showId: Long): Flow<List<WatchProviders>> =
-        dao.observeWatchProvidersByTraktId(showId)
+        dao.observeWatchProvidersByShowId(showId)
             .map { providers -> providers.map { it.toWatchProviders() } }
 
-    private fun WatchProvidersByTraktId.toWatchProviders(): WatchProviders =
+    private fun WatchProvidersByShowId.toWatchProviders(): WatchProviders =
         WatchProviders(
             provider_id = provider_id,
             name = name,

--- a/data/watchproviders/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/implementation/WatchProvidersStore.kt
+++ b/data/watchproviders/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/implementation/WatchProvidersStore.kt
@@ -31,13 +31,13 @@ public class WatchProvidersStore(
     private val databaseTransactionRunner: DatabaseTransactionRunner,
     private val dispatchers: AppCoroutineDispatchers,
 ) : Store<Long, List<WatchProvidersByTraktId>> by storeBuilder(
-    fetcher = Fetcher.of { traktId ->
-        val tmdbId = tvShowsDao.getTmdbIdByTraktId(traktId)
-            ?: throw Throwable("TMDB ID not found for Trakt ID: $traktId")
+    fetcher = Fetcher.of { showId ->
+        val tmdbId = tvShowsDao.getTmdbIdByTraktId(showId)
+            ?: throw Throwable("TMDB ID not found for Trakt ID: $showId")
         when (val response = remoteDataSource.getShowWatchProviders(tmdbId)) {
             is ApiResponse.Success -> {
                 requestManagerRepository.upsert(
-                    entityId = traktId,
+                    entityId = showId,
                     requestType = WATCH_PROVIDERS.name,
                 )
                 WatchProvidersFetchResult(tmdbId, response.body)
@@ -50,23 +50,23 @@ public class WatchProvidersStore(
         }
     },
     sourceOfTruth = SourceOfTruth.of<Long, WatchProvidersFetchResult, List<WatchProvidersByTraktId>>(
-        reader = { traktId ->
-            dao.observeWatchProvidersByTraktId(traktId)
+        reader = { showId ->
+            dao.observeWatchProvidersByTraktId(showId)
         },
-        writer = { traktId, result ->
+        writer = { showId, result ->
             databaseTransactionRunner {
-                dao.deleteByTraktId(traktId)
-                val showId = showIdResolver.showIdForTraktId(traktId)
-                if (showId != null) {
+                dao.deleteByTraktId(showId)
+                val internalShowId = showIdResolver.showIdForTraktId(showId)
+                if (internalShowId != null) {
                     result.response.results.US
-                        ?.let { mapper.mapToRows(us = it, tmdbId = result.tmdbId, showId = showId) }
+                        ?.let { mapper.mapToRows(us = it, tmdbId = result.tmdbId, showId = internalShowId) }
                         ?.forEach(dao::upsert)
                 }
             }
         },
-        delete = { traktId ->
+        delete = { showId ->
             databaseTransactionRunner {
-                dao.deleteByTraktId(traktId)
+                dao.deleteByTraktId(showId)
             }
         },
         deleteAll = { databaseTransactionRunner(dao::deleteAll) },
@@ -77,9 +77,9 @@ public class WatchProvidersStore(
 ).validator(
     Validator.by { result ->
         withContext(dispatchers.io) {
-            val traktId = result.firstOrNull()?.trakt_id ?: return@withContext false
+            val showId = result.firstOrNull()?.trakt_id ?: return@withContext false
             !requestManagerRepository.isRequestExpired(
-                entityId = traktId,
+                entityId = showId,
                 requestType = WATCH_PROVIDERS.name,
                 threshold = WATCH_PROVIDERS.duration,
             )

--- a/data/watchproviders/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/implementation/WatchProvidersStore.kt
+++ b/data/watchproviders/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/implementation/WatchProvidersStore.kt
@@ -7,7 +7,7 @@ import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.data.watchproviders.api.WatchProviderDao
 import com.thomaskioko.tvmaniac.db.DatabaseTransactionRunner
 import com.thomaskioko.tvmaniac.db.ShowIdResolver
-import com.thomaskioko.tvmaniac.db.WatchProvidersByTraktId
+import com.thomaskioko.tvmaniac.db.WatchProvidersByShowId
 import com.thomaskioko.tvmaniac.resourcemanager.api.RequestManagerRepository
 import com.thomaskioko.tvmaniac.resourcemanager.api.RequestTypeConfig.WATCH_PROVIDERS
 import com.thomaskioko.tvmaniac.shows.api.TvShowsDao
@@ -30,9 +30,9 @@ public class WatchProvidersStore(
     private val requestManagerRepository: RequestManagerRepository,
     private val databaseTransactionRunner: DatabaseTransactionRunner,
     private val dispatchers: AppCoroutineDispatchers,
-) : Store<Long, List<WatchProvidersByTraktId>> by storeBuilder(
+) : Store<Long, List<WatchProvidersByShowId>> by storeBuilder(
     fetcher = Fetcher.of { showId ->
-        val tmdbId = tvShowsDao.getTmdbIdByTraktId(showId)
+        val tmdbId = tvShowsDao.getTmdbIdByShowId(showId)
             ?: throw Throwable("TMDB ID not found for Trakt ID: $showId")
         when (val response = remoteDataSource.getShowWatchProviders(tmdbId)) {
             is ApiResponse.Success -> {
@@ -49,13 +49,13 @@ public class WatchProvidersStore(
             is ApiResponse.Error.OfflineError -> throw Throwable("No internet connection")
         }
     },
-    sourceOfTruth = SourceOfTruth.of<Long, WatchProvidersFetchResult, List<WatchProvidersByTraktId>>(
+    sourceOfTruth = SourceOfTruth.of<Long, WatchProvidersFetchResult, List<WatchProvidersByShowId>>(
         reader = { showId ->
-            dao.observeWatchProvidersByTraktId(showId)
+            dao.observeWatchProvidersByShowId(showId)
         },
         writer = { showId, result ->
             databaseTransactionRunner {
-                dao.deleteByTraktId(showId)
+                dao.deleteByShowId(showId)
                 val internalShowId = showIdResolver.showIdForTraktId(showId)
                 if (internalShowId != null) {
                     result.response.results.US
@@ -66,7 +66,7 @@ public class WatchProvidersStore(
         },
         delete = { showId ->
             databaseTransactionRunner {
-                dao.deleteByTraktId(showId)
+                dao.deleteByShowId(showId)
             }
         },
         deleteAll = { databaseTransactionRunner(dao::deleteAll) },

--- a/data/watchproviders/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/testing/FakeWatchProviderRepository.kt
+++ b/data/watchproviders/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/watchproviders/testing/FakeWatchProviderRepository.kt
@@ -10,7 +10,7 @@ public class FakeWatchProviderRepository : WatchProviderRepository {
     private var watchProvidersResult = MutableStateFlow<List<WatchProviders>>(emptyList())
     private val fetchInvocations = mutableListOf<FetchInvocation>()
 
-    public data class FetchInvocation(val traktId: Long, val forceRefresh: Boolean)
+    public data class FetchInvocation(val showId: Long, val forceRefresh: Boolean)
 
     public suspend fun setWatchProvidersResult(result: List<WatchProviders>) {
         watchProvidersResult.emit(result)
@@ -22,11 +22,11 @@ public class FakeWatchProviderRepository : WatchProviderRepository {
         fetchInvocations.clear()
     }
 
-    override suspend fun fetchWatchProviders(traktId: Long, forceRefresh: Boolean) {
-        fetchInvocations.add(FetchInvocation(traktId, forceRefresh))
+    override suspend fun fetchWatchProviders(showId: Long, forceRefresh: Boolean) {
+        fetchInvocations.add(FetchInvocation(showId, forceRefresh))
     }
 
     override fun observeWatchProviders(
-        traktId: Long,
+        showId: Long,
     ): Flow<List<WatchProviders>> = watchProvidersResult.asStateFlow()
 }

--- a/domain/calendar/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/calendar/ObserveCalendarInteractor.kt
+++ b/domain/calendar/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/calendar/ObserveCalendarInteractor.kt
@@ -52,7 +52,7 @@ public class ObserveCalendarInteractor(
 
     private fun groupEntriesByShow(entries: List<CalendarEntry>): List<GroupedEpisodeEntry> {
         return entries
-            .groupBy { it.showTraktId }
+            .groupBy { it.showId }
             .map { (_, showEntries) ->
                 val sortedEntries = showEntries.sortedWith(
                     compareBy({ it.seasonNumber }, { it.episodeNumber }),
@@ -61,8 +61,8 @@ public class ObserveCalendarInteractor(
                 val additionalCount = sortedEntries.size - 1
 
                 GroupedEpisodeEntry(
-                    showTraktId = firstEntry.showTraktId,
-                    episodeTraktId = firstEntry.episodeTraktId,
+                    showId = firstEntry.showId,
+                    episodeId = firstEntry.episodeId,
                     showTitle = firstEntry.showTitle,
                     posterUrl = firstEntry.showPosterPath,
                     episodeInfo = calendarEpisodeFormatter.formatEpisodeInfo(

--- a/domain/calendar/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/calendar/model/GroupedEpisodeEntry.kt
+++ b/domain/calendar/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/calendar/model/GroupedEpisodeEntry.kt
@@ -1,8 +1,8 @@
 package com.thomaskioko.tvmaniac.domain.calendar.model
 
 public data class GroupedEpisodeEntry(
-    val showTraktId: Long,
-    val episodeTraktId: Long,
+    val showId: Long,
+    val episodeId: Long,
     val showTitle: String,
     val posterUrl: String?,
     val episodeInfo: String,

--- a/domain/calendar/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/calendar/ObserveCalendarInteractorTest.kt
+++ b/domain/calendar/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/calendar/ObserveCalendarInteractorTest.kt
@@ -39,8 +39,8 @@ internal class ObserveCalendarInteractorTest {
         val airDate = todayEpochMillis()
         calendarRepository.setCalendarEntries(
             listOf(
-                createTestEntry(showTraktId = 1, episodeTraktId = 10, airDate = airDate),
-                createTestEntry(showTraktId = 2, episodeTraktId = 20, airDate = airDate),
+                createTestEntry(showId = 1, episodeId = 10, airDate = airDate),
+                createTestEntry(showId = 2, episodeId = 20, airDate = airDate),
             ),
         )
         val interactor = createInteractor()
@@ -61,8 +61,8 @@ internal class ObserveCalendarInteractorTest {
         val tomorrowEpoch = tomorrowEpochMillis()
         calendarRepository.setCalendarEntries(
             listOf(
-                createTestEntry(showTraktId = 1, episodeTraktId = 10, airDate = todayEpoch),
-                createTestEntry(showTraktId = 2, episodeTraktId = 20, airDate = tomorrowEpoch),
+                createTestEntry(showId = 1, episodeId = 10, airDate = todayEpoch),
+                createTestEntry(showId = 2, episodeId = 20, airDate = tomorrowEpoch),
             ),
         )
         val interactor = createInteractor()
@@ -83,8 +83,8 @@ internal class ObserveCalendarInteractorTest {
         val airDate = todayEpochMillis()
         calendarRepository.setCalendarEntries(
             listOf(
-                createTestEntry(showTraktId = 1, episodeTraktId = 10, seasonNumber = 1, episodeNumber = 1, airDate = airDate),
-                createTestEntry(showTraktId = 1, episodeTraktId = 11, seasonNumber = 1, episodeNumber = 2, airDate = airDate),
+                createTestEntry(showId = 1, episodeId = 10, seasonNumber = 1, episodeNumber = 1, airDate = airDate),
+                createTestEntry(showId = 1, episodeId = 11, seasonNumber = 1, episodeNumber = 2, airDate = airDate),
             ),
         )
         val interactor = createInteractor()
@@ -106,8 +106,8 @@ internal class ObserveCalendarInteractorTest {
         calendarRepository.setCalendarEntries(
             listOf(
                 createTestEntry(
-                    showTraktId = 1,
-                    episodeTraktId = 10,
+                    showId = 1,
+                    episodeId = 10,
                     seasonNumber = 2,
                     episodeNumber = 5,
                     episodeTitle = "The One",
@@ -132,8 +132,8 @@ internal class ObserveCalendarInteractorTest {
         calendarRepository.setCalendarEntries(
             listOf(
                 createTestEntry(
-                    showTraktId = 1,
-                    episodeTraktId = 10,
+                    showId = 1,
+                    episodeId = 10,
                     seasonNumber = 1,
                     episodeNumber = 3,
                     episodeTitle = null,
@@ -158,8 +158,8 @@ internal class ObserveCalendarInteractorTest {
         calendarRepository.setCalendarEntries(
             listOf(
                 createTestEntry(
-                    showTraktId = 1,
-                    episodeTraktId = 10,
+                    showId = 1,
+                    episodeId = 10,
                     showTitle = "Breaking Bad",
                     showPosterPath = "/poster.jpg",
                     network = "AMC",
@@ -178,8 +178,8 @@ internal class ObserveCalendarInteractorTest {
 
         interactor.flow.test {
             val episode = awaitItem()[0].episodes[0]
-            episode.showTraktId shouldBe 1
-            episode.episodeTraktId shouldBe 10
+            episode.showId shouldBe 1
+            episode.episodeId shouldBe 10
             episode.showTitle shouldBe "Breaking Bad"
             episode.posterUrl shouldBe "/poster.jpg"
             episode.network shouldBe "AMC"
@@ -196,8 +196,8 @@ internal class ObserveCalendarInteractorTest {
         val tomorrowEpoch = tomorrowEpochMillis()
         calendarRepository.setCalendarEntries(
             listOf(
-                createTestEntry(showTraktId = 2, episodeTraktId = 20, airDate = tomorrowEpoch),
-                createTestEntry(showTraktId = 1, episodeTraktId = 10, airDate = todayEpoch),
+                createTestEntry(showId = 2, episodeId = 20, airDate = tomorrowEpoch),
+                createTestEntry(showId = 1, episodeId = 10, airDate = todayEpoch),
             ),
         )
         val interactor = createInteractor()
@@ -208,8 +208,8 @@ internal class ObserveCalendarInteractorTest {
         interactor.flow.test {
             val groups = awaitItem()
             groups shouldHaveSize 2
-            groups[0].episodes[0].showTraktId shouldBe 1
-            groups[1].episodes[0].showTraktId shouldBe 2
+            groups[0].episodes[0].showId shouldBe 1
+            groups[1].episodes[0].showId shouldBe 2
         }
     }
 
@@ -219,16 +219,16 @@ internal class ObserveCalendarInteractorTest {
         calendarRepository.setCalendarEntries(
             listOf(
                 createTestEntry(
-                    showTraktId = 1,
-                    episodeTraktId = 11,
+                    showId = 1,
+                    episodeId = 11,
                     seasonNumber = 1,
                     episodeNumber = 2,
                     episodeTitle = "Second",
                     airDate = airDate,
                 ),
                 createTestEntry(
-                    showTraktId = 1,
-                    episodeTraktId = 10,
+                    showId = 1,
+                    episodeId = 10,
                     seasonNumber = 1,
                     episodeNumber = 1,
                     episodeTitle = "First",
@@ -243,7 +243,7 @@ internal class ObserveCalendarInteractorTest {
 
         interactor.flow.test {
             val episode = awaitItem()[0].episodes[0]
-            episode.episodeTraktId shouldBe 10
+            episode.episodeId shouldBe 10
             episode.episodeInfo shouldBe "S01E01 · First"
             episode.additionalEpisodesCount shouldBe 1
         }
@@ -287,8 +287,8 @@ internal class ObserveCalendarInteractorTest {
 
     @Suppress("LongParameterList")
     private fun createTestEntry(
-        showTraktId: Long = 1,
-        episodeTraktId: Long = 10,
+        showId: Long = 1,
+        episodeId: Long = 10,
         seasonNumber: Int = 1,
         episodeNumber: Int = 1,
         episodeTitle: String? = "Test Episode",
@@ -301,8 +301,8 @@ internal class ObserveCalendarInteractorTest {
         rating: Double? = 8.0,
         votes: Int? = 100,
     ): CalendarEntry = CalendarEntry(
-        showTraktId = showTraktId,
-        episodeTraktId = episodeTraktId,
+        showId = showId,
+        episodeId = episodeId,
         seasonNumber = seasonNumber,
         episodeNumber = episodeNumber,
         episodeTitle = episodeTitle,

--- a/domain/continue-watching/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/SyncContinueWatchingInteractor.kt
+++ b/domain/continue-watching/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/SyncContinueWatchingInteractor.kt
@@ -90,7 +90,7 @@ public class SyncContinueWatchingInteractor(
                         val result = runCatching {
                             syncShowMetadataInteractor.executeSync(
                                 params = SyncShowMetadataInteractor.Param(
-                                    traktId = show.traktId,
+                                    showId = show.showId,
                                     forceRefresh = forceRefresh,
                                 ),
                             )
@@ -99,13 +99,13 @@ public class SyncContinueWatchingInteractor(
 
                         logger.warning(
                             TAG,
-                            "syncShowMetadata failed for ${show.traktId}: ${failure.message}",
+                            "syncShowMetadata failed for ${show.showId}: ${failure.message}",
                         )
 
                         if (failure.toSyncError() is NetworkSyncError.Retryable) {
                             logger.warning(
                                 TAG,
-                                "Backing off metadata fan-out after retryable failure on ${show.traktId}",
+                                "Backing off metadata fan-out after retryable failure on ${show.showId}",
                             )
                             shouldStopMetadataSync.value = true
                         }

--- a/domain/continue-watching/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/UpNextSectionsMapper.kt
+++ b/domain/continue-watching/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/UpNextSectionsMapper.kt
@@ -80,7 +80,7 @@ public class UpNextSectionsMapper(
         badge: EpisodeBadge,
     ): UpNextEpisodeInfo {
         return UpNextEpisodeInfo(
-            showTraktId = showTraktId,
+            showId = showId,
             showName = showName,
             showPoster = showPoster,
             episodeId = episodeId,

--- a/domain/continue-watching/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/WatchlistShowMappers.kt
+++ b/domain/continue-watching/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/WatchlistShowMappers.kt
@@ -7,7 +7,7 @@ import com.thomaskioko.tvmaniac.upnext.api.model.NextEpisodeWithShow
 internal fun NextEpisodeWithShow.toWatchlistShowInfo(): WatchlistShowInfo {
     val progress = if (totalCount > 0) watchedCount.toFloat() / totalCount else 0f
     return WatchlistShowInfo(
-        traktId = showTraktId,
+        showId = showId,
         tmdbId = showTmdbId,
         title = showName,
         posterImageUrl = showPoster,

--- a/domain/continue-watching/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/model/UpNextSections.kt
+++ b/domain/continue-watching/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/model/UpNextSections.kt
@@ -14,7 +14,7 @@ public data class UpNextSections(
 }
 
 public data class UpNextEpisodeInfo(
-    val showTraktId: Long,
+    val showId: Long,
     val showName: String,
     val showPoster: String?,
     val episodeId: Long,

--- a/domain/continue-watching/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/model/WatchlistSections.kt
+++ b/domain/continue-watching/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/model/WatchlistSections.kt
@@ -6,7 +6,7 @@ public data class WatchlistSections(
 )
 
 public data class WatchlistShowInfo(
-    val traktId: Long,
+    val showId: Long,
     val tmdbId: Long?,
     val title: String?,
     val posterImageUrl: String?,

--- a/domain/continue-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/ObserveCompletedShowsInteractorTest.kt
+++ b/domain/continue-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/ObserveCompletedShowsInteractorTest.kt
@@ -48,8 +48,8 @@ internal class ObserveCompletedShowsInteractorTest {
     fun `should emit completed shows from the repository`() = runTest {
         upNextRepository.setCompletedShows(
             listOf(
-                createCompletedShow(showTraktId = 1, showName = "Breaking Bad"),
-                createCompletedShow(showTraktId = 2, showName = "The Wire"),
+                createCompletedShow(showId = 1, showName = "Breaking Bad"),
+                createCompletedShow(showId = 2, showName = "The Wire"),
             ),
         )
 
@@ -66,7 +66,7 @@ internal class ObserveCompletedShowsInteractorTest {
     @Test
     fun `should cap the result at the requested limit`() = runTest {
         upNextRepository.setCompletedShows(
-            (1L..5L).map { createCompletedShow(showTraktId = it, showName = "Show $it") },
+            (1L..5L).map { createCompletedShow(showId = it, showName = "Show $it") },
         )
 
         interactor(ObserveCompletedShowsInteractor.Param(limit = 2))
@@ -78,11 +78,11 @@ internal class ObserveCompletedShowsInteractorTest {
     }
 
     private fun createCompletedShow(
-        showTraktId: Long,
+        showId: Long,
         showName: String,
     ) = CompletedShow(
-        showTraktId = showTraktId,
-        showTmdbId = showTraktId,
+        showId = showId,
+        showTmdbId = showId,
         showName = showName,
         showPoster = "/poster.jpg",
         lastWatchedAt = 0L,

--- a/domain/continue-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/ObserveUpNextInteractorTest.kt
+++ b/domain/continue-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/ObserveUpNextInteractorTest.kt
@@ -34,41 +34,41 @@ class ObserveUpNextInteractorTest {
 
     @Test
     fun `should sort shows by last watched descending`() = runTest {
-        val watchedNow = createEpisode(showTraktId = 1, lastWatchedAt = 5_000L)
-        val watchedEarlier = createEpisode(showTraktId = 2, lastWatchedAt = 2_000L)
-        val watchedLongAgo = createEpisode(showTraktId = 3, lastWatchedAt = 1_000L)
+        val watchedNow = createEpisode(showId = 1, lastWatchedAt = 5_000L)
+        val watchedEarlier = createEpisode(showId = 2, lastWatchedAt = 2_000L)
+        val watchedLongAgo = createEpisode(showId = 3, lastWatchedAt = 1_000L)
         repository.setNextEpisodesForWatchlist(listOf(watchedEarlier, watchedLongAgo, watchedNow))
         repository.setUpNextSortOption(UpNextSortOption.LAST_WATCHED.name)
 
         interactor.flow.test {
-            awaitItem().episodes.map { it.showTraktId } shouldBe listOf(1L, 2L, 3L)
+            awaitItem().episodes.map { it.showId } shouldBe listOf(1L, 2L, 3L)
         }
     }
 
     @Test
     fun `should sort by air date descending when sort option is air date`() = runTest {
-        val airedNow = createEpisode(showTraktId = 1, firstAired = 5_000L)
-        val airedEarlier = createEpisode(showTraktId = 2, firstAired = 2_000L)
+        val airedNow = createEpisode(showId = 1, firstAired = 5_000L)
+        val airedEarlier = createEpisode(showId = 2, firstAired = 2_000L)
         repository.setNextEpisodesForWatchlist(listOf(airedEarlier, airedNow))
         repository.setUpNextSortOption(UpNextSortOption.AIR_DATE.name)
 
         interactor.flow.test {
-            awaitItem().episodes.map { it.showTraktId } shouldBe listOf(1L, 2L)
+            awaitItem().episodes.map { it.showId } shouldBe listOf(1L, 2L)
         }
     }
 
     private fun createEpisode(
-        showTraktId: Long,
+        showId: Long,
         lastWatchedAt: Long? = null,
         firstAired: Long? = null,
     ) = NextEpisodeWithShow(
-        showTraktId = showTraktId,
-        showTmdbId = showTraktId,
-        showName = "Show $showTraktId",
+        showId = showId,
+        showTmdbId = showId,
+        showName = "Show $showId",
         showPoster = null,
         showStatus = null,
         showYear = null,
-        episodeId = showTraktId * 100,
+        episodeId = showId * 100,
         episodeName = "Episode",
         seasonId = 1L,
         seasonNumber = 1L,

--- a/domain/continue-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/ObserveUpNextSectionsInteractorTest.kt
+++ b/domain/continue-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/ObserveUpNextSectionsInteractorTest.kt
@@ -62,8 +62,8 @@ class ObserveUpNextSectionsInteractorTest {
     @Test
     fun `should return episodes in watchNext when no lastWatched data`() = runTest {
         val episodes = listOf(
-            createNextEpisode(showTraktId = 1, showName = "Loki"),
-            createNextEpisode(showTraktId = 2, showName = "Wednesday"),
+            createNextEpisode(showId = 1, showName = "Loki"),
+            createNextEpisode(showId = 2, showName = "Wednesday"),
         )
         upNextRepository.setNextEpisodesForWatchlist(episodes)
 
@@ -89,8 +89,8 @@ class ObserveUpNextSectionsInteractorTest {
         dateTimeProvider.setCurrentTimeMillis(currentTime)
 
         val episodes = listOf(
-            createNextEpisode(showTraktId = 1, showName = "Stale Show", lastWatchedAt = seventeenDaysAgo, firstAired = pastAiredDate),
-            createNextEpisode(showTraktId = 2, showName = "Active Show", lastWatchedAt = oneDayAgo, firstAired = pastAiredDate),
+            createNextEpisode(showId = 1, showName = "Stale Show", lastWatchedAt = seventeenDaysAgo, firstAired = pastAiredDate),
+            createNextEpisode(showId = 2, showName = "Active Show", lastWatchedAt = oneDayAgo, firstAired = pastAiredDate),
         )
         upNextRepository.setNextEpisodesForWatchlist(episodes)
 
@@ -109,8 +109,8 @@ class ObserveUpNextSectionsInteractorTest {
     @Test
     fun `should filter episodes by show name when query is provided`() = runTest {
         val episodes = listOf(
-            createNextEpisode(showTraktId = 1, showName = "Loki"),
-            createNextEpisode(showTraktId = 2, showName = "Wednesday"),
+            createNextEpisode(showId = 1, showName = "Loki"),
+            createNextEpisode(showId = 2, showName = "Wednesday"),
         )
         upNextRepository.setNextEpisodesForWatchlist(episodes)
 
@@ -127,7 +127,7 @@ class ObserveUpNextSectionsInteractorTest {
     @Test
     fun `should calculate remaining episodes from episode data`() = runTest {
         val episodes = listOf(
-            createNextEpisode(showTraktId = 1, showName = "Loki", watchedCount = 5, totalCount = 10),
+            createNextEpisode(showId = 1, showName = "Loki", watchedCount = 5, totalCount = 10),
         )
         upNextRepository.setNextEpisodesForWatchlist(episodes)
 
@@ -144,8 +144,8 @@ class ObserveUpNextSectionsInteractorTest {
     @Test
     fun `should handle case insensitive query filtering`() = runTest {
         val episodes = listOf(
-            createNextEpisode(showTraktId = 1, showName = "Loki"),
-            createNextEpisode(showTraktId = 2, showName = "Wednesday"),
+            createNextEpisode(showId = 1, showName = "Loki"),
+            createNextEpisode(showId = 2, showName = "Wednesday"),
         )
         upNextRepository.setNextEpisodesForWatchlist(episodes)
 
@@ -163,7 +163,7 @@ class ObserveUpNextSectionsInteractorTest {
     fun `should preserve episode details in output`() = runTest {
         val episodes = listOf(
             NextEpisodeWithShow(
-                showTraktId = 1,
+                showId = 1,
                 showTmdbId = 1,
                 showName = "Loki",
                 showPoster = "/poster.jpg",
@@ -193,7 +193,7 @@ class ObserveUpNextSectionsInteractorTest {
             val result = awaitItem()
             result.watchNext.size shouldBe 1
             val episode = result.watchNext[0]
-            episode.showTraktId shouldBe 1
+            episode.showId shouldBe 1
             episode.showName shouldBe "Loki"
             episode.episodeId shouldBe 101
             episode.episodeTitle shouldBe "Glorious Purpose"
@@ -210,8 +210,8 @@ class ObserveUpNextSectionsInteractorTest {
     @Test
     fun `should filter out episodes with unknown air date`() = runTest {
         val episodes = listOf(
-            createNextEpisode(showTraktId = 1, showName = "Loki", firstAired = LocalDate(2021, 6, 9).toEpochMillis()),
-            createNextEpisode(showTraktId = 2, showName = "Wednesday", firstAired = null),
+            createNextEpisode(showId = 1, showName = "Loki", firstAired = LocalDate(2021, 6, 9).toEpochMillis()),
+            createNextEpisode(showId = 2, showName = "Wednesday", firstAired = null),
         )
         upNextRepository.setNextEpisodesForWatchlist(episodes)
 
@@ -228,7 +228,7 @@ class ObserveUpNextSectionsInteractorTest {
     @Test
     fun `should format episode number with padding`() = runTest {
         val episodes = listOf(
-            createNextEpisode(showTraktId = 1, showName = "Show", seasonNumber = 10, episodeNumber = 5),
+            createNextEpisode(showId = 1, showName = "Show", seasonNumber = 10, episodeNumber = 5),
         )
         upNextRepository.setNextEpisodesForWatchlist(episodes)
 
@@ -244,7 +244,7 @@ class ObserveUpNextSectionsInteractorTest {
     @Test
     fun `should return null formatted runtime when runtime is null`() = runTest {
         val episodes = listOf(
-            createNextEpisode(showTraktId = 1, showName = "Show", runtime = null),
+            createNextEpisode(showId = 1, showName = "Show", runtime = null),
         )
         upNextRepository.setNextEpisodesForWatchlist(episodes)
 
@@ -263,8 +263,8 @@ class ObserveUpNextSectionsInteractorTest {
         val futureEpoch = dateTimeProvider.nowMillis() + (17 * 24 * 60 * 60 * 1000L)
 
         val episodes = listOf(
-            createNextEpisode(showTraktId = 1, showName = "Aired Show", firstAired = pastEpoch),
-            createNextEpisode(showTraktId = 2, showName = "Future Show", firstAired = futureEpoch),
+            createNextEpisode(showId = 1, showName = "Aired Show", firstAired = pastEpoch),
+            createNextEpisode(showId = 2, showName = "Future Show", firstAired = futureEpoch),
         )
         upNextRepository.setNextEpisodesForWatchlist(episodes)
 
@@ -279,7 +279,7 @@ class ObserveUpNextSectionsInteractorTest {
     }
 
     private fun createNextEpisode(
-        showTraktId: Long,
+        showId: Long,
         showName: String,
         lastWatchedAt: Long? = null,
         firstAired: Long? = LocalDate(2021, 6, 9).toEpochMillis(),
@@ -289,13 +289,13 @@ class ObserveUpNextSectionsInteractorTest {
         episodeNumber: Long = 2L,
         runtime: Long? = 45L,
     ) = NextEpisodeWithShow(
-        showTraktId = showTraktId,
-        showTmdbId = showTraktId,
+        showId = showId,
+        showTmdbId = showId,
         showName = showName,
         showPoster = "/poster.jpg",
         showStatus = "Ended",
         showYear = "2024",
-        episodeId = showTraktId * 100 + 1,
+        episodeId = showId * 100 + 1,
         episodeName = "Episode Title",
         seasonId = 1L,
         seasonNumber = seasonNumber,

--- a/domain/continue-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/ObserveWatchlistPreviewInteractorTest.kt
+++ b/domain/continue-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/ObserveWatchlistPreviewInteractorTest.kt
@@ -48,8 +48,8 @@ internal class ObserveWatchlistPreviewInteractorTest {
     fun `should exclude completed shows from the preview`() = runTest {
         upNextRepository.setNextEpisodesForWatchlist(
             listOf(
-                createNextEpisode(showTraktId = 1, showName = "In Progress", watchedCount = 5, totalCount = 10),
-                createNextEpisode(showTraktId = 2, showName = "Completed", watchedCount = 10, totalCount = 10),
+                createNextEpisode(showId = 1, showName = "In Progress", watchedCount = 5, totalCount = 10),
+                createNextEpisode(showId = 2, showName = "Completed", watchedCount = 10, totalCount = 10),
             ),
         )
 
@@ -66,7 +66,7 @@ internal class ObserveWatchlistPreviewInteractorTest {
     @Test
     fun `should cap the preview at the requested limit`() = runTest {
         upNextRepository.setNextEpisodesForWatchlist(
-            (1L..5L).map { createNextEpisode(showTraktId = it, showName = "Show $it") },
+            (1L..5L).map { createNextEpisode(showId = it, showName = "Show $it") },
         )
 
         interactor(ObserveWatchlistPreviewInteractor.Param(limit = 2))
@@ -78,13 +78,13 @@ internal class ObserveWatchlistPreviewInteractorTest {
     }
 
     private fun createNextEpisode(
-        showTraktId: Long,
+        showId: Long,
         showName: String,
         watchedCount: Long = 0,
         totalCount: Long = 10,
     ) = NextEpisodeWithShow(
-        showTraktId = showTraktId,
-        showTmdbId = showTraktId,
+        showId = showId,
+        showTmdbId = showId,
         showName = showName,
         showPoster = "/poster.jpg",
         showStatus = "Ended",

--- a/domain/continue-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/ObserveWatchlistSectionsInteractorTest.kt
+++ b/domain/continue-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/ObserveWatchlistSectionsInteractorTest.kt
@@ -63,8 +63,8 @@ class ObserveWatchlistSectionsInteractorTest {
 
         upNextRepository.setNextEpisodesForWatchlist(
             listOf(
-                createNextEpisode(showTraktId = 84958, showName = "Loki", lastWatchedAt = twentyTwoDaysAgo),
-                createNextEpisode(showTraktId = 1232, showName = "The Lazarus Project", lastWatchedAt = recentWatch),
+                createNextEpisode(showId = 84958, showName = "Loki", lastWatchedAt = twentyTwoDaysAgo),
+                createNextEpisode(showId = 1232, showName = "The Lazarus Project", lastWatchedAt = recentWatch),
             ),
         )
 
@@ -84,8 +84,8 @@ class ObserveWatchlistSectionsInteractorTest {
     fun `should filter watchlist by query`() = runTest {
         upNextRepository.setNextEpisodesForWatchlist(
             listOf(
-                createNextEpisode(showTraktId = 84958, showName = "Loki"),
-                createNextEpisode(showTraktId = 1232, showName = "The Lazarus Project"),
+                createNextEpisode(showId = 84958, showName = "Loki"),
+                createNextEpisode(showId = 1232, showName = "The Lazarus Project"),
             ),
         )
 
@@ -104,7 +104,7 @@ class ObserveWatchlistSectionsInteractorTest {
         upNextRepository.setNextEpisodesForWatchlist(
             listOf(
                 createNextEpisode(
-                    showTraktId = 1,
+                    showId = 1,
                     showName = "Show with Progress",
                     watchedCount = 5,
                     totalCount = 10,
@@ -128,8 +128,8 @@ class ObserveWatchlistSectionsInteractorTest {
     fun `should exclude completed shows from sections`() = runTest {
         upNextRepository.setNextEpisodesForWatchlist(
             listOf(
-                createNextEpisode(showTraktId = 1, showName = "In Progress", watchedCount = 5, totalCount = 10),
-                createNextEpisode(showTraktId = 2, showName = "Completed", watchedCount = 10, totalCount = 10),
+                createNextEpisode(showId = 1, showName = "In Progress", watchedCount = 5, totalCount = 10),
+                createNextEpisode(showId = 2, showName = "Completed", watchedCount = 10, totalCount = 10),
             ),
         )
 
@@ -145,14 +145,14 @@ class ObserveWatchlistSectionsInteractorTest {
     }
 
     private fun createNextEpisode(
-        showTraktId: Long,
+        showId: Long,
         showName: String,
         lastWatchedAt: Long? = null,
         watchedCount: Long = 0,
         totalCount: Long = 10,
     ) = NextEpisodeWithShow(
-        showTraktId = showTraktId,
-        showTmdbId = showTraktId,
+        showId = showId,
+        showTmdbId = showId,
         showName = showName,
         showPoster = "/poster.jpg",
         showStatus = "Ended",

--- a/domain/continue-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/SyncContinueWatchingInteractorTest.kt
+++ b/domain/continue-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/SyncContinueWatchingInteractorTest.kt
@@ -112,9 +112,9 @@ class SyncContinueWatchingInteractorTest {
     fun `should sync metadata for every watched show`() = runTest(testDispatcher) {
         continueWatchingRepository.setEntries(
             listOf(
-                watchedShow(traktId = 42L),
-                watchedShow(traktId = 99L),
-                watchedShow(traktId = 101L),
+                watchedShow(showId = 42L),
+                watchedShow(showId = 99L),
+                watchedShow(showId = 101L),
             ),
         )
 
@@ -122,12 +122,12 @@ class SyncContinueWatchingInteractorTest {
 
         showDetailsRepository.fetchInvocations().map { it.id } shouldContainExactlyInAnyOrder listOf(42L, 99L, 101L)
         seasonDetailsRepository.getSyncedShowIds() shouldContainExactlyInAnyOrder listOf(42L, 99L, 101L)
-        watchProviderRepository.fetchInvocations().map { it.traktId } shouldContainExactlyInAnyOrder listOf(42L, 99L, 101L)
+        watchProviderRepository.fetchInvocations().map { it.showId } shouldContainExactlyInAnyOrder listOf(42L, 99L, 101L)
     }
 
     @Test
     fun `should propagate force refresh to per-show metadata sync`() = runTest(testDispatcher) {
-        continueWatchingRepository.setEntries(listOf(watchedShow(traktId = 7L)))
+        continueWatchingRepository.setEntries(listOf(watchedShow(showId = 7L)))
 
         interactor.executeSync(SyncContinueWatchingInteractor.Param(forceRefresh = true))
 
@@ -144,9 +144,9 @@ class SyncContinueWatchingInteractorTest {
         watchProviderRepository.fetchInvocations().shouldBeEmpty()
     }
 
-    private fun watchedShow(traktId: Long): ContinueWatchingEntry = ContinueWatchingEntry(
-        traktId = traktId,
-        tmdbId = traktId,
+    private fun watchedShow(showId: Long): ContinueWatchingEntry = ContinueWatchingEntry(
+        showId = showId,
+        tmdbId = showId,
         airedEpisodes = 10L,
         completedCount = 1L,
         lastWatchedAt = NOW,

--- a/domain/continue-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/UpNextSectionsMapperTest.kt
+++ b/domain/continue-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/UpNextSectionsMapperTest.kt
@@ -32,7 +32,7 @@ class UpNextSectionsMapperTest {
 
         val episodes = listOf(
             createNextEpisode(
-                showTraktId = 1,
+                showId = 1,
                 showName = "New Series",
                 seasonNumber = 1,
                 episodeNumber = 1,
@@ -56,7 +56,7 @@ class UpNextSectionsMapperTest {
 
         val episodes = listOf(
             createNextEpisode(
-                showTraktId = 1,
+                showId = 1,
                 showName = "Ongoing Series",
                 seasonNumber = 2,
                 episodeNumber = 5,
@@ -80,7 +80,7 @@ class UpNextSectionsMapperTest {
 
         val episodes = listOf(
             createNextEpisode(
-                showTraktId = 1,
+                showId = 1,
                 showName = "Returning Show",
                 seasonNumber = 5,
                 episodeNumber = 1,
@@ -104,7 +104,7 @@ class UpNextSectionsMapperTest {
 
         val episodes = listOf(
             createNextEpisode(
-                showTraktId = 1,
+                showId = 1,
                 showName = "Old Show Season 1",
                 seasonNumber = 1,
                 episodeNumber = 1,
@@ -128,7 +128,7 @@ class UpNextSectionsMapperTest {
 
         val episodes = listOf(
             createNextEpisode(
-                showTraktId = 1,
+                showId = 1,
                 showName = "Returning Show Old Premiere",
                 seasonNumber = 5,
                 episodeNumber = 1,
@@ -151,7 +151,7 @@ class UpNextSectionsMapperTest {
 
         val episodes = listOf(
             createNextEpisode(
-                showTraktId = 1,
+                showId = 1,
                 showName = "Unknown Air Date Show",
                 seasonNumber = 2,
                 episodeNumber = 1,
@@ -173,8 +173,8 @@ class UpNextSectionsMapperTest {
         dateTimeProvider.setCurrentTimeMillis(currentTime)
 
         val episodes = listOf(
-            createNextEpisode(showTraktId = 1, showName = "Aired", firstAired = pastDate),
-            createNextEpisode(showTraktId = 2, showName = "Future", firstAired = futureDate),
+            createNextEpisode(showId = 1, showName = "Aired", firstAired = pastDate),
+            createNextEpisode(showId = 2, showName = "Future", firstAired = futureDate),
         )
 
         val result = mapper.map(episodes)
@@ -190,8 +190,8 @@ class UpNextSectionsMapperTest {
         dateTimeProvider.setCurrentTimeMillis(currentTime)
 
         val episodes = listOf(
-            createNextEpisode(showTraktId = 1, showName = "Known Date", firstAired = pastDate),
-            createNextEpisode(showTraktId = 2, showName = "Unknown Date", firstAired = null),
+            createNextEpisode(showId = 1, showName = "Known Date", firstAired = pastDate),
+            createNextEpisode(showId = 2, showName = "Unknown Date", firstAired = null),
         )
 
         val result = mapper.map(episodes)
@@ -209,7 +209,7 @@ class UpNextSectionsMapperTest {
 
         val episodes = listOf(
             createNextEpisode(
-                showTraktId = 1,
+                showId = 1,
                 showName = "Stale Show",
                 lastWatchedAt = twentyDaysAgo,
                 firstAired = pastAired,
@@ -232,7 +232,7 @@ class UpNextSectionsMapperTest {
 
         val episodes = listOf(
             createNextEpisode(
-                showTraktId = 1,
+                showId = 1,
                 showName = "Active Show",
                 lastWatchedAt = fiveDaysAgo,
                 firstAired = pastAired,
@@ -255,7 +255,7 @@ class UpNextSectionsMapperTest {
 
         val episodes = listOf(
             createNextEpisode(
-                showTraktId = 1,
+                showId = 1,
                 showName = "Stale Show",
                 lastWatchedAt = staleWatched,
                 firstAired = pastAired,
@@ -277,7 +277,7 @@ class UpNextSectionsMapperTest {
 
         val episodes = listOf(
             createNextEpisode(
-                showTraktId = 1,
+                showId = 1,
                 showName = "Show",
                 watchedCount = 3,
                 totalCount = 10,
@@ -298,7 +298,7 @@ class UpNextSectionsMapperTest {
 
         val episodes = listOf(
             createNextEpisode(
-                showTraktId = 1,
+                showId = 1,
                 showName = "Show",
                 seasonNumber = 2,
                 episodeNumber = 5,
@@ -319,7 +319,7 @@ class UpNextSectionsMapperTest {
 
         val episodes = listOf(
             createNextEpisode(
-                showTraktId = 1,
+                showId = 1,
                 showName = "Show",
                 runtime = 45,
                 firstAired = pastAired,
@@ -339,7 +339,7 @@ class UpNextSectionsMapperTest {
 
         val episodes = listOf(
             createNextEpisode(
-                showTraktId = 1,
+                showId = 1,
                 showName = "Show",
                 runtime = null,
                 firstAired = pastAired,
@@ -352,7 +352,7 @@ class UpNextSectionsMapperTest {
     }
 
     private fun createNextEpisode(
-        showTraktId: Long,
+        showId: Long,
         showName: String,
         lastWatchedAt: Long? = null,
         firstAired: Long? = LocalDate(2021, 6, 9).toEpochMillis(),
@@ -363,13 +363,13 @@ class UpNextSectionsMapperTest {
         runtime: Long? = 45L,
         showYear: String? = "2024",
     ) = NextEpisodeWithShow(
-        showTraktId = showTraktId,
-        showTmdbId = showTraktId,
+        showId = showId,
+        showTmdbId = showId,
         showName = showName,
         showPoster = "/poster.jpg",
         showStatus = "Ended",
         showYear = showYear,
-        episodeId = showTraktId * 100 + 1,
+        episodeId = showId * 100 + 1,
         episodeName = "Episode Title",
         seasonId = 1L,
         seasonNumber = seasonNumber,

--- a/domain/discover/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/discover/DiscoverShowsInteractorTest.kt
+++ b/domain/discover/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/discover/DiscoverShowsInteractorTest.kt
@@ -103,7 +103,7 @@ class DiscoverShowsInteractorTest {
 
     private fun createTestShows() = List(3) {
         ShowEntity(
-            traktId = it.toLong(),
+            showId = it.toLong(),
             tmdbId = it.toLong(),
             title = "Show $it",
             posterPath = "poster_$it.jpg",

--- a/domain/episode/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/episode/MarkEpisodeUnwatchedInteractor.kt
+++ b/domain/episode/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/episode/MarkEpisodeUnwatchedInteractor.kt
@@ -11,13 +11,13 @@ public class MarkEpisodeUnwatchedInteractor(
 
     override suspend fun doWork(params: MarkEpisodeUnwatchedParams) {
         episodeRepository.markEpisodeAsUnwatched(
-            showTraktId = params.showTraktId,
+            showId = params.showId,
             episodeId = params.episodeId,
         )
     }
 }
 
 public data class MarkEpisodeUnwatchedParams(
-    val showTraktId: Long,
+    val showId: Long,
     val episodeId: Long,
 )

--- a/domain/episode/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/episode/MarkEpisodeWatchedInteractor.kt
+++ b/domain/episode/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/episode/MarkEpisodeWatchedInteractor.kt
@@ -12,14 +12,14 @@ public class MarkEpisodeWatchedInteractor(
     override suspend fun doWork(params: MarkEpisodeWatchedParams) {
         if (params.markPreviousEpisodes) {
             episodeRepository.markEpisodeAndPreviousEpisodesWatched(
-                showTraktId = params.showTraktId,
+                showId = params.showId,
                 episodeId = params.episodeId,
                 seasonNumber = params.seasonNumber,
                 episodeNumber = params.episodeNumber,
             )
         } else {
             episodeRepository.markEpisodeAsWatched(
-                showTraktId = params.showTraktId,
+                showId = params.showId,
                 episodeId = params.episodeId,
                 seasonNumber = params.seasonNumber,
                 episodeNumber = params.episodeNumber,
@@ -29,7 +29,7 @@ public class MarkEpisodeWatchedInteractor(
 }
 
 public data class MarkEpisodeWatchedParams(
-    val showTraktId: Long,
+    val showId: Long,
     val episodeId: Long,
     val seasonNumber: Long,
     val episodeNumber: Long,

--- a/domain/episode/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/episode/MarkEpisodeWatchedInteractorTest.kt
+++ b/domain/episode/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/episode/MarkEpisodeWatchedInteractorTest.kt
@@ -18,7 +18,7 @@ class MarkEpisodeWatchedInteractorTest {
     @Test
     fun `should mark episode as watched successfully`() = runTest {
         val params = MarkEpisodeWatchedParams(
-            showTraktId = 84958,
+            showId = 84958,
             episodeId = 123456,
             seasonNumber = 1,
             episodeNumber = 5,
@@ -34,14 +34,14 @@ class MarkEpisodeWatchedInteractorTest {
     @Test
     fun `should handle multiple episodes being marked as watched`() = runTest {
         val episode1 = MarkEpisodeWatchedParams(
-            showTraktId = 84958,
+            showId = 84958,
             episodeId = 123456,
             seasonNumber = 1,
             episodeNumber = 1,
         )
 
         val episode2 = MarkEpisodeWatchedParams(
-            showTraktId = 84958,
+            showId = 84958,
             episodeId = 123457,
             seasonNumber = 1,
             episodeNumber = 2,
@@ -63,7 +63,7 @@ class MarkEpisodeWatchedInteractorTest {
     @Test
     fun `should complete successfully when marking episode from different season`() = runTest {
         val params = MarkEpisodeWatchedParams(
-            showTraktId = 84958,
+            showId = 84958,
             episodeId = 123456,
             seasonNumber = 2,
             episodeNumber = 3,
@@ -79,14 +79,14 @@ class MarkEpisodeWatchedInteractorTest {
     @Test
     fun `should handle episodes from different shows`() = runTest {
         val lokiEpisode = MarkEpisodeWatchedParams(
-            showTraktId = 84958,
+            showId = 84958,
             episodeId = 123456,
             seasonNumber = 1,
             episodeNumber = 1,
         )
 
         val lazarusEpisode = MarkEpisodeWatchedParams(
-            showTraktId = 1232,
+            showId = 1232,
             episodeId = 789012,
             seasonNumber = 1,
             episodeNumber = 1,

--- a/domain/favorites/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/favorites/ObserveFavoritesInteractorTest.kt
+++ b/domain/favorites/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/favorites/ObserveFavoritesInteractorTest.kt
@@ -30,14 +30,14 @@ internal class ObserveFavoritesInteractorTest {
     private companion object {
         val shows = listOf(
             FavoriteShow(
-                traktId = 1,
+                showId = 1,
                 tmdbId = 1,
                 title = "Breaking Bad",
                 posterPath = "/1.jpg",
                 year = "2008",
             ),
             FavoriteShow(
-                traktId = 2,
+                showId = 2,
                 tmdbId = 2,
                 title = "Severance",
                 posterPath = "/2.jpg",

--- a/domain/library/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/library/SyncLibraryInteractor.kt
+++ b/domain/library/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/library/SyncLibraryInteractor.kt
@@ -73,18 +73,18 @@ public class SyncLibraryInteractor(
                 val result = runCatching {
                     syncShowMetadataInteractor.executeSync(
                         SyncShowMetadataInteractor.Param(
-                            traktId = show.traktId,
+                            showId = show.showId,
                             forceRefresh = params.forceRefresh,
                         ),
                     )
                 }
                 val failure = result.exceptionOrNull() ?: continue
 
-                logger.warning(TAG, "syncShowMetadata failed for ${show.traktId}: ${failure.message}")
+                logger.warning(TAG, "syncShowMetadata failed for ${show.showId}: ${failure.message}")
                 syncObserver.log(SyncError.BackgroundSyncFailed(TAG, failure))
 
                 if (failure.toSyncError() is NetworkSyncError.Retryable) {
-                    logger.warning(TAG, "Backing off metadata fan-out after retryable failure on ${show.traktId}")
+                    logger.warning(TAG, "Backing off metadata fan-out after retryable failure on ${show.showId}")
                     break
                 }
             }

--- a/domain/notifications/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/notifications/interactor/RefreshUpcomingSeasonDetailsInteractor.kt
+++ b/domain/notifications/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/notifications/interactor/RefreshUpcomingSeasonDetailsInteractor.kt
@@ -33,7 +33,7 @@ public class RefreshUpcomingSeasonDetailsInteractor(
                 apiRateLimiter.withRateLimitTracking {
                     seasonDetailsRepository.fetchSeasonDetails(
                         param = SeasonDetailsParam(
-                            showTraktId = season.showTraktId,
+                            showId = season.showId,
                             seasonId = season.seasonId,
                             seasonNumber = season.seasonNumber,
                         ),

--- a/domain/recently-watched/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/recentlywatched/ObserveRecentlyWatchedInteractorTest.kt
+++ b/domain/recently-watched/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/recentlywatched/ObserveRecentlyWatchedInteractorTest.kt
@@ -30,7 +30,7 @@ internal class ObserveRecentlyWatchedInteractorTest {
     private companion object {
         val episodes = listOf(
             RecentlyWatchedEpisode(
-                showTraktId = 1,
+                showId = 1,
                 showTmdbId = 1,
                 showTitle = "Breaking Bad",
                 posterPath = "/1.jpg",
@@ -40,7 +40,7 @@ internal class ObserveRecentlyWatchedInteractorTest {
                 watchedAt = 2_000L,
             ),
             RecentlyWatchedEpisode(
-                showTraktId = 2,
+                showId = 2,
                 showTmdbId = 2,
                 showTitle = "Severance",
                 posterPath = "/2.jpg",

--- a/domain/seasondetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/seasondetails/FetchPreviousSeasonsInteractor.kt
+++ b/domain/seasondetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/seasondetails/FetchPreviousSeasonsInteractor.kt
@@ -10,13 +10,13 @@ public class FetchPreviousSeasonsInteractor(
 ) : Interactor<FetchPreviousSeasonsParams>() {
     override suspend fun doWork(params: FetchPreviousSeasonsParams) {
         seasonDetailsRepository.syncPreviousSeasonsEpisodes(
-            showTraktId = params.showTraktId,
+            showId = params.showId,
             beforeSeasonNumber = params.seasonNumber,
         )
     }
 }
 
 public data class FetchPreviousSeasonsParams(
-    val showTraktId: Long,
+    val showId: Long,
     val seasonNumber: Long,
 )

--- a/domain/seasondetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/seasondetails/MarkSeasonUnwatchedInteractor.kt
+++ b/domain/seasondetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/seasondetails/MarkSeasonUnwatchedInteractor.kt
@@ -11,13 +11,13 @@ public class MarkSeasonUnwatchedInteractor(
 
     override suspend fun doWork(params: MarkSeasonUnwatchedParams) {
         episodeRepository.markSeasonUnwatched(
-            showTraktId = params.showTraktId,
+            showId = params.showId,
             seasonNumber = params.seasonNumber,
         )
     }
 }
 
 public data class MarkSeasonUnwatchedParams(
-    val showTraktId: Long,
+    val showId: Long,
     val seasonNumber: Long,
 )

--- a/domain/seasondetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/seasondetails/MarkSeasonWatchedInteractor.kt
+++ b/domain/seasondetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/seasondetails/MarkSeasonWatchedInteractor.kt
@@ -12,12 +12,12 @@ public class MarkSeasonWatchedInteractor(
     override suspend fun doWork(params: MarkSeasonWatchedParams) {
         if (params.markPreviousSeasons) {
             episodeRepository.markSeasonAndPreviousSeasonsWatched(
-                showTraktId = params.showTraktId,
+                showId = params.showId,
                 seasonNumber = params.seasonNumber,
             )
         } else {
             episodeRepository.markSeasonWatched(
-                showTraktId = params.showTraktId,
+                showId = params.showId,
                 seasonNumber = params.seasonNumber,
             )
         }
@@ -25,7 +25,7 @@ public class MarkSeasonWatchedInteractor(
 }
 
 public data class MarkSeasonWatchedParams(
-    val showTraktId: Long,
+    val showId: Long,
     val seasonNumber: Long,
     val markPreviousSeasons: Boolean = false,
 )

--- a/domain/seasondetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/seasondetails/ObserveSeasonWatchProgressInteractor.kt
+++ b/domain/seasondetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/seasondetails/ObserveSeasonWatchProgressInteractor.kt
@@ -13,13 +13,13 @@ public class ObserveSeasonWatchProgressInteractor(
 
     override fun createObservable(params: ObserveSeasonWatchProgressParams): Flow<SeasonWatchProgress> {
         return episodeRepository.observeSeasonWatchProgress(
-            showTraktId = params.showTraktId,
+            showId = params.showId,
             seasonNumber = params.seasonNumber,
         )
     }
 }
 
 public data class ObserveSeasonWatchProgressParams(
-    val showTraktId: Long,
+    val showId: Long,
     val seasonNumber: Long,
 )

--- a/domain/seasondetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/seasondetails/ObserveUnwatchedInPreviousSeasonsInteractor.kt
+++ b/domain/seasondetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/seasondetails/ObserveUnwatchedInPreviousSeasonsInteractor.kt
@@ -13,7 +13,7 @@ public class ObserveUnwatchedInPreviousSeasonsInteractor(
 
     override fun createObservable(params: ObserveUnwatchedInPreviousSeasonsParams): Flow<Boolean> {
         return episodeRepository.observeUnwatchedCountInPreviousSeasons(
-            showTraktId = params.showTraktId,
+            showId = params.showId,
             seasonNumber = params.seasonNumber,
         )
             .map { it > 0 }
@@ -21,6 +21,6 @@ public class ObserveUnwatchedInPreviousSeasonsInteractor(
 }
 
 public data class ObserveUnwatchedInPreviousSeasonsParams(
-    val showTraktId: Long,
+    val showId: Long,
     val seasonNumber: Long,
 )

--- a/domain/showdetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/FollowShowInteractor.kt
+++ b/domain/showdetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/FollowShowInteractor.kt
@@ -15,13 +15,13 @@ public class FollowShowInteractor(
 ) : Interactor<FollowShowInteractor.Param>() {
 
     override suspend fun doWork(params: Param) {
-        followedShowsRepository.addFollowedShow(params.traktId)
+        followedShowsRepository.addFollowedShow(params.showId)
 
         appScopeLauncher.launch(TAG) {
             libraryRepository.syncPendingFollowedShows()
             syncShowMetadataInteractor.executeSync(
                 SyncShowMetadataInteractor.Param(
-                    traktId = params.traktId,
+                    showId = params.showId,
                     forceRefresh = params.forceRefresh,
                 ),
             )
@@ -29,7 +29,7 @@ public class FollowShowInteractor(
     }
 
     public data class Param(
-        val traktId: Long,
+        val showId: Long,
         val forceRefresh: Boolean = false,
     )
 

--- a/domain/showdetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/Mapper.kt
+++ b/domain/showdetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/Mapper.kt
@@ -25,7 +25,7 @@ internal fun List<ShowCast>.toCastList(): List<Casts> =
 internal fun List<SimilarShows>.toSimilarShowList(): List<Show> =
     map {
         Show(
-            traktId = it.show_trakt_id,
+            showId = it.show_trakt_id,
             title = it.name,
             posterImageUrl = it.poster_path,
             backdropImageUrl = it.backdrop_path,

--- a/domain/showdetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/Mapper.kt
+++ b/domain/showdetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/Mapper.kt
@@ -1,6 +1,6 @@
 package com.thomaskioko.tvmaniac.domain.showdetails
 
-import com.thomaskioko.tvmaniac.db.SelectByShowTraktId
+import com.thomaskioko.tvmaniac.db.SelectByShowId
 import com.thomaskioko.tvmaniac.db.ShowCast
 import com.thomaskioko.tvmaniac.db.ShowSeasons
 import com.thomaskioko.tvmaniac.db.SimilarShows
@@ -57,7 +57,7 @@ internal fun List<ShowSeasons>.toSeasonsList(
         )
     }
 
-internal fun List<SelectByShowTraktId>.toTrailerList(): List<Trailer> =
+internal fun List<SelectByShowId>.toTrailerList(): List<Trailer> =
     map { trailer ->
         Trailer(
             showTmdbId = trailer.show_tmdb_id.id,

--- a/domain/showdetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/ObservableShowDetailsInteractor.kt
+++ b/domain/showdetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/ObservableShowDetailsInteractor.kt
@@ -21,7 +21,7 @@ public class ObservableShowDetailsInteractor(
         showDetailsRepository.observeShowDetails(params)
             .map { row ->
                 ShowDetails(
-                    traktId = row.trakt_id,
+                    showId = row.trakt_id,
                     tmdbId = row.tmdb_id.id,
                     title = row.name,
                     overview = row.overview,

--- a/domain/showdetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/ShowDetailsInteractor.kt
+++ b/domain/showdetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/ShowDetailsInteractor.kt
@@ -30,14 +30,14 @@ public class ShowDetailsInteractor(
     override suspend fun doWork(params: Param) {
         withContext(dispatchers.io) {
             coroutineScope {
-                launch { castRepository.fetchShowCast(showTraktId = params.id, forceRefresh = params.forceRefresh) }
-                launch { trailerRepository.fetchTrailers(traktId = params.id, forceRefresh = params.forceRefresh) }
-                launch { providerRepository.fetchWatchProviders(traktId = params.id, forceRefresh = params.forceRefresh) }
+                launch { castRepository.fetchShowCast(showId = params.id, forceRefresh = params.forceRefresh) }
+                launch { trailerRepository.fetchTrailers(showId = params.id, forceRefresh = params.forceRefresh) }
+                launch { providerRepository.fetchWatchProviders(showId = params.id, forceRefresh = params.forceRefresh) }
                 launch {
                     showDetailsRepository.fetchShowDetails(id = params.id, forceRefresh = params.forceRefresh)
-                    seasonsEpisodesSyncRepository.syncSeasonsWithEpisodes(showTraktId = params.id, forceRefresh = params.forceRefresh)
-                    seasonDetailsRepository.syncShowSeasonDetails(showTraktId = params.id, forceRefresh = params.forceRefresh)
-                    watchedEpisodeSyncRepository.syncShowEpisodeWatches(showTraktId = params.id, forceRefresh = params.forceRefresh)
+                    seasonsEpisodesSyncRepository.syncSeasonsWithEpisodes(showId = params.id, forceRefresh = params.forceRefresh)
+                    seasonDetailsRepository.syncShowSeasonDetails(showId = params.id, forceRefresh = params.forceRefresh)
+                    watchedEpisodeSyncRepository.syncShowEpisodeWatches(showId = params.id, forceRefresh = params.forceRefresh)
                 }
             }
         }

--- a/domain/showdetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/SyncShowMetadataInteractor.kt
+++ b/domain/showdetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/SyncShowMetadataInteractor.kt
@@ -19,22 +19,22 @@ public class SyncShowMetadataInteractor(
     override suspend fun doWork(params: Param) {
         withContext(dispatchers.io) {
             showDetailsRepository.fetchShowDetails(
-                id = params.traktId,
+                id = params.showId,
                 forceRefresh = params.forceRefresh,
             )
             seasonDetailsRepository.syncShowSeasonDetails(
-                showTraktId = params.traktId,
+                showId = params.showId,
                 forceRefresh = params.forceRefresh,
             )
             watchProviderRepository.fetchWatchProviders(
-                traktId = params.traktId,
+                showId = params.showId,
                 forceRefresh = params.forceRefresh,
             )
         }
     }
 
     public data class Param(
-        val traktId: Long,
+        val showId: Long,
         val forceRefresh: Boolean = false,
     )
 }

--- a/domain/showdetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/model/ShowDetails.kt
+++ b/domain/showdetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/model/ShowDetails.kt
@@ -2,7 +2,7 @@ package com.thomaskioko.tvmaniac.domain.showdetails.model
 
 public data class ShowDetails(
     val tmdbId: Long,
-    val traktId: Long,
+    val showId: Long,
     val title: String,
     val overview: String,
     val language: String?,
@@ -18,7 +18,7 @@ public data class ShowDetails(
     public companion object {
         public val Empty: ShowDetails = ShowDetails(
             tmdbId = 0,
-            traktId = 0,
+            showId = 0,
             title = "",
             overview = "",
             language = null,
@@ -60,7 +60,7 @@ public data class Season(
 }
 
 public data class Show(
-    val traktId: Long,
+    val showId: Long,
     val title: String,
     val posterImageUrl: String?,
     val backdropImageUrl: String?,

--- a/domain/showdetails/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/SyncShowMetadataInteractorTest.kt
+++ b/domain/showdetails/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/showdetails/SyncShowMetadataInteractorTest.kt
@@ -35,17 +35,17 @@ class SyncShowMetadataInteractorTest {
     @Test
     fun `should fan out show details season details and watch providers for the given trakt id`() =
         runTest(testDispatcher) {
-            interactor.executeSync(SyncShowMetadataInteractor.Param(traktId = 1388L))
+            interactor.executeSync(SyncShowMetadataInteractor.Param(showId = 1388L))
 
             showDetailsRepository.fetchInvocations().map { it.id } shouldBe listOf(1388L)
             seasonDetailsRepository.getSyncedShowIds() shouldBe listOf(1388L)
-            watchProviderRepository.fetchInvocations().map { it.traktId } shouldBe listOf(1388L)
+            watchProviderRepository.fetchInvocations().map { it.showId } shouldBe listOf(1388L)
         }
 
     @Test
     fun `should propagate force refresh to every downstream repository`() = runTest(testDispatcher) {
         interactor.executeSync(
-            SyncShowMetadataInteractor.Param(traktId = 1388L, forceRefresh = true),
+            SyncShowMetadataInteractor.Param(showId = 1388L, forceRefresh = true),
         )
 
         showDetailsRepository.fetchInvocations().single().forceRefresh shouldBe true

--- a/domain/similarshows/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/similarshows/SimilarShowsInteractor.kt
+++ b/domain/similarshows/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/similarshows/SimilarShowsInteractor.kt
@@ -14,7 +14,7 @@ public class SimilarShowsInteractor(
 ) : Interactor<Param>() {
     override suspend fun doWork(params: Param) {
         withContext(dispatchers.io) {
-            similarShowsRepository.fetchSimilarShows(traktId = params.id, forceRefresh = params.forceRefresh)
+            similarShowsRepository.fetchSimilarShows(showId = params.id, forceRefresh = params.forceRefresh)
         }
     }
 

--- a/domain/start-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/startwatching/ObserveStartWatchingInteractorTest.kt
+++ b/domain/start-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/startwatching/ObserveStartWatchingInteractorTest.kt
@@ -30,7 +30,7 @@ internal class ObserveStartWatchingInteractorTest {
     private companion object {
         val shows = listOf(
             StartWatchingShow(
-                traktId = 1,
+                showId = 1,
                 tmdbId = 1,
                 title = "Breaking Bad",
                 posterPath = "/1.jpg",
@@ -38,7 +38,7 @@ internal class ObserveStartWatchingInteractorTest {
                 inLibrary = true,
             ),
             StartWatchingShow(
-                traktId = 2,
+                showId = 2,
                 tmdbId = 2,
                 title = "Severance",
                 posterPath = "/2.jpg",

--- a/domain/traktlists/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/traktlists/ToggleShowInListInteractor.kt
+++ b/domain/traktlists/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/traktlists/ToggleShowInListInteractor.kt
@@ -16,14 +16,14 @@ public class ToggleShowInListInteractor(
         repository.toggleShowInList(
             slug = slug,
             listId = params.listId,
-            traktShowId = params.traktShowId,
+            showId = params.showId,
             isCurrentlyInList = params.isCurrentlyInList,
         )
     }
 
     public data class Params(
         val listId: Long,
-        val traktShowId: Long,
+        val showId: Long,
         val isCurrentlyInList: Boolean,
     )
 }

--- a/domain/watchproviders/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/watchproviders/WatchProvidersInteractor.kt
+++ b/domain/watchproviders/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/watchproviders/WatchProvidersInteractor.kt
@@ -14,7 +14,7 @@ public class WatchProvidersInteractor(
 ) : Interactor<Param>() {
     override suspend fun doWork(params: Param) {
         withContext(dispatchers.io) {
-            repository.fetchWatchProviders(traktId = params.id, forceRefresh = params.forceRefresh)
+            repository.fetchWatchProviders(showId = params.id, forceRefresh = params.forceRefresh)
         }
     }
 

--- a/features/calendar/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/calendar/CalendarAction.kt
+++ b/features/calendar/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/calendar/CalendarAction.kt
@@ -8,6 +8,6 @@ public data object NavigateToPreviousWeek : CalendarAction
 
 public data object NavigateToNextWeek : CalendarAction
 
-public data class EpisodeCardClicked(val episodeTraktId: Long) : CalendarAction
+public data class EpisodeCardClicked(val episodeId: Long) : CalendarAction
 
 public data class MessageShown(val id: Long) : CalendarAction

--- a/features/calendar/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/calendar/CalendarPresenter.kt
+++ b/features/calendar/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/calendar/CalendarPresenter.kt
@@ -103,7 +103,7 @@ public class CalendarPresenter(
             is NavigateToPreviousWeek -> navigateToPreviousWeek()
             is NavigateToNextWeek -> navigateToNextWeek()
             is EpisodeCardClicked -> navigator.navigateTo(
-                EpisodeSheetRoute(EpisodeSheetParam(episodeId = action.episodeTraktId, source = ScreenSource.CALENDAR)),
+                EpisodeSheetRoute(EpisodeSheetParam(episodeId = action.episodeId, source = ScreenSource.CALENDAR)),
             )
             is MessageShown -> clearMessage(action.id)
         }

--- a/features/calendar/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/calendar/CalendarStateMapper.kt
+++ b/features/calendar/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/calendar/CalendarStateMapper.kt
@@ -48,8 +48,8 @@ public class CalendarStateMapper(
     ): ImmutableList<CalendarEpisodeItem> {
         return entries.map { entry ->
             CalendarEpisodeItem(
-                showTraktId = entry.showTraktId,
-                episodeTraktId = entry.episodeTraktId,
+                showId = entry.showId,
+                episodeId = entry.episodeId,
                 showTitle = entry.showTitle,
                 posterUrl = entry.posterUrl,
                 episodeInfo = entry.episodeInfo,

--- a/features/calendar/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/calendar/model/CalendarEpisodeItem.kt
+++ b/features/calendar/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/calendar/model/CalendarEpisodeItem.kt
@@ -1,8 +1,8 @@
 package com.thomaskioko.tvmaniac.presentation.calendar.model
 
 public data class CalendarEpisodeItem(
-    val showTraktId: Long,
-    val episodeTraktId: Long,
+    val showId: Long,
+    val episodeId: Long,
     val showTitle: String,
     val posterUrl: String?,
     val episodeInfo: String,

--- a/features/calendar/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/calendar/CalendarPresenterTest.kt
+++ b/features/calendar/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/calendar/CalendarPresenterTest.kt
@@ -71,8 +71,8 @@ internal class CalendarPresenterTest {
         val airDate = todayEpochMillis()
         calendarRepository.setCalendarEntries(
             listOf(
-                createTestEntry(showTraktId = 1, episodeTraktId = 10, airDate = airDate),
-                createTestEntry(showTraktId = 2, episodeTraktId = 20, airDate = airDate),
+                createTestEntry(showId = 1, episodeId = 10, airDate = airDate),
+                createTestEntry(showId = 2, episodeId = 20, airDate = airDate),
             ),
         )
 
@@ -93,15 +93,15 @@ internal class CalendarPresenterTest {
         calendarRepository.setCalendarEntries(
             listOf(
                 createTestEntry(
-                    showTraktId = 1,
-                    episodeTraktId = 10,
+                    showId = 1,
+                    episodeId = 10,
                     seasonNumber = 1,
                     episodeNumber = 1,
                     airDate = airDate,
                 ),
                 createTestEntry(
-                    showTraktId = 1,
-                    episodeTraktId = 11,
+                    showId = 1,
+                    episodeId = 11,
                     seasonNumber = 1,
                     episodeNumber = 2,
                     airDate = airDate,
@@ -126,8 +126,8 @@ internal class CalendarPresenterTest {
         val tomorrowEpoch = tomorrowEpochMillis()
         calendarRepository.setCalendarEntries(
             listOf(
-                createTestEntry(showTraktId = 1, episodeTraktId = 10, airDate = todayEpoch),
-                createTestEntry(showTraktId = 2, episodeTraktId = 20, airDate = tomorrowEpoch),
+                createTestEntry(showId = 1, episodeId = 10, airDate = todayEpoch),
+                createTestEntry(showId = 2, episodeId = 20, airDate = tomorrowEpoch),
             ),
         )
 
@@ -148,8 +148,8 @@ internal class CalendarPresenterTest {
         calendarRepository.setCalendarEntries(
             listOf(
                 createTestEntry(
-                    showTraktId = 1,
-                    episodeTraktId = 10,
+                    showId = 1,
+                    episodeId = 10,
                     seasonNumber = 2,
                     episodeNumber = 5,
                     episodeTitle = "The One",
@@ -173,8 +173,8 @@ internal class CalendarPresenterTest {
         calendarRepository.setCalendarEntries(
             listOf(
                 createTestEntry(
-                    showTraktId = 1,
-                    episodeTraktId = 10,
+                    showId = 1,
+                    episodeId = 10,
                     seasonNumber = 1,
                     episodeNumber = 3,
                     episodeTitle = null,
@@ -294,7 +294,7 @@ internal class CalendarPresenterTest {
 
         presenter.state.test { awaitItem() }
 
-        presenter.dispatch(EpisodeCardClicked(episodeTraktId = 42))
+        presenter.dispatch(EpisodeCardClicked(episodeId = 42))
 
         val activated = navigator.lastActivatedOverlay
         (activated as EpisodeSheetRoute).param.episodeId shouldBe 42
@@ -307,7 +307,7 @@ internal class CalendarPresenterTest {
 
         presenter.state.test { awaitItem() }
 
-        presenter.dispatch(EpisodeCardClicked(episodeTraktId = 999))
+        presenter.dispatch(EpisodeCardClicked(episodeId = 999))
 
         val activated = navigator.lastActivatedOverlay
         (activated as EpisodeSheetRoute).param.episodeId shouldBe 999
@@ -334,8 +334,8 @@ internal class CalendarPresenterTest {
         calendarRepository.setCalendarEntries(
             listOf(
                 createTestEntry(
-                    showTraktId = 1,
-                    episodeTraktId = 10,
+                    showId = 1,
+                    episodeId = 10,
                     showTitle = "Breaking Bad",
                     showPosterPath = "/poster.jpg",
                     network = "AMC",
@@ -354,8 +354,8 @@ internal class CalendarPresenterTest {
             skipItems(1) // Skip initial loading state
             val state = awaitItem()
             val episode = state.dateGroups[0].episodes[0]
-            episode.showTraktId shouldBe 1
-            episode.episodeTraktId shouldBe 10
+            episode.showId shouldBe 1
+            episode.episodeId shouldBe 10
             episode.showTitle shouldBe "Breaking Bad"
             episode.posterUrl shouldBe "/poster.jpg"
             episode.network shouldBe "AMC"
@@ -370,7 +370,7 @@ internal class CalendarPresenterTest {
     fun `should show loading false given data is available`() = runTest {
         val airDate = todayEpochMillis()
         calendarRepository.setCalendarEntries(
-            listOf(createTestEntry(showTraktId = 1, episodeTraktId = 10, airDate = airDate)),
+            listOf(createTestEntry(showId = 1, episodeId = 10, airDate = airDate)),
         )
 
         val presenter = createPresenter()
@@ -446,8 +446,8 @@ internal class CalendarPresenterTest {
 
     @Suppress("LongParameterList")
     private fun createTestEntry(
-        showTraktId: Long = 1,
-        episodeTraktId: Long = 10,
+        showId: Long = 1,
+        episodeId: Long = 10,
         seasonNumber: Int = 1,
         episodeNumber: Int = 1,
         episodeTitle: String? = "Test Episode",
@@ -460,8 +460,8 @@ internal class CalendarPresenterTest {
         rating: Double? = 8.0,
         votes: Int? = 100,
     ): CalendarEntry = CalendarEntry(
-        showTraktId = showTraktId,
-        episodeTraktId = episodeTraktId,
+        showId = showId,
+        episodeId = episodeId,
         seasonNumber = seasonNumber,
         episodeNumber = episodeNumber,
         episodeTitle = episodeTitle,

--- a/features/calendar/ui/src/main/kotlin/com/thomaskioko/tvmaniac/ui/calendar/CalendarScreen.kt
+++ b/features/calendar/ui/src/main/kotlin/com/thomaskioko/tvmaniac/ui/calendar/CalendarScreen.kt
@@ -153,7 +153,7 @@ private fun CalendarBody(
                 moreEpisodesFormat = state.moreEpisodesFormat,
                 contentPadding = contentPadding,
                 scrollBehavior = scrollBehavior,
-                onEpisodeClicked = { episodeTraktId -> onAction(EpisodeCardClicked(episodeTraktId)) },
+                onEpisodeClicked = { episodeId -> onAction(EpisodeCardClicked(episodeId)) },
             )
         }
     }
@@ -258,13 +258,13 @@ private fun CalendarContent(
 
             items(
                 items = dateGroup.episodes,
-                key = { "${dateGroup.dateLabel}_${it.showTraktId}" },
+                key = { "${dateGroup.dateLabel}_${it.showId}" },
             ) { episode ->
                 CalendarEpisodeCard(
-                    modifier = Modifier.testTag(CalendarTestTags.episodeCard(episode.episodeTraktId)),
+                    modifier = Modifier.testTag(CalendarTestTags.episodeCard(episode.episodeId)),
                     episode = episode,
                     moreEpisodesFormat = moreEpisodesFormat,
-                    onClick = { onEpisodeClicked(episode.episodeTraktId) },
+                    onClick = { onEpisodeClicked(episode.episodeId) },
                 )
             }
         }
@@ -364,7 +364,7 @@ private fun CalendarEpisodeCard(
             if (episode.additionalEpisodesCount > 0) {
                 Box(
                     modifier = Modifier
-                        .testTag(CalendarTestTags.additionalEpisodesCount(episode.episodeTraktId))
+                        .testTag(CalendarTestTags.additionalEpisodesCount(episode.episodeId))
                         .semantics(mergeDescendants = true) {}
                         .fillMaxWidth()
                         .background(MaterialTheme.colorScheme.surfaceVariant)
@@ -398,8 +398,8 @@ private fun CalendarScreenPreview() {
                     dateLabel = "Today, Jan 31, 2026",
                     episodes = persistentListOf(
                         CalendarEpisodeItem(
-                            showTraktId = 1,
-                            episodeTraktId = 100,
+                            showId = 1,
+                            episodeId = 100,
                             showTitle = "Severance",
                             posterUrl = null,
                             episodeInfo = "S02E01 · Hello, Ms. Cobel",
@@ -418,8 +418,8 @@ private fun CalendarScreenPreview() {
                     dateLabel = "Tomorrow, Feb 1, 2026",
                     episodes = persistentListOf(
                         CalendarEpisodeItem(
-                            showTraktId = 2,
-                            episodeTraktId = 200,
+                            showId = 2,
+                            episodeId = 200,
                             showTitle = "Hell's Paradise",
                             posterUrl = null,
                             episodeInfo = "S02E04 · The Battle Begins",

--- a/features/calendar/ui/src/test/kotlin/com/thomaskioko/tvmaniac/ui/calendar/roborrazi/CalendarScreenshotTest.kt
+++ b/features/calendar/ui/src/test/kotlin/com/thomaskioko/tvmaniac/ui/calendar/roborrazi/CalendarScreenshotTest.kt
@@ -95,8 +95,8 @@ class CalendarScreenshotTest {
                                 dateLabel = "Today, Jan 31, 2026",
                                 episodes = persistentListOf(
                                     CalendarEpisodeItem(
-                                        showTraktId = 1,
-                                        episodeTraktId = 100,
+                                        showId = 1,
+                                        episodeId = 100,
                                         showTitle = "Severance",
                                         posterUrl = null,
                                         episodeInfo = "S02E01 · Hello, Ms. Cobel",
@@ -115,8 +115,8 @@ class CalendarScreenshotTest {
                                 dateLabel = "Tomorrow, Feb 1, 2026",
                                 episodes = persistentListOf(
                                     CalendarEpisodeItem(
-                                        showTraktId = 2,
-                                        episodeTraktId = 200,
+                                        showId = 2,
+                                        episodeId = 200,
                                         showTitle = "Hell's Paradise",
                                         posterUrl = null,
                                         episodeInfo = "S02E04 · The Battle Begins",

--- a/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingAction.kt
+++ b/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingAction.kt
@@ -2,25 +2,25 @@ package com.thomaskioko.tvmaniac.continuewatching.presenter
 
 public sealed interface ContinueWatchingAction
 
-public data class ContinueWatchingShowClicked(val traktId: Long) : ContinueWatchingAction
+public data class ContinueWatchingShowClicked(val showId: Long) : ContinueWatchingAction
 
 public data class ContinueWatchingMessageShown(val id: Long) : ContinueWatchingAction
 
-public data class UpNextEpisodeClicked(val showTraktId: Long, val episodeId: Long) : ContinueWatchingAction
+public data class UpNextEpisodeClicked(val showId: Long, val episodeId: Long) : ContinueWatchingAction
 
-public data class ShowTitleClicked(val showTraktId: Long) : ContinueWatchingAction
+public data class ShowTitleClicked(val showId: Long) : ContinueWatchingAction
 
 public data class MarkUpNextEpisodeWatched(
-    val showTraktId: Long,
+    val showId: Long,
     val episodeId: Long,
     val seasonNumber: Long,
     val episodeNumber: Long,
 ) : ContinueWatchingAction
 
-public data class UnfollowShowFromUpNext(val showTraktId: Long) : ContinueWatchingAction
+public data class UnfollowShowFromUpNext(val showId: Long) : ContinueWatchingAction
 
 public data class OpenSeasonFromUpNext(
-    val showTraktId: Long,
+    val showId: Long,
     val seasonId: Long,
     val seasonNumber: Long,
 ) : ContinueWatchingAction

--- a/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingPresenter.kt
+++ b/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingPresenter.kt
@@ -132,16 +132,16 @@ public class ContinueWatchingPresenter(
 
     public fun dispatch(action: ContinueWatchingAction) {
         when (action) {
-            is ContinueWatchingShowClicked -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(id = action.traktId)))
+            is ContinueWatchingShowClicked -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(showId = action.showId)))
             is ContinueWatchingMessageShown -> clearMessage(action.id)
-            is UpNextEpisodeClicked -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(id = action.showTraktId)))
-            is ShowTitleClicked -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(id = action.showTraktId)))
+            is UpNextEpisodeClicked -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(showId = action.showId)))
+            is ShowTitleClicked -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(showId = action.showId)))
             is MarkUpNextEpisodeWatched -> markEpisodeWatched(action)
-            is UnfollowShowFromUpNext -> unfollowShow(action.showTraktId)
+            is UnfollowShowFromUpNext -> unfollowShow(action.showId)
             is OpenSeasonFromUpNext -> navigator.navigateTo(
                 SeasonDetailsRoute(
                     SeasonDetailsUiParam(
-                        showTraktId = action.showTraktId,
+                        showId = action.showId,
                         seasonId = action.seasonId,
                         seasonNumber = action.seasonNumber,
                     ),
@@ -160,7 +160,7 @@ public class ContinueWatchingPresenter(
             try {
                 markEpisodeWatchedInteractor(
                     MarkEpisodeWatchedParams(
-                        showTraktId = action.showTraktId,
+                        showId = action.showId,
                         episodeId = action.episodeId,
                         seasonNumber = action.seasonNumber,
                         episodeNumber = action.episodeNumber,
@@ -185,9 +185,9 @@ public class ContinueWatchingPresenter(
         private val INDICATOR_FLOOR: Duration = 150.milliseconds
     }
 
-    private fun unfollowShow(showTraktId: Long) {
+    private fun unfollowShow(showId: Long) {
         coroutineScope.launch {
-            unfollowShowInteractor.executeSync(showTraktId)
+            unfollowShowInteractor.executeSync(showId)
         }
     }
 

--- a/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/Mapper.kt
+++ b/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/Mapper.kt
@@ -27,7 +27,7 @@ public fun List<FollowedShows>.entityToWatchlistShowList(
         val total = it.total_episode_count
         val progress = if (total > 0) watched.toFloat() / total else 0f
         ContinueWatchingItem(
-            traktId = it.show_trakt_id,
+            showId = it.show_trakt_id,
             title = it.name,
             posterImageUrl = it.poster_path,
             status = it.status,
@@ -51,7 +51,7 @@ public fun List<SearchFollowedShows>.entityToWatchlistShowList(
         val total = it.total_episode_count
         val progress = if (total > 0) watched.toFloat() / total else 0f
         ContinueWatchingItem(
-            traktId = it.show_trakt_id,
+            showId = it.show_trakt_id,
             title = it.name,
             posterImageUrl = it.poster_path,
             status = it.status,
@@ -73,7 +73,7 @@ internal fun WatchlistSections.toPresenter(): SectionedItems = SectionedItems(
 )
 
 internal fun WatchlistShowInfo.toPresenter(): ContinueWatchingItem = ContinueWatchingItem(
-    traktId = traktId,
+    showId = showId,
     title = title ?: "",
     posterImageUrl = posterImageUrl,
     status = status,
@@ -104,7 +104,7 @@ internal fun UpNextSections.toPresenter(): SectionedEpisodes = SectionedEpisodes
 
 internal fun UpNextEpisodeInfo.toPresenter(): UpNextEpisodeItem {
     return UpNextEpisodeItem(
-        showTraktId = showTraktId,
+        showId = showId,
         showName = showName,
         showPoster = showPoster,
         episodeId = episodeId,

--- a/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/model/ContinueWatchingItem.kt
+++ b/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/model/ContinueWatchingItem.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.continuewatching.presenter.model
 
 public data class ContinueWatchingItem(
-    val traktId: Long,
+    val showId: Long,
     val title: String,
     val posterImageUrl: String? = null,
     val status: String? = null,

--- a/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/model/UpNextEpisodeItem.kt
+++ b/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/model/UpNextEpisodeItem.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.continuewatching.presenter.model
 
 public data class UpNextEpisodeItem(
-    val showTraktId: Long,
+    val showId: Long,
     val showName: String,
     val showPoster: String?,
     val episodeId: Long,

--- a/features/continue-watching/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingPresenterTest.kt
+++ b/features/continue-watching/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingPresenterTest.kt
@@ -91,8 +91,8 @@ class ContinueWatchingPresenterTest {
     @Test
     fun `should emit watchNextEpisodes when episodes are available`() = runTest {
         val nextEpisodes = listOf(
-            createNextEpisodeWithShow(showTraktId = 1L, showName = "Loki", episodeId = 101L),
-            createNextEpisodeWithShow(showTraktId = 2L, showName = "Wednesday", episodeId = 201L),
+            createNextEpisodeWithShow(showId = 1L, showName = "Loki", episodeId = 101L),
+            createNextEpisodeWithShow(showId = 2L, showName = "Wednesday", episodeId = 201L),
         )
 
         presenter.state.test {
@@ -110,8 +110,8 @@ class ContinueWatchingPresenterTest {
     @Test
     fun `should filter watchNextEpisodes by show name when query is active`() = runTest {
         val nextEpisodes = listOf(
-            createNextEpisodeWithShow(showTraktId = 1L, showName = "Loki", episodeId = 101L),
-            createNextEpisodeWithShow(showTraktId = 2L, showName = "Wednesday", episodeId = 201L),
+            createNextEpisodeWithShow(showId = 1L, showName = "Loki", episodeId = 101L),
+            createNextEpisodeWithShow(showId = 2L, showName = "Wednesday", episodeId = 201L),
         )
 
         presenter.state.test {
@@ -137,7 +137,7 @@ class ContinueWatchingPresenterTest {
         factory.dateTimeProvider.setCurrentTimeMillis(currentTime)
 
         val premiereEpisode = createNextEpisodeWithShow(
-            showTraktId = 1L,
+            showId = 1L,
             showName = "Loki",
             episodeId = 101L,
             episodeNumber = 1L,
@@ -165,13 +165,13 @@ class ContinueWatchingPresenterTest {
         factory.dateTimeProvider.setCurrentTimeMillis(currentTime)
 
         val staleEpisode = createNextEpisodeWithShow(
-            showTraktId = 1L,
+            showId = 1L,
             showName = "Stale Show",
             episodeId = 101L,
             lastWatchedAt = seventeenDaysAgo,
         )
         val activeEpisode = createNextEpisodeWithShow(
-            showTraktId = 2L,
+            showId = 2L,
             showName = "Active Show",
             episodeId = 201L,
             lastWatchedAt = oneDayAgo,
@@ -196,7 +196,7 @@ class ContinueWatchingPresenterTest {
     }
 
     private fun createNextEpisodeWithShow(
-        showTraktId: Long,
+        showId: Long,
         showName: String,
         episodeId: Long,
         episodeNumber: Long = 2L,
@@ -204,8 +204,8 @@ class ContinueWatchingPresenterTest {
         lastWatchedAt: Long? = null,
         firstAired: Long? = LocalDate(2021, 6, 9).toEpochMillis(),
     ) = NextEpisodeWithShow(
-        showTraktId = showTraktId,
-        showTmdbId = showTraktId,
+        showId = showId,
+        showTmdbId = showId,
         showName = showName,
         showPoster = "/poster.jpg",
         showStatus = "Ended",

--- a/features/continue-watching/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/MockData.kt
+++ b/features/continue-watching/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/MockData.kt
@@ -7,7 +7,7 @@ import kotlinx.collections.immutable.toPersistentList
 
 val cachedNextEpisodes = mutableListOf(
     NextEpisodeWithShow(
-        showTraktId = 84958,
+        showId = 84958,
         showTmdbId = 84958,
         showName = "Loki",
         showPoster = "/kEl2t3OhXc3Zb9FBh1AuYzRTgZp.jpg",
@@ -32,7 +32,7 @@ val cachedNextEpisodes = mutableListOf(
 
 val updatedNextEpisodes = listOf(
     NextEpisodeWithShow(
-        showTraktId = 84958,
+        showId = 84958,
         showTmdbId = 84958,
         showName = "Loki",
         showPoster = "/kEl2t3OhXc3Zb9FBh1AuYzRTgZp.jpg",
@@ -54,7 +54,7 @@ val updatedNextEpisodes = listOf(
         totalCount = 0,
     ),
     NextEpisodeWithShow(
-        showTraktId = 1232,
+        showId = 1232,
         showTmdbId = 1232,
         showName = "The Lazarus Project",
         showPoster = "/kEl2t3OhXc3Zb9FBh1AuYzRTgZp.jpg",
@@ -83,7 +83,7 @@ internal fun expectedUiResult(
     .map {
         val progress = if (it.totalCount > 0) it.watchedCount.toFloat() / it.totalCount else 0f
         ContinueWatchingItem(
-            traktId = it.showTraktId,
+            showId = it.showId,
             title = it.showName ?: "",
             posterImageUrl = it.showPoster,
             status = it.showStatus,

--- a/features/continue-watching/ui/src/main/kotlin/com/thomaskioko/tvmaniac/continuewatching/ui/ContinueWatchingListItem.kt
+++ b/features/continue-watching/ui/src/main/kotlin/com/thomaskioko/tvmaniac/continuewatching/ui/ContinueWatchingListItem.kt
@@ -43,7 +43,7 @@ internal fun ContinueWatchingListItem(
         modifier = modifier
             .fillMaxWidth()
             .height(140.dp),
-        onClick = { onItemClicked(item.traktId) },
+        onClick = { onItemClicked(item.showId) },
         shape = RectangleShape,
     ) {
         Row(
@@ -53,7 +53,7 @@ internal fun ContinueWatchingListItem(
             // Poster image
             PosterCard(
                 imageUrl = item.posterImageUrl,
-                onClick = { onItemClicked(item.traktId) },
+                onClick = { onItemClicked(item.showId) },
                 title = item.title,
                 shape = RectangleShape,
             )

--- a/features/continue-watching/ui/src/main/kotlin/com/thomaskioko/tvmaniac/continuewatching/ui/ContinueWatchingPreviewParameterProvider.kt
+++ b/features/continue-watching/ui/src/main/kotlin/com/thomaskioko/tvmaniac/continuewatching/ui/ContinueWatchingPreviewParameterProvider.kt
@@ -11,7 +11,7 @@ import kotlinx.collections.immutable.toPersistentList
 
 internal val continueWatchingItems = List(3) { index ->
     ContinueWatchingItem(
-        traktId = 84958L + index,
+        showId = 84958L + index,
         title = "Loki",
         posterImageUrl = null,
         year = "2021",
@@ -24,7 +24,7 @@ internal val continueWatchingItems = List(3) { index ->
 
 internal val staleContinueWatchingItems = List(2) { index ->
     ContinueWatchingItem(
-        traktId = 94958L + index,
+        showId = 94958L + index,
         title = "The Mandalorian",
         posterImageUrl = null,
         year = "2019",
@@ -38,7 +38,7 @@ internal val staleContinueWatchingItems = List(2) { index ->
 
 internal val watchNextEpisodes = listOf(
     UpNextEpisodeItem(
-        showTraktId = 84958L,
+        showId = 84958L,
         showName = "Loki",
         showPoster = null,
         episodeId = 1L,
@@ -54,7 +54,7 @@ internal val watchNextEpisodes = listOf(
         remainingEpisodes = 5,
     ),
     UpNextEpisodeItem(
-        showTraktId = 95557L,
+        showId = 95557L,
         showName = "The Walking Dead",
         showPoster = null,
         episodeId = 12L,
@@ -73,7 +73,7 @@ internal val watchNextEpisodes = listOf(
 
 internal val staleEpisodes = listOf(
     UpNextEpisodeItem(
-        showTraktId = 94958L,
+        showId = 94958L,
         showName = "The Mandalorian",
         showPoster = null,
         episodeId = 5L,

--- a/features/continue-watching/ui/src/main/kotlin/com/thomaskioko/tvmaniac/continuewatching/ui/ContinueWatchingScreen.kt
+++ b/features/continue-watching/ui/src/main/kotlin/com/thomaskioko/tvmaniac/continuewatching/ui/ContinueWatchingScreen.kt
@@ -151,7 +151,7 @@ public fun ContinueWatchingScreen(
                                 onMarkWatched = { episode ->
                                     onAction(
                                         MarkUpNextEpisodeWatched(
-                                            showTraktId = episode.showTraktId,
+                                            showId = episode.showId,
                                             episodeId = episode.episodeId,
                                             seasonNumber = episode.seasonNumber,
                                             episodeNumber = episode.episodeNumber,
@@ -203,7 +203,7 @@ private fun SectionedContinueWatchingGridContent(
             }
             items(
                 items = chunkedWatchNext,
-                key = { "watchnext_row_${it.first().traktId}" },
+                key = { "watchnext_row_${it.first().showId}" },
                 contentType = { "WatchnextRow" },
             ) { rowItems ->
                 GridRow(
@@ -219,7 +219,7 @@ private fun SectionedContinueWatchingGridContent(
             }
             items(
                 items = chunkedStale,
-                key = { "stale_row_${it.first().traktId}" },
+                key = { "stale_row_${it.first().showId}" },
                 contentType = { "StaleRow" },
             ) { rowItems ->
                 GridRow(
@@ -270,11 +270,11 @@ private fun ContinueWatchingGridItem(
     ) {
         PosterCard(
             imageUrl = show.posterImageUrl,
-            onClick = { onItemClicked(show.traktId) },
+            onClick = { onItemClicked(show.showId) },
             modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(2f / 3f)
-                .testTag(MyShowsTestTags.showCard(show.traktId)),
+                .testTag(MyShowsTestTags.showCard(show.showId)),
             title = show.title.orEmpty(),
             shape = RectangleShape,
         )
@@ -317,7 +317,7 @@ private fun SectionedUpNextListContent(
             }
             items(
                 items = watchNextEpisodes,
-                key = { "watchnext_${it.showTraktId}_${it.episodeId}" },
+                key = { "watchnext_${it.showId}_${it.episodeId}" },
                 contentType = { "WatchnextEpisode" },
             ) { episode ->
                 ContinueWatchingUpNextListItem(
@@ -325,7 +325,7 @@ private fun SectionedUpNextListContent(
                     premiereLabel = premiereLabel,
                     newLabel = newLabel,
                     onItemClicked = onEpisodeClicked,
-                    onShowTitleClicked = { onShowTitleClicked(episode.showTraktId) },
+                    onShowTitleClicked = { onShowTitleClicked(episode.showId) },
                     onMarkWatched = { onMarkWatched(episode) },
                     modifier = Modifier.animateItem(),
                     isUpdating = episode.episodeId in updatingEpisodeIds,
@@ -342,7 +342,7 @@ private fun SectionedUpNextListContent(
             }
             items(
                 items = staleEpisodes,
-                key = { "stale_${it.showTraktId}_${it.episodeId}" },
+                key = { "stale_${it.showId}_${it.episodeId}" },
                 contentType = { "StaleEpisode" },
             ) { episode ->
                 ContinueWatchingUpNextListItem(
@@ -350,7 +350,7 @@ private fun SectionedUpNextListContent(
                     premiereLabel = premiereLabel,
                     newLabel = newLabel,
                     onItemClicked = onEpisodeClicked,
-                    onShowTitleClicked = { onShowTitleClicked(episode.showTraktId) },
+                    onShowTitleClicked = { onShowTitleClicked(episode.showId) },
                     onMarkWatched = { onMarkWatched(episode) },
                     modifier = Modifier.animateItem(),
                     isUpdating = episode.episodeId in updatingEpisodeIds,

--- a/features/continue-watching/ui/src/main/kotlin/com/thomaskioko/tvmaniac/continuewatching/ui/ContinueWatchingUpNextListItem.kt
+++ b/features/continue-watching/ui/src/main/kotlin/com/thomaskioko/tvmaniac/continuewatching/ui/ContinueWatchingUpNextListItem.kt
@@ -52,7 +52,7 @@ internal fun ContinueWatchingUpNextListItem(
 ) {
     Card(
         shape = MaterialTheme.shapes.small,
-        onClick = { onItemClicked(item.showTraktId, item.episodeId) },
+        onClick = { onItemClicked(item.showId, item.episodeId) },
         modifier = modifier,
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface,
@@ -77,7 +77,7 @@ internal fun ContinueWatchingUpNextListItem(
             ) {
                 TextTitlePill(
                     showName = item.showName,
-                    onClick = { onShowTitleClicked(item.showTraktId) },
+                    onClick = { onShowTitleClicked(item.showId) },
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))
@@ -162,7 +162,7 @@ internal fun ContinueWatchingUpNextListItem(
 private fun ContinueWatchingUpNextListItemPreview() {
     ContinueWatchingUpNextListItem(
         item = UpNextEpisodeItem(
-            showTraktId = 1L,
+            showId = 1L,
             showName = "The Walking Dead: Daryl Dixon",
             showPoster = "/poster.jpg",
             episodeId = 123L,

--- a/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/DiscoverShowsAction.kt
+++ b/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/DiscoverShowsAction.kt
@@ -16,35 +16,35 @@ public data object StartWatchingMoreClicked : DiscoverShowAction
 
 public data object RefreshData : DiscoverShowAction
 
-public data class ShowClicked(val traktId: Long) : DiscoverShowAction
+public data class ShowClicked(val showId: Long) : DiscoverShowAction
 
 public data class MessageShown(val id: Long) : DiscoverShowAction
 
-public data class UpdateShowInLibrary(val traktId: Long, val inLibrary: Boolean) : DiscoverShowAction
+public data class UpdateShowInLibrary(val showId: Long, val inLibrary: Boolean) : DiscoverShowAction
 
 public data class NextEpisodeClicked(
-    val showTraktId: Long,
+    val showId: Long,
     val seasonId: Long,
     val seasonNumber: Long,
 ) : DiscoverShowAction
 
 public data class MarkNextEpisodeWatched(
-    val showTraktId: Long,
+    val showId: Long,
     val episodeId: Long,
     val seasonNumber: Long,
     val episodeNumber: Long,
 ) : DiscoverShowAction
 
-public data class UnfollowShowFromUpNext(val showTraktId: Long) : DiscoverShowAction
+public data class UnfollowShowFromUpNext(val showId: Long) : DiscoverShowAction
 
 public data class OpenSeasonFromUpNext(
-    val showTraktId: Long,
+    val showId: Long,
     val seasonId: Long,
     val seasonNumber: Long,
 ) : DiscoverShowAction
 
-public data class OpenShowFromUpNext(val showTraktId: Long) : DiscoverShowAction
+public data class OpenShowFromUpNext(val showId: Long) : DiscoverShowAction
 
 public data object SearchIconClicked : DiscoverShowAction
 
-public data class DiscoverEpisodeLongPressed(val showTraktId: Long, val episodeId: Long) : DiscoverShowAction
+public data class DiscoverEpisodeLongPressed(val showId: Long, val episodeId: Long) : DiscoverShowAction

--- a/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/DiscoverShowsMapper.kt
+++ b/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/DiscoverShowsMapper.kt
@@ -10,7 +10,7 @@ import kotlinx.collections.immutable.toImmutableList
 internal fun List<ShowEntity>?.toShowList(): ImmutableList<DiscoverShow> =
     this?.map {
         DiscoverShow(
-            traktId = it.traktId,
+            showId = it.showId,
             tmdbId = it.tmdbId,
             title = it.title,
             posterImageUrl = it.posterPath,
@@ -24,7 +24,7 @@ internal fun List<ShowEntity>?.toShowList(): ImmutableList<DiscoverShow> =
 internal fun List<StartWatchingShow>.toStartWatchingShowList(): ImmutableList<DiscoverShow> =
     map {
         DiscoverShow(
-            traktId = it.traktId,
+            showId = it.showId,
             tmdbId = it.tmdbId,
             title = it.title,
             posterImageUrl = it.posterPath,

--- a/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/DiscoverShowsPresenter.kt
+++ b/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/DiscoverShowsPresenter.kt
@@ -186,7 +186,7 @@ public class DiscoverShowsPresenter(
 
         public fun dispatch(action: DiscoverShowAction) {
             when (action) {
-                is ShowClicked -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(id = action.traktId)))
+                is ShowClicked -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(showId = action.showId)))
                 PopularClicked -> navigator.navigateTo(MoreShowsRoute(Category.POPULAR.id))
                 TopRatedClicked -> navigator.navigateTo(MoreShowsRoute(Category.TOP_RATED.id))
                 TrendingClicked -> navigator.navigateTo(MoreShowsRoute(Category.TRENDING_TODAY.id))
@@ -197,10 +197,10 @@ public class DiscoverShowsPresenter(
                 is UpdateShowInLibrary -> {
                     coroutineScope.launch {
                         if (action.inLibrary) {
-                            unfollowShowInteractor.executeSync(action.traktId)
+                            unfollowShowInteractor.executeSync(action.showId)
                         } else {
                             followShowInteractor.executeSync(
-                                FollowShowInteractor.Param(traktId = action.traktId),
+                                FollowShowInteractor.Param(showId = action.showId),
                             )
                         }
                     }
@@ -211,7 +211,7 @@ public class DiscoverShowsPresenter(
                 is NextEpisodeClicked -> navigator.navigateTo(
                     SeasonDetailsRoute(
                         SeasonDetailsUiParam(
-                            showTraktId = action.showTraktId,
+                            showId = action.showId,
                             seasonId = action.seasonId,
                             seasonNumber = action.seasonNumber,
                         ),
@@ -221,7 +221,7 @@ public class DiscoverShowsPresenter(
                     coroutineScope.launch {
                         markEpisodeWatchedInteractor(
                             MarkEpisodeWatchedParams(
-                                showTraktId = action.showTraktId,
+                                showId = action.showId,
                                 episodeId = action.episodeId,
                                 seasonNumber = action.seasonNumber,
                                 episodeNumber = action.episodeNumber,
@@ -231,20 +231,20 @@ public class DiscoverShowsPresenter(
                 }
                 is UnfollowShowFromUpNext -> {
                     coroutineScope.launch {
-                        unfollowShowInteractor.executeSync(action.showTraktId)
+                        unfollowShowInteractor.executeSync(action.showId)
                     }
                 }
                 is OpenSeasonFromUpNext -> navigator.navigateTo(
                     SeasonDetailsRoute(
                         SeasonDetailsUiParam(
-                            showTraktId = action.showTraktId,
+                            showId = action.showId,
                             seasonId = action.seasonId,
                             seasonNumber = action.seasonNumber,
                         ),
                     ),
                 )
                 is OpenShowFromUpNext -> navigator.navigateTo(
-                    ShowDetailsRoute(ShowDetailsParam(id = action.showTraktId)),
+                    ShowDetailsRoute(ShowDetailsParam(showId = action.showId)),
                 )
                 SearchIconClicked -> navigator.navigateTo(SearchRoute)
                 is DiscoverEpisodeLongPressed -> navigator.navigateTo(
@@ -298,7 +298,7 @@ public class DiscoverShowsPresenter(
 
 private fun UpNextEpisode.toUiModel(): NextEpisodeUiModel {
     return NextEpisodeUiModel(
-        showTraktId = showTraktId,
+        showId = showId,
         showName = showName,
         imageUrl = stillPath ?: showPoster,
         episodeId = episodeId,

--- a/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/model/DiscoverShow.kt
+++ b/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/model/DiscoverShow.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.discover.presenter.model
 
 public data class DiscoverShow(
-    val traktId: Long,
+    val showId: Long,
     val tmdbId: Long,
     val title: String = "",
     val posterImageUrl: String? = null,

--- a/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/model/NextEpisodeUiModel.kt
+++ b/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/model/NextEpisodeUiModel.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.discover.presenter.model
 
 public data class NextEpisodeUiModel(
-    val showTraktId: Long,
+    val showId: Long,
     val showName: String,
     val imageUrl: String?,
     val episodeId: Long,

--- a/features/discover/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/discover/presenter/DiscoverShowsPresenterTest.kt
+++ b/features/discover/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/discover/presenter/DiscoverShowsPresenterTest.kt
@@ -381,12 +381,12 @@ class DiscoverShowsPresenterTest {
         )
 
         testNavigator.test {
-            testPresenter.dispatch(NextEpisodeClicked(showTraktId = 123L, seasonId = 10L, seasonNumber = 2L))
+            testPresenter.dispatch(NextEpisodeClicked(showId = 123L, seasonId = 10L, seasonNumber = 2L))
 
             awaitNavigateTo(
                 SeasonDetailsRoute(
                     param = SeasonDetailsUiParam(
-                        showTraktId = 123L,
+                        showId = 123L,
                         seasonId = 10L,
                         seasonNumber = 2L,
                     ),
@@ -436,7 +436,7 @@ class DiscoverShowsPresenterTest {
 
     private fun createNextEpisodesList(size: Int = LIST_SIZE) = List(size) { index ->
         NextEpisodeWithShow(
-            showTraktId = 84958L + index,
+            showId = 84958L + index,
             showTmdbId = 84958L + index,
             showName = "Test Show $index",
             showPoster = "/test-poster-$index.jpg",
@@ -460,7 +460,7 @@ class DiscoverShowsPresenterTest {
     private fun nextEpisodeUiModelList(size: Int = LIST_SIZE) =
         createNextEpisodesList(size).map { episode ->
             NextEpisodeUiModel(
-                showTraktId = episode.showTraktId,
+                showId = episode.showId,
                 showName = episode.showName!!,
                 imageUrl = episode.stillPath ?: episode.showPoster,
                 episodeId = episode.episodeId!!,
@@ -477,7 +477,7 @@ class DiscoverShowsPresenterTest {
 
     private fun createDiscoverShowList(size: Int = LIST_SIZE) = List(size) {
         ShowEntity(
-            traktId = 84958,
+            showId = 84958,
             tmdbId = 84958,
             title = "Loki",
             posterPath = "/kEl2t3OhXc3Zb9FBh1AuYzRTgZp.jpg",
@@ -488,7 +488,7 @@ class DiscoverShowsPresenterTest {
     private fun uiModelList(size: Int = LIST_SIZE) = createDiscoverShowList(size).map {
         DiscoverShow(
             tmdbId = it.tmdbId,
-            traktId = it.traktId,
+            showId = it.showId,
             title = it.title,
             posterImageUrl = it.posterPath,
             inLibrary = it.inLibrary,
@@ -497,11 +497,11 @@ class DiscoverShowsPresenterTest {
     }.toImmutableList()
 
     private val startWatchingShowList = listOf(
-        StartWatchingShow(traktId = 1, tmdbId = 11, title = "Breaking Bad", posterPath = "/1.jpg", year = "2008", inLibrary = true),
+        StartWatchingShow(showId = 1, tmdbId = 11, title = "Breaking Bad", posterPath = "/1.jpg", year = "2008", inLibrary = true),
     )
 
     private val expectedStartWatchingDiscoverShows = listOf(
-        DiscoverShow(traktId = 1, tmdbId = 11, title = "Breaking Bad", posterImageUrl = "/1.jpg", inLibrary = true),
+        DiscoverShow(showId = 1, tmdbId = 11, title = "Breaking Bad", posterImageUrl = "/1.jpg", inLibrary = true),
     ).toImmutableList()
 
     companion object {

--- a/features/discover/ui/src/main/java/com/thomaskioko/tvmaniac/discover/ui/DiscoverPreviewParameterProvider.kt
+++ b/features/discover/ui/src/main/java/com/thomaskioko/tvmaniac/discover/ui/DiscoverPreviewParameterProvider.kt
@@ -9,14 +9,14 @@ import kotlinx.collections.immutable.toImmutableList
 
 internal val discoverShow = DiscoverShow(
     tmdbId = 84958,
-    traktId = 84958,
+    showId = 84958,
     title = "Loki",
     posterImageUrl = "/kEl2t3OhXc3Zb9FBh1AuYzRTgZp.jpg",
     overView = "After stealing the Tesseract during the events of Avengers: Endgame, an ",
 )
 
 internal val nextEpisodeUiModel = NextEpisodeUiModel(
-    showTraktId = 1L,
+    showId = 1L,
     showName = "The Walking Dead: Daryl Dixon",
     imageUrl = "/kEl2t3OhXc3Zb9FBh1AuYzRTgZp.jpg",
     episodeId = 123L,
@@ -42,13 +42,13 @@ internal val discoverContentSuccess = DiscoverViewState(
 private fun createDiscoverShowList(size: Int = 20) = List(size) { index ->
     discoverShow.copy(
         tmdbId = discoverShow.tmdbId + index,
-        traktId = discoverShow.traktId + index,
+        showId = discoverShow.showId + index,
     )
 }.toImmutableList()
 
 private fun createNextEpisodesList(size: Int = 3) = List(size) { index ->
     nextEpisodeUiModel.copy(
-        showTraktId = (index + 1).toLong(),
+        showId = (index + 1).toLong(),
         showName = when (index) {
             0 -> "The Walking Dead: Daryl Dixon"
             1 -> "Wednesday"

--- a/features/discover/ui/src/main/java/com/thomaskioko/tvmaniac/discover/ui/DiscoverScreen.kt
+++ b/features/discover/ui/src/main/java/com/thomaskioko/tvmaniac/discover/ui/DiscoverScreen.kt
@@ -282,7 +282,7 @@ private fun LazyColumnContent(
                 title = label_discover_up_next.resolve(context),
                 nextEpisodes = dataLoadedState.nextEpisodes,
                 onEpisodeClick = { episode ->
-                    onAction(DiscoverEpisodeLongPressed(showTraktId = episode.showTraktId, episodeId = episode.episodeId))
+                    onAction(DiscoverEpisodeLongPressed(showId = episode.showId, episodeId = episode.episodeId))
                 },
             )
         }

--- a/features/discover/ui/src/main/java/com/thomaskioko/tvmaniac/discover/ui/component/DiscoverHeaderContent.kt
+++ b/features/discover/ui/src/main/java/com/thomaskioko/tvmaniac/discover/ui/component/DiscoverHeaderContent.kt
@@ -90,7 +90,7 @@ internal fun PosterCardsPager(
                 .height(pagerHeight)
                 .testTag(DiscoverTestTags.FEATURED_PAGER_TEST_TAG),
             state = pagerState,
-            key = { index -> list[index].traktId },
+            key = { index -> list[index].showId },
             verticalAlignment = Alignment.Bottom,
         ) { currentPage ->
 
@@ -100,8 +100,8 @@ internal fun PosterCardsPager(
                 currentPage = currentPage,
                 imageUrl = currentShow.posterImageUrl,
                 modifier = Modifier
-                    .testTag(DiscoverTestTags.featuredShowItem(currentShow.traktId))
-                    .clickable(onClick = { memoizedOnClick(currentShow.traktId) }),
+                    .testTag(DiscoverTestTags.featuredShowItem(currentShow.showId))
+                    .clickable(onClick = { memoizedOnClick(currentShow.showId) }),
             ) {
                 ShowCardOverlay(
                     title = currentShow.title,

--- a/features/discover/ui/src/main/java/com/thomaskioko/tvmaniac/discover/ui/component/HorizontalRowContent.kt
+++ b/features/discover/ui/src/main/java/com/thomaskioko/tvmaniac/discover/ui/component/HorizontalRowContent.kt
@@ -61,13 +61,13 @@ internal fun HorizontalRowContent(
                 ) {
                     items(
                         items = tvShows,
-                        key = { tvShow -> "${rowKey}_${tvShow.traktId}" },
+                        key = { tvShow -> "${rowKey}_${tvShow.showId}" },
                         contentType = { "ShowModel" },
                     ) { tvShow ->
                         PosterCard(
                             imageUrl = tvShow.posterImageUrl,
-                            onClick = { onItemClicked(tvShow.traktId) },
-                            modifier = Modifier.testTag(DiscoverTestTags.showCard(rowKey, tvShow.traktId)),
+                            onClick = { onItemClicked(tvShow.showId) },
+                            modifier = Modifier.testTag(DiscoverTestTags.showCard(rowKey, tvShow.showId)),
                             title = tvShow.title,
                             isInLibrary = tvShow.inLibrary,
                         )

--- a/features/discover/ui/src/main/java/com/thomaskioko/tvmaniac/discover/ui/component/NextEpisodeCard.kt
+++ b/features/discover/ui/src/main/java/com/thomaskioko/tvmaniac/discover/ui/component/NextEpisodeCard.kt
@@ -121,7 +121,7 @@ internal fun NextEpisodeCard(
 private fun NextEpisodeCardPreview() {
     NextEpisodeCard(
         episode = NextEpisodeUiModel(
-            showTraktId = 1L,
+            showId = 1L,
             showName = "The Walking Dead: Daryl Dixon",
             imageUrl = "/still.jpg",
             episodeId = 123L,

--- a/features/discover/ui/src/main/java/com/thomaskioko/tvmaniac/discover/ui/component/NextEpisodesSection.kt
+++ b/features/discover/ui/src/main/java/com/thomaskioko/tvmaniac/discover/ui/component/NextEpisodesSection.kt
@@ -59,11 +59,11 @@ internal fun NextEpisodesSection(
                 ) {
                     items(
                         items = nextEpisodes,
-                        key = { episode -> "next_episode_${episode.showTraktId}_${episode.episodeId}" },
+                        key = { episode -> "next_episode_${episode.showId}_${episode.episodeId}" },
                         contentType = { "NextEpisode" },
                     ) { episode ->
                         NextEpisodeCard(
-                            modifier = Modifier.testTag(DiscoverTestTags.upNextCard(episode.showTraktId)),
+                            modifier = Modifier.testTag(DiscoverTestTags.upNextCard(episode.showId)),
                             episode = episode,
                             onClick = { onEpisodeClick(episode) },
                         )
@@ -82,7 +82,7 @@ private fun NextEpisodesSectionPreview() {
         title = "Up Next",
         nextEpisodes = persistentListOf(
             NextEpisodeUiModel(
-                showTraktId = 1L,
+                showId = 1L,
                 showName = "The Walking Dead: Daryl Dixon",
                 imageUrl = "/still1.jpg",
                 episodeId = 123L,
@@ -96,7 +96,7 @@ private fun NextEpisodesSectionPreview() {
                 isNew = true,
             ),
             NextEpisodeUiModel(
-                showTraktId = 2L,
+                showId = 2L,
                 showName = "Wednesday",
                 imageUrl = "/still1.jpg",
                 episodeId = 124L,
@@ -110,7 +110,7 @@ private fun NextEpisodesSectionPreview() {
                 isNew = false,
             ),
             NextEpisodeUiModel(
-                showTraktId = 3L,
+                showId = 3L,
                 showName = "House of the Dragon",
                 imageUrl = "/still1.jpg",
                 episodeId = 125L,

--- a/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenter.kt
+++ b/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenter.kt
@@ -99,14 +99,14 @@ public class EpisodeSheetPresenter(
             if (episode.is_watched != 0L) {
                 markEpisodeUnwatchedInteractor(
                     MarkEpisodeUnwatchedParams(
-                        showTraktId = episode.show_trakt_id,
+                        showId = episode.show_trakt_id,
                         episodeId = episode.episode_id.id,
                     ),
                 ).collectStatus(actionLoadingState, logger, uiMessageManager, errorToStringMapper = errorToStringMapper)
             } else {
                 markEpisodeWatchedInteractor(
                     MarkEpisodeWatchedParams(
-                        showTraktId = episode.show_trakt_id,
+                        showId = episode.show_trakt_id,
                         episodeId = episode.episode_id.id,
                         seasonNumber = episode.season_number,
                         episodeNumber = episode.episode_number,
@@ -119,7 +119,7 @@ public class EpisodeSheetPresenter(
     private fun openShow() {
         val episode = currentEpisode ?: return
         navigator.dismissOverlay()
-        navigator.pushToFront(ShowDetailsRoute(ShowDetailsParam(id = episode.show_trakt_id)))
+        navigator.pushToFront(ShowDetailsRoute(ShowDetailsParam(showId = episode.show_trakt_id)))
     }
 
     private fun openSeason() {
@@ -128,7 +128,7 @@ public class EpisodeSheetPresenter(
         navigator.navigateTo(
             SeasonDetailsRoute(
                 SeasonDetailsUiParam(
-                    showTraktId = episode.show_trakt_id,
+                    showId = episode.show_trakt_id,
                     seasonId = episode.season_id.id,
                     seasonNumber = episode.season_number,
                 ),

--- a/features/episode-sheet/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenterTest.kt
+++ b/features/episode-sheet/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenterTest.kt
@@ -189,7 +189,7 @@ internal class EpisodeSheetPresenterTest {
 
             val call = episodeRepository.lastMarkEpisodeWatchedCall
             call shouldBe com.thomaskioko.tvmaniac.episodes.testing.MarkEpisodeWatchedCall(
-                showTraktId = 100L,
+                showId = 100L,
                 episodeId = 1L,
                 seasonNumber = 1L,
                 episodeNumber = 1L,
@@ -215,7 +215,7 @@ internal class EpisodeSheetPresenterTest {
 
             val call = episodeRepository.lastMarkEpisodeUnwatchedCall
             call shouldBe com.thomaskioko.tvmaniac.episodes.testing.MarkEpisodeUnwatchedCall(
-                showTraktId = 100L,
+                showId = 100L,
                 episodeId = 1L,
             )
             navigator.overlayDismissCount shouldBe 1
@@ -242,7 +242,7 @@ internal class EpisodeSheetPresenterTest {
 
             episodeRepository.lastMarkEpisodeWatchedCall shouldBe
                 com.thomaskioko.tvmaniac.episodes.testing.MarkEpisodeWatchedCall(
-                    showTraktId = 100L,
+                    showId = 100L,
                     episodeId = 1L,
                     seasonNumber = 1L,
                     episodeNumber = 1L,
@@ -263,7 +263,7 @@ internal class EpisodeSheetPresenterTest {
 
             presenter.dispatch(EpisodeSheetAction.OpenShow)
 
-            (navigator.lastNavigatedRoute as ShowDetailsRoute).param.id shouldBe 100L
+            (navigator.lastNavigatedRoute as ShowDetailsRoute).param.showId shouldBe 100L
             navigator.overlayDismissCount shouldBe 1
         }
     }
@@ -282,7 +282,7 @@ internal class EpisodeSheetPresenterTest {
             presenter.dispatch(EpisodeSheetAction.OpenSeason)
 
             val seasonRoute = navigator.lastNavigatedRoute as SeasonDetailsRoute
-            seasonRoute.param.showTraktId shouldBe 100L
+            seasonRoute.param.showId shouldBe 100L
             seasonRoute.param.seasonId shouldBe 10L
             seasonRoute.param.seasonNumber shouldBe 1L
             navigator.overlayDismissCount shouldBe 1

--- a/features/library/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/library/LibraryAction.kt
+++ b/features/library/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/library/LibraryAction.kt
@@ -5,7 +5,7 @@ import com.thomaskioko.tvmaniac.presentation.library.model.ShowStatus
 
 public sealed interface LibraryAction
 
-public data class LibraryShowClicked(val traktId: Long) : LibraryAction
+public data class LibraryShowClicked(val showId: Long) : LibraryAction
 
 public data class LibraryQueryChanged(val query: String) : LibraryAction
 

--- a/features/library/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/library/LibraryPresenter.kt
+++ b/features/library/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/library/LibraryPresenter.kt
@@ -117,7 +117,7 @@ public class LibraryPresenter(
 
     public fun dispatch(action: LibraryAction) {
         when (action) {
-            is LibraryShowClicked -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(id = action.traktId)))
+            is LibraryShowClicked -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(showId = action.showId)))
             is LibraryQueryChanged -> updateQuery(action.query)
             is ClearLibraryQuery -> clearQuery()
             is ToggleSearchActive -> toggleSearchActive()
@@ -285,7 +285,7 @@ public class LibraryPresenter(
 }
 
 private fun LibraryItem.toLibraryShowItem(): LibraryShowItem = LibraryShowItem(
-    traktId = traktId,
+    showId = showId,
     tmdbId = tmdbId,
     title = title,
     posterImageUrl = posterPath,

--- a/features/library/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/library/model/LibraryShowItem.kt
+++ b/features/library/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/library/model/LibraryShowItem.kt
@@ -4,7 +4,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 public data class LibraryShowItem(
-    val traktId: Long,
+    val showId: Long,
     val tmdbId: Long?,
     val title: String,
     val posterImageUrl: String? = null,

--- a/features/library/ui/src/main/kotlin/com/thomaskioko/tvmaniac/ui/library/LibraryListItem.kt
+++ b/features/library/ui/src/main/kotlin/com/thomaskioko/tvmaniac/ui/library/LibraryListItem.kt
@@ -50,7 +50,7 @@ internal fun LibraryListItem(
             .height(200.dp),
         color = MaterialTheme.colorScheme.surface,
         shadowElevation = 4.dp,
-        onClick = { onItemClicked(item.traktId) },
+        onClick = { onItemClicked(item.showId) },
     ) {
         Row {
             PosterCard(

--- a/features/library/ui/src/main/kotlin/com/thomaskioko/tvmaniac/ui/library/LibraryScreen.kt
+++ b/features/library/ui/src/main/kotlin/com/thomaskioko/tvmaniac/ui/library/LibraryScreen.kt
@@ -372,13 +372,13 @@ private fun LibraryGridContent(
     ) {
         items(
             items = items,
-            key = { it.traktId },
+            key = { it.showId },
             contentType = { "LibraryGridItem" },
         ) { item ->
             LibraryGridItem(
                 item = item,
                 onItemClicked = onItemClicked,
-                modifier = Modifier.testTag(LibraryTestTags.showRow(item.traktId)),
+                modifier = Modifier.testTag(LibraryTestTags.showRow(item.showId)),
             )
         }
 
@@ -396,7 +396,7 @@ private fun LibraryGridItem(
 ) {
     PosterCard(
         imageUrl = item.posterImageUrl,
-        onClick = { onItemClicked(item.traktId) },
+        onClick = { onItemClicked(item.showId) },
         modifier = modifier
             .fillMaxWidth()
             .aspectRatio(2f / 3f),
@@ -422,13 +422,13 @@ private fun LibraryListContent(
     ) {
         items(
             count = items.size,
-            key = { items[it].traktId },
+            key = { items[it].showId },
             contentType = { "LibraryListItem" },
         ) { index ->
             LibraryListItem(
                 item = items[index],
                 onItemClicked = onItemClicked,
-                modifier = Modifier.testTag(LibraryTestTags.showRow(items[index].traktId)),
+                modifier = Modifier.testTag(LibraryTestTags.showRow(items[index].showId)),
             )
         }
 

--- a/features/library/ui/src/main/kotlin/com/thomaskioko/tvmaniac/ui/library/preview/LibraryListItemPreviewParameterProvider.kt
+++ b/features/library/ui/src/main/kotlin/com/thomaskioko/tvmaniac/ui/library/preview/LibraryListItemPreviewParameterProvider.kt
@@ -8,7 +8,7 @@ import kotlinx.collections.immutable.persistentListOf
 internal class LibraryListItemPreviewParameterProvider : PreviewParameterProvider<LibraryShowItem> {
     override val values: Sequence<LibraryShowItem> = sequenceOf(
         LibraryShowItem(
-            traktId = 1,
+            showId = 1,
             tmdbId = 1396,
             title = "Breaking Bad",
             posterImageUrl = null,
@@ -25,7 +25,7 @@ internal class LibraryListItemPreviewParameterProvider : PreviewParameterProvide
             ),
         ),
         LibraryShowItem(
-            traktId = 2,
+            showId = 2,
             tmdbId = 1399,
             title = "Game of Thrones: A Very Long Title That Should Wrap to Multiple Lines",
             posterImageUrl = null,
@@ -39,7 +39,7 @@ internal class LibraryListItemPreviewParameterProvider : PreviewParameterProvide
             watchProviders = persistentListOf(),
         ),
         LibraryShowItem(
-            traktId = 3,
+            showId = 3,
             tmdbId = null,
             title = "Minimal Show",
             posterImageUrl = null,

--- a/features/library/ui/src/main/kotlin/com/thomaskioko/tvmaniac/ui/library/preview/LibraryStatePreviewParameterProvider.kt
+++ b/features/library/ui/src/main/kotlin/com/thomaskioko/tvmaniac/ui/library/preview/LibraryStatePreviewParameterProvider.kt
@@ -48,7 +48,7 @@ internal class LibraryStatePreviewParameterProvider : PreviewParameterProvider<L
             isGridMode = false,
             items = persistentListOf(
                 LibraryShowItem(
-                    traktId = 1,
+                    showId = 1,
                     tmdbId = 1396,
                     title = "Breaking Bad",
                     posterImageUrl = null,
@@ -86,7 +86,7 @@ private fun previewStatuses() = persistentListOf(
 
 private fun previewLibraryItems(): ImmutableList<LibraryShowItem> = listOf(
     LibraryShowItem(
-        traktId = 1,
+        showId = 1,
         tmdbId = 1396,
         title = "Breaking Bad",
         posterImageUrl = null,
@@ -103,7 +103,7 @@ private fun previewLibraryItems(): ImmutableList<LibraryShowItem> = listOf(
         ),
     ),
     LibraryShowItem(
-        traktId = 2,
+        showId = 2,
         tmdbId = 1399,
         title = "Game of Thrones",
         posterImageUrl = null,
@@ -119,7 +119,7 @@ private fun previewLibraryItems(): ImmutableList<LibraryShowItem> = listOf(
         ),
     ),
     LibraryShowItem(
-        traktId = 3,
+        showId = 3,
         tmdbId = 66732,
         title = "Stranger Things",
         posterImageUrl = null,
@@ -135,7 +135,7 @@ private fun previewLibraryItems(): ImmutableList<LibraryShowItem> = listOf(
         ),
     ),
     LibraryShowItem(
-        traktId = 4,
+        showId = 4,
         tmdbId = 94997,
         title = "House of the Dragon",
         posterImageUrl = null,
@@ -149,7 +149,7 @@ private fun previewLibraryItems(): ImmutableList<LibraryShowItem> = listOf(
         watchProviders = persistentListOf(),
     ),
     LibraryShowItem(
-        traktId = 5,
+        showId = 5,
         tmdbId = 60625,
         title = "Rick and Morty",
         posterImageUrl = null,

--- a/features/more-shows/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/moreshows/presentation/MoreShowsAction.kt
+++ b/features/more-shows/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/moreshows/presentation/MoreShowsAction.kt
@@ -6,7 +6,7 @@ public data object MoreBackClicked : MoreShowsActions
 
 public data object RefreshMoreShows : MoreShowsActions
 
-public data class MoreShowClicked(val traktId: Long) : MoreShowsActions
+public data class MoreShowClicked(val showId: Long) : MoreShowsActions
 
 public data object RetryLoadMore : MoreShowsActions
 

--- a/features/more-shows/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/moreshows/presentation/MoreShowsPresenter.kt
+++ b/features/more-shows/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/moreshows/presentation/MoreShowsPresenter.kt
@@ -82,7 +82,7 @@ public class MoreShowsPresenter(
 
     public fun dispatch(action: MoreShowsActions) {
         when (action) {
-            is MoreShowClicked -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(id = action.traktId)))
+            is MoreShowClicked -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(showId = action.showId)))
             MoreBackClicked -> navigator.navigateBack()
             RefreshMoreShows -> {
                 when (categoryId) {
@@ -205,7 +205,7 @@ public class MoreShowsPresenter(
         it.map { show ->
             TvShow(
                 tmdbId = show.tmdbId,
-                traktId = show.traktId,
+                showId = show.showId,
                 title = show.title,
                 posterImageUrl = show.posterPath,
                 inLibrary = show.inLibrary,

--- a/features/more-shows/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/moreshows/presentation/TvShow.kt
+++ b/features/more-shows/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/moreshows/presentation/TvShow.kt
@@ -2,7 +2,7 @@ package com.thomaskioko.tvmaniac.moreshows.presentation
 
 public data class TvShow(
     val tmdbId: Long = 0,
-    val traktId: Long = 0,
+    val showId: Long = 0,
     val title: String = "",
     val posterImageUrl: String? = null,
     val inLibrary: Boolean = false,

--- a/features/more-shows/ui/src/main/kotlin/com/thomaskioko/tvmaniac/moreshows/ui/MoreShowsScreen.kt
+++ b/features/more-shows/ui/src/main/kotlin/com/thomaskioko/tvmaniac/moreshows/ui/MoreShowsScreen.kt
@@ -187,11 +187,11 @@ internal fun GridContent(
                 show?.let {
                     PosterCard(
                         imageUrl = show.posterImageUrl,
-                        onClick = { onAction(MoreShowClicked(show.traktId)) },
+                        onClick = { onAction(MoreShowClicked(show.showId)) },
                         modifier = Modifier
                             .animateItem()
                             .fillMaxWidth()
-                            .testTag(MoreShowsTestTags.showCard(show.traktId)),
+                            .testTag(MoreShowsTestTags.showCard(show.showId)),
                         title = show.title,
                     )
                 }

--- a/features/profile/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/profile/presenter/ProfileAction.kt
+++ b/features/profile/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/profile/presenter/ProfileAction.kt
@@ -9,7 +9,7 @@ public sealed interface ProfileAction {
 
     public data object RefreshProfile : ProfileAction
 
-    public data class ShowClicked(val traktId: Long) : ProfileAction
+    public data class ShowClicked(val showId: Long) : ProfileAction
 
     public data class MessageShown(val id: Long) : ProfileAction
 }

--- a/features/profile/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/profile/presenter/ProfilePresenter.kt
+++ b/features/profile/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/profile/presenter/ProfilePresenter.kt
@@ -200,7 +200,7 @@ public class ProfilePresenter(
                 fetchUserData(forceRefresh = true)
                 syncFavorites(forceRefresh = true)
             }
-            is ShowClicked -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(id = action.traktId)))
+            is ShowClicked -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(showId = action.showId)))
             is MessageShown -> {
                 clearMessage(action.id)
                 coroutineScope.launch { traktAuthRepository.setAuthError(null) }
@@ -311,42 +311,42 @@ private fun TraktListEntity.toListItem(localizer: Localizer): ProfileListItem = 
 )
 
 private fun UpNextEpisode.toShowItem(): ProfileShowItem = ProfileShowItem(
-    traktId = showTraktId,
+    showId = showId,
     tmdbId = showTmdbId,
     title = showName,
     posterUrl = showPoster,
 )
 
 private fun CompletedShow.toShowItem(): ProfileShowItem = ProfileShowItem(
-    traktId = showTraktId,
+    showId = showId,
     tmdbId = showTmdbId,
     title = showName.orEmpty(),
     posterUrl = showPoster,
 )
 
 private fun LibraryItem.toShowItem(): ProfileShowItem = ProfileShowItem(
-    traktId = traktId,
+    showId = showId,
     tmdbId = tmdbId,
     title = title,
     posterUrl = posterPath,
 )
 
 private fun WatchlistShowInfo.toShowItem(): ProfileShowItem = ProfileShowItem(
-    traktId = traktId,
+    showId = showId,
     tmdbId = tmdbId,
     title = title.orEmpty(),
     posterUrl = posterImageUrl,
 )
 
 private fun FavoriteShow.toShowItem(): ProfileShowItem = ProfileShowItem(
-    traktId = traktId,
+    showId = showId,
     tmdbId = tmdbId,
     title = title,
     posterUrl = posterPath,
 )
 
 private fun RecentlyWatchedEpisode.toRecentItem(): ProfileRecentItem = ProfileRecentItem(
-    traktId = showTraktId,
+    showId = showId,
     tmdbId = showTmdbId,
     title = showTitle,
     posterUrl = posterPath,

--- a/features/profile/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/profile/presenter/model/ProfileRecentItem.kt
+++ b/features/profile/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/profile/presenter/model/ProfileRecentItem.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.profile.presenter.model
 
 public data class ProfileRecentItem(
-    val traktId: Long,
+    val showId: Long,
     val tmdbId: Long,
     val title: String,
     val posterUrl: String?,

--- a/features/profile/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/profile/presenter/model/ProfileShowItem.kt
+++ b/features/profile/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/profile/presenter/model/ProfileShowItem.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.profile.presenter.model
 
 public data class ProfileShowItem(
-    val traktId: Long,
+    val showId: Long,
     val tmdbId: Long?,
     val title: String,
     val posterUrl: String?,

--- a/features/profile/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/profile/ProfilePresenterTest.kt
+++ b/features/profile/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/profile/ProfilePresenterTest.kt
@@ -348,13 +348,13 @@ internal class ProfilePresenterTest {
             )
 
             val inProgress = loaded.inProgress.shouldBeInstanceOf<SectionState.Content<ProfileShowItem>>()
-            inProgress.items.first().traktId shouldBe 1L
+            inProgress.items.first().showId shouldBe 1L
             inProgress.items.first().title shouldBe "Breaking Bad"
 
             val recent = loaded.recentlyWatched.shouldBeInstanceOf<SectionState.Content<ProfileRecentItem>>()
             recent.items shouldBe listOf(
                 ProfileRecentItem(
-                    traktId = 1L,
+                    showId = 1L,
                     tmdbId = 2L,
                     title = "Breaking Bad",
                     posterUrl = "/poster.jpg",
@@ -363,14 +363,14 @@ internal class ProfilePresenterTest {
             )
 
             val library = loaded.library.shouldBeInstanceOf<SectionState.Content<ProfileShowItem>>()
-            library.items.first().traktId shouldBe 1L
+            library.items.first().showId shouldBe 1L
 
             val watchlist = loaded.watchlist.shouldBeInstanceOf<SectionState.Content<ProfileShowItem>>()
-            watchlist.items.first().traktId shouldBe 1L
+            watchlist.items.first().showId shouldBe 1L
 
             val favorites = loaded.favorites.shouldBeInstanceOf<SectionState.Content<ProfileShowItem>>()
             favorites.items shouldBe listOf(
-                ProfileShowItem(traktId = 1L, tmdbId = 2L, title = "Breaking Bad", posterUrl = "/poster.jpg"),
+                ProfileShowItem(showId = 1L, tmdbId = 2L, title = "Breaking Bad", posterUrl = "/poster.jpg"),
             )
         }
     }
@@ -417,8 +417,8 @@ internal class ProfilePresenterTest {
         val testPresenter = createPresenter(navigator = navigator)
 
         navigator.test {
-            testPresenter.dispatch(ProfileAction.ShowClicked(traktId = 5L))
-            awaitNavigateTo(ShowDetailsRoute(ShowDetailsParam(id = 5L)))
+            testPresenter.dispatch(ProfileAction.ShowClicked(showId = 5L))
+            awaitNavigateTo(ShowDetailsRoute(ShowDetailsParam(showId = 5L)))
         }
     }
 
@@ -464,7 +464,7 @@ internal class ProfilePresenterTest {
     )
 
     private fun createNextEpisode(): NextEpisodeWithShow = NextEpisodeWithShow(
-        showTraktId = 1L,
+        showId = 1L,
         showTmdbId = 2L,
         showName = "Breaking Bad",
         showPoster = "/poster.jpg",
@@ -487,7 +487,7 @@ internal class ProfilePresenterTest {
     )
 
     private fun createRecentlyWatched(): RecentlyWatchedEpisode = RecentlyWatchedEpisode(
-        showTraktId = 1L,
+        showId = 1L,
         showTmdbId = 2L,
         showTitle = "Breaking Bad",
         posterPath = "/poster.jpg",
@@ -498,7 +498,7 @@ internal class ProfilePresenterTest {
     )
 
     private fun createLibraryItem(): LibraryItem = LibraryItem(
-        traktId = 1L,
+        showId = 1L,
         tmdbId = 2L,
         title = "Breaking Bad",
         posterPath = "/poster.jpg",
@@ -516,7 +516,7 @@ internal class ProfilePresenterTest {
     )
 
     private fun createFavorite(): FavoriteShow = FavoriteShow(
-        traktId = 1L,
+        showId = 1L,
         tmdbId = 2L,
         title = "Breaking Bad",
         posterPath = "/poster.jpg",

--- a/features/profile/ui/src/main/kotlin/com/thomaskioko/tvmaniac/profile/ui/ProfilePreviewParameterProvider.kt
+++ b/features/profile/ui/src/main/kotlin/com/thomaskioko/tvmaniac/profile/ui/ProfilePreviewParameterProvider.kt
@@ -48,9 +48,9 @@ internal val sampleProfileLabels: ProfileLabels = ProfileLabels(
 )
 
 private val sampleShows = persistentListOf(
-    ProfileShowItem(traktId = 1, tmdbId = 1396, title = "Breaking Bad", posterUrl = null),
-    ProfileShowItem(traktId = 2, tmdbId = 1399, title = "Game of Thrones", posterUrl = null),
-    ProfileShowItem(traktId = 3, tmdbId = 66732, title = "Stranger Things", posterUrl = null),
+    ProfileShowItem(showId = 1, tmdbId = 1396, title = "Breaking Bad", posterUrl = null),
+    ProfileShowItem(showId = 2, tmdbId = 1399, title = "Game of Thrones", posterUrl = null),
+    ProfileShowItem(showId = 3, tmdbId = 66732, title = "Stranger Things", posterUrl = null),
 )
 
 internal val unauthenticatedState = ProfileState(
@@ -103,9 +103,9 @@ internal val authenticatedState = ProfileState(
     completed = SectionState.Content(sampleShows),
     recentlyWatched = SectionState.Content(
         persistentListOf(
-            ProfileRecentItem(traktId = 1, tmdbId = 1396, title = "Breaking Bad", posterUrl = null, episodeLabel = "S5E14"),
-            ProfileRecentItem(traktId = 2, tmdbId = 1399, title = "Game of Thrones", posterUrl = null, episodeLabel = "S8E3"),
-            ProfileRecentItem(traktId = 3, tmdbId = 1394, title = "Stranger Things", posterUrl = null, episodeLabel = "S1E3"),
+            ProfileRecentItem(showId = 1, tmdbId = 1396, title = "Breaking Bad", posterUrl = null, episodeLabel = "S5E14"),
+            ProfileRecentItem(showId = 2, tmdbId = 1399, title = "Game of Thrones", posterUrl = null, episodeLabel = "S8E3"),
+            ProfileRecentItem(showId = 3, tmdbId = 1394, title = "Stranger Things", posterUrl = null, episodeLabel = "S1E3"),
         ),
     ),
     library = SectionState.Content(sampleShows),

--- a/features/profile/ui/src/main/kotlin/com/thomaskioko/tvmaniac/profile/ui/components/FavoritesSection.kt
+++ b/features/profile/ui/src/main/kotlin/com/thomaskioko/tvmaniac/profile/ui/components/FavoritesSection.kt
@@ -78,15 +78,15 @@ private fun PosterRow(
     ) {
         items(
             items = shows,
-            key = { it.traktId },
+            key = { it.showId },
         ) { show ->
             PosterCard(
                 imageUrl = show.posterUrl,
                 title = show.title,
                 imageWidth = posterWidth,
                 shape = MaterialTheme.shapes.medium,
-                onClick = { onShowClick(show.traktId) },
-                modifier = Modifier.testTag(ProfileTestTags.showCard(show.traktId)),
+                onClick = { onShowClick(show.showId) },
+                modifier = Modifier.testTag(ProfileTestTags.showCard(show.showId)),
             )
         }
     }
@@ -116,8 +116,8 @@ private fun FavoritesSectionPreview() {
     FavoritesSection(
         favorites = SectionState.Content(
             persistentListOf(
-                ProfileShowItem(traktId = 1, tmdbId = 1396, title = "Breaking Bad", posterUrl = null),
-                ProfileShowItem(traktId = 2, tmdbId = 1399, title = "Game of Thrones", posterUrl = null),
+                ProfileShowItem(showId = 1, tmdbId = 1396, title = "Breaking Bad", posterUrl = null),
+                ProfileShowItem(showId = 2, tmdbId = 1399, title = "Game of Thrones", posterUrl = null),
             ),
         ),
         title = "Favorites",

--- a/features/profile/ui/src/main/kotlin/com/thomaskioko/tvmaniac/profile/ui/components/ProgressSection.kt
+++ b/features/profile/ui/src/main/kotlin/com/thomaskioko/tvmaniac/profile/ui/components/ProgressSection.kt
@@ -184,15 +184,15 @@ private fun PosterRow(
     ) {
         items(
             items = shows,
-            key = { it.traktId },
+            key = { it.showId },
         ) { show ->
             PosterCard(
                 imageUrl = show.posterUrl,
                 title = show.title,
                 imageWidth = posterWidth,
                 shape = MaterialTheme.shapes.medium,
-                onClick = { onShowClick(show.traktId) },
-                modifier = Modifier.testTag(ProfileTestTags.showCard(show.traktId)),
+                onClick = { onShowClick(show.showId) },
+                modifier = Modifier.testTag(ProfileTestTags.showCard(show.showId)),
             )
         }
     }
@@ -239,13 +239,13 @@ private fun ProgressSectionPreview() {
     ProgressSection(
         inProgress = SectionState.Content(
             persistentListOf(
-                ProfileShowItem(traktId = 1, tmdbId = 1396, title = "Breaking Bad", posterUrl = null),
-                ProfileShowItem(traktId = 2, tmdbId = 1399, title = "Game of Thrones", posterUrl = null),
+                ProfileShowItem(showId = 1, tmdbId = 1396, title = "Breaking Bad", posterUrl = null),
+                ProfileShowItem(showId = 2, tmdbId = 1399, title = "Game of Thrones", posterUrl = null),
             ),
         ),
         completed = SectionState.Content(
             persistentListOf(
-                ProfileShowItem(traktId = 3, tmdbId = 66732, title = "Stranger Things", posterUrl = null),
+                ProfileShowItem(showId = 3, tmdbId = 66732, title = "Stranger Things", posterUrl = null),
             ),
         ),
         title = "Progress",

--- a/features/profile/ui/src/main/kotlin/com/thomaskioko/tvmaniac/profile/ui/components/RecentlyWatchedSection.kt
+++ b/features/profile/ui/src/main/kotlin/com/thomaskioko/tvmaniac/profile/ui/components/RecentlyWatchedSection.kt
@@ -83,7 +83,7 @@ private fun EpisodeRow(
     ) {
         items(
             items = items,
-            key = { "${it.traktId}-${it.episodeLabel}" },
+            key = { "${it.showId}-${it.episodeLabel}" },
         ) { item ->
             EpisodeCard(item = item, posterWidth = posterWidth, onShowClick = onShowClick)
         }
@@ -102,8 +102,8 @@ private fun EpisodeCard(
             title = item.title,
             imageWidth = posterWidth,
             shape = MaterialTheme.shapes.medium,
-            onClick = { onShowClick(item.traktId) },
-            modifier = Modifier.testTag(ProfileTestTags.showCard(item.traktId)),
+            onClick = { onShowClick(item.showId) },
+            modifier = Modifier.testTag(ProfileTestTags.showCard(item.showId)),
         )
 
         Spacer(modifier = Modifier.height(8.dp))
@@ -171,14 +171,14 @@ private fun RecentlyWatchedSectionPreview() {
         recentlyWatched = SectionState.Content(
             persistentListOf(
                 ProfileRecentItem(
-                    traktId = 1,
+                    showId = 1,
                     tmdbId = 1396,
                     title = "Breaking Bad",
                     posterUrl = null,
                     episodeLabel = "S05E14",
                 ),
                 ProfileRecentItem(
-                    traktId = 2,
+                    showId = 2,
                     tmdbId = 1399,
                     title = "Game of Thrones",
                     posterUrl = null,

--- a/features/profile/ui/src/test/kotlin/com/thomaskioko/tvmaniac/profile/roborazzi/FavoritesSectionTest.kt
+++ b/features/profile/ui/src/test/kotlin/com/thomaskioko/tvmaniac/profile/roborazzi/FavoritesSectionTest.kt
@@ -30,9 +30,9 @@ internal class FavoritesSectionTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     private val shows = persistentListOf(
-        ProfileShowItem(traktId = 1, tmdbId = 1396, title = "Breaking Bad", posterUrl = null),
-        ProfileShowItem(traktId = 2, tmdbId = 1399, title = "Game of Thrones", posterUrl = null),
-        ProfileShowItem(traktId = 3, tmdbId = 66732, title = "Stranger Things", posterUrl = null),
+        ProfileShowItem(showId = 1, tmdbId = 1396, title = "Breaking Bad", posterUrl = null),
+        ProfileShowItem(showId = 2, tmdbId = 1399, title = "Game of Thrones", posterUrl = null),
+        ProfileShowItem(showId = 3, tmdbId = 66732, title = "Stranger Things", posterUrl = null),
     )
 
     @Test

--- a/features/profile/ui/src/test/kotlin/com/thomaskioko/tvmaniac/profile/roborazzi/ProgressSectionTest.kt
+++ b/features/profile/ui/src/test/kotlin/com/thomaskioko/tvmaniac/profile/roborazzi/ProgressSectionTest.kt
@@ -30,9 +30,9 @@ internal class ProgressSectionTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     private val shows = persistentListOf(
-        ProfileShowItem(traktId = 1, tmdbId = 1396, title = "Breaking Bad", posterUrl = null),
-        ProfileShowItem(traktId = 2, tmdbId = 1399, title = "Game of Thrones", posterUrl = null),
-        ProfileShowItem(traktId = 3, tmdbId = 66732, title = "Stranger Things", posterUrl = null),
+        ProfileShowItem(showId = 1, tmdbId = 1396, title = "Breaking Bad", posterUrl = null),
+        ProfileShowItem(showId = 2, tmdbId = 1399, title = "Game of Thrones", posterUrl = null),
+        ProfileShowItem(showId = 3, tmdbId = 66732, title = "Stranger Things", posterUrl = null),
     )
 
     @Test

--- a/features/profile/ui/src/test/kotlin/com/thomaskioko/tvmaniac/profile/roborazzi/RecentlyWatchedSectionTest.kt
+++ b/features/profile/ui/src/test/kotlin/com/thomaskioko/tvmaniac/profile/roborazzi/RecentlyWatchedSectionTest.kt
@@ -30,9 +30,9 @@ internal class RecentlyWatchedSectionTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     private val episodes = persistentListOf(
-        ProfileRecentItem(traktId = 1, tmdbId = 1396, title = "Breaking Bad", posterUrl = null, episodeLabel = "S5E14"),
-        ProfileRecentItem(traktId = 2, tmdbId = 1399, title = "Game of Thrones", posterUrl = null, episodeLabel = "S8E3"),
-        ProfileRecentItem(traktId = 3, tmdbId = 66732, title = "Stranger Things", posterUrl = null, episodeLabel = "S4E9"),
+        ProfileRecentItem(showId = 1, tmdbId = 1396, title = "Breaking Bad", posterUrl = null, episodeLabel = "S5E14"),
+        ProfileRecentItem(showId = 2, tmdbId = 1399, title = "Game of Thrones", posterUrl = null, episodeLabel = "S8E3"),
+        ProfileRecentItem(showId = 3, tmdbId = 66732, title = "Stranger Things", posterUrl = null, episodeLabel = "S4E9"),
     )
 
     @Test

--- a/features/progress/ui/src/main/kotlin/com/thomaskioko/tvmaniac/ui/progress/ProgressScreen.kt
+++ b/features/progress/ui/src/main/kotlin/com/thomaskioko/tvmaniac/ui/progress/ProgressScreen.kt
@@ -280,7 +280,7 @@ internal class ProgressPreviewParameterProvider : PreviewParameterProvider<Progr
 
 internal fun previewUpNextEpisodes() = persistentListOf(
     UpNextEpisodeUiModel(
-        showTraktId = 1,
+        showId = 1,
         showTmdbId = 1396,
         showName = "Breaking Bad",
         showStatus = "Ended",
@@ -309,8 +309,8 @@ internal fun previewCalendarEvents() = persistentListOf(
         dateLabel = "Today, Jan 31, 2026",
         episodes = persistentListOf(
             CalendarEpisodeItem(
-                showTraktId = 1,
-                episodeTraktId = 100,
+                showId = 1,
+                episodeId = 100,
                 showTitle = "Severance",
                 posterUrl = null,
                 episodeInfo = "S02E01 · Hello, Ms. Cobel",

--- a/features/root/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenter.kt
+++ b/features/root/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenter.kt
@@ -261,7 +261,7 @@ public class DefaultRootPresenter(
                 navigator.navigateTo(
                     ShowDetailsRoute(
                         param = ShowDetailsParam(
-                            id = destination.showId,
+                            showId = destination.showId,
                             forceRefresh = destination.forceRefresh,
                         ),
                     ),
@@ -271,7 +271,7 @@ public class DefaultRootPresenter(
                 navigator.navigateTo(
                     SeasonDetailsRoute(
                         param = SeasonDetailsUiParam(
-                            showTraktId = destination.showId,
+                            showId = destination.showId,
                             seasonNumber = destination.seasonNumber,
                             seasonId = destination.seasonId,
                             forceRefresh = destination.forceRefresh,

--- a/features/root/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenterTest.kt
+++ b/features/root/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenterTest.kt
@@ -122,7 +122,7 @@ abstract class DefaultRootPresenterTest {
             awaitItem().active.instance.shouldBeInstanceOf<RootChild>()
 
             val param = SeasonDetailsUiParam(
-                showTraktId = 1,
+                showId = 1,
                 seasonId = 2,
                 seasonNumber = 3,
             )
@@ -444,7 +444,7 @@ abstract class DefaultRootPresenterTest {
         presenter.toastState.test {
             awaitItem() shouldBe ToastState()
 
-            syncObserver.log(SyncError.MarkWatchedFailed(showTraktId = 1L, cause = RuntimeException("boom")))
+            syncObserver.log(SyncError.MarkWatchedFailed(showId = 1L, cause = RuntimeException("boom")))
 
             val emitted = awaitItem()
             emitted.message shouldBe StringResourceKey.SyncFailedWillRetry.getString()
@@ -463,7 +463,7 @@ abstract class DefaultRootPresenterTest {
             val syncJob = launch { syncObserver.trackSync("test") { gate.await() } }
             awaitItem().type shouldBe ToastType.Status
 
-            syncObserver.log(SyncError.MarkWatchedFailed(showTraktId = 1L, cause = RuntimeException("boom")))
+            syncObserver.log(SyncError.MarkWatchedFailed(showId = 1L, cause = RuntimeException("boom")))
             awaitItem().type shouldBe ToastType.Error
 
             gate.complete(Unit)
@@ -480,7 +480,7 @@ abstract class DefaultRootPresenterTest {
             val syncJob = launch { syncObserver.trackSync("test") { gate.await() } }
             awaitItem().type shouldBe ToastType.Status
 
-            syncObserver.log(SyncError.MarkWatchedFailed(showTraktId = 1L, cause = RuntimeException("boom")))
+            syncObserver.log(SyncError.MarkWatchedFailed(showId = 1L, cause = RuntimeException("boom")))
             val errorToast = awaitItem()
             errorToast.type shouldBe ToastType.Error
 
@@ -501,7 +501,7 @@ abstract class DefaultRootPresenterTest {
             val firstJob = launch { syncObserver.trackSync("first") { firstGate.await() } }
             awaitItem().type shouldBe ToastType.Status
 
-            syncObserver.log(SyncError.MarkWatchedFailed(showTraktId = 1L, cause = RuntimeException("boom")))
+            syncObserver.log(SyncError.MarkWatchedFailed(showId = 1L, cause = RuntimeException("boom")))
             val errorToast = awaitItem()
             errorToast.type shouldBe ToastType.Error
 

--- a/features/search/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/search/presenter/Mapper.kt
+++ b/features/search/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/search/presenter/Mapper.kt
@@ -23,7 +23,7 @@ public class Mapper(
         items.map {
             ShowItem(
                 tmdbId = it.tmdbId,
-                traktId = it.traktId,
+                showId = it.showId,
                 title = it.title,
                 posterImageUrl = it.posterPath,
                 inLibrary = it.inLibrary,
@@ -43,7 +43,7 @@ public class Mapper(
                 shows = entity.shows.map { show ->
                     ShowItem(
                         tmdbId = show.tmdbId,
-                        traktId = show.traktId,
+                        showId = show.showId,
                         title = show.title,
                         posterImageUrl = show.posterPath,
                         inLibrary = show.inLibrary,

--- a/features/search/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/search/presenter/SearchShowAction.kt
+++ b/features/search/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/search/presenter/SearchShowAction.kt
@@ -9,5 +9,5 @@ public data object ClearQuery : SearchShowAction
 public data class MessageShown(val id: Long) : SearchShowAction
 public data object ReloadShowContent : SearchShowAction
 public data class QueryChanged(val query: String) : SearchShowAction
-public data class SearchShowClicked(val id: Long) : SearchShowAction
+public data class SearchShowClicked(val showId: Long) : SearchShowAction
 public data class CategoryChanged(val category: GenreShowCategory) : SearchShowAction

--- a/features/search/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/search/presenter/SearchShowsPresenter.kt
+++ b/features/search/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/search/presenter/SearchShowsPresenter.kt
@@ -143,7 +143,7 @@ public class SearchShowsPresenter(
                 }
 
                 is QueryChanged -> handleQueryChange(action.query)
-                is SearchShowClicked -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(id = action.id)))
+                is SearchShowClicked -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(showId = action.showId)))
             }
         }
 

--- a/features/search/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/search/presenter/model/ShowItem.kt
+++ b/features/search/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/search/presenter/model/ShowItem.kt
@@ -2,7 +2,7 @@ package com.thomaskioko.tvmaniac.search.presenter.model
 
 public data class ShowItem(
     val tmdbId: Long = 0,
-    val traktId: Long = 0,
+    val showId: Long = 0,
     val title: String = "",
     val status: String? = null,
     val voteAverage: Double? = null,

--- a/features/search/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/search/SearchShowsPresenterTest.kt
+++ b/features/search/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/search/SearchShowsPresenterTest.kt
@@ -383,7 +383,7 @@ internal class SearchShowsPresenterTest {
 
     private fun createDiscoverShowList(size: Int = LIST_SIZE) = List(size) {
         ShowEntity(
-            traktId = 84958,
+            showId = 84958,
             tmdbId = 84958,
             title = "Loki",
             posterPath = "/kEl2t3OhXc3Zb9FBh1AuYzRTgZp.jpg",
@@ -399,7 +399,7 @@ internal class SearchShowsPresenterTest {
         .map {
             ShowItem(
                 tmdbId = it.tmdbId,
-                traktId = it.traktId,
+                showId = it.showId,
                 title = it.title,
                 posterImageUrl = it.posterPath,
                 inLibrary = it.inLibrary,
@@ -416,7 +416,7 @@ internal class SearchShowsPresenterTest {
             genre = TraktGenreEntity(slug = "horror", name = "Horror"),
             shows = List(LIST_SIZE) {
                 ShowEntity(
-                    traktId = 84958,
+                    showId = 84958,
                     tmdbId = 84958,
                     title = "Loki",
                     posterPath = "/kEl2t3OhXc3Zb9FBh1AuYzRTgZp.jpg",
@@ -434,7 +434,7 @@ internal class SearchShowsPresenterTest {
             shows = List(LIST_SIZE) {
                 ShowItem(
                     tmdbId = 84958,
-                    traktId = 84958,
+                    showId = 84958,
                     title = "Loki",
                     posterImageUrl = "/kEl2t3OhXc3Zb9FBh1AuYzRTgZp.jpg",
                     inLibrary = false,
@@ -461,7 +461,7 @@ internal class SearchShowsPresenterTest {
             genre = TraktGenreEntity(slug = "horror", name = "Horror"),
             shows = List(LIST_SIZE) {
                 ShowEntity(
-                    traktId = id,
+                    showId = id,
                     tmdbId = id,
                     title = title,
                     posterPath = "/poster.jpg",
@@ -479,7 +479,7 @@ internal class SearchShowsPresenterTest {
             shows = List(LIST_SIZE) {
                 ShowItem(
                     tmdbId = id,
-                    traktId = id,
+                    showId = id,
                     title = title,
                     posterImageUrl = "/poster.jpg",
                     inLibrary = false,

--- a/features/search/ui/src/main/kotlin/com/thomaskioko/tvmaniac/search/ui/SearchPreviewParameterProvider.kt
+++ b/features/search/ui/src/main/kotlin/com/thomaskioko/tvmaniac/search/ui/SearchPreviewParameterProvider.kt
@@ -42,13 +42,13 @@ internal class SearchPreviewParameterProvider : PreviewParameterProvider<SearchS
 internal fun createDiscoverShowList(size: Int = 5) = List(size) { index ->
     discoverShow.copy(
         tmdbId = discoverShow.tmdbId + index.toLong(),
-        traktId = discoverShow.traktId + index.toLong(),
+        showId = discoverShow.showId + index.toLong(),
     )
 }.toImmutableList()
 
 internal val discoverShow = ShowItem(
     tmdbId = 84958,
-    traktId = 84958,
+    showId = 84958,
     title = "Loki",
     posterImageUrl = null,
     overview = "After stealing the Tesseract during the events of Avengers: Endgame, an ",
@@ -63,7 +63,7 @@ internal fun createGenreRowList() = listOf(
         subtitle = "Non-stop thrill and action",
         shows = List(5) {
             ShowItem(
-                traktId = 84958L + it,
+                showId = 84958L + it,
                 tmdbId = 84958L + it,
                 title = "Loki",
                 posterImageUrl = null,
@@ -77,7 +77,7 @@ internal fun createGenreRowList() = listOf(
         subtitle = "Guaranteed laughs in every episode",
         shows = List(5) {
             ShowItem(
-                traktId = 94958L + it,
+                showId = 94958L + it,
                 tmdbId = 94958L + it,
                 title = "Ted Lasso",
                 posterImageUrl = null,

--- a/features/search/ui/src/main/kotlin/com/thomaskioko/tvmaniac/search/ui/SearchScreen.kt
+++ b/features/search/ui/src/main/kotlin/com/thomaskioko/tvmaniac/search/ui/SearchScreen.kt
@@ -331,21 +331,21 @@ private fun SearchResultsContent(
         ) {
             items(
                 items = results,
-                key = { it.traktId },
+                key = { it.showId },
                 contentType = { "SearchResult" },
             ) { item ->
 
                 Spacer(modifier = Modifier.height(8.dp))
 
                 SearchResultItem(
-                    modifier = Modifier.testTag(SearchTestTags.resultItem(item.traktId)),
+                    modifier = Modifier.testTag(SearchTestTags.resultItem(item.showId)),
                     title = item.title,
                     status = item.status,
                     voteAverage = item.voteAverage,
                     year = item.year,
                     overview = item.overview,
                     imageUrl = item.posterImageUrl,
-                    onClick = { onAction(SearchShowClicked(item.traktId)) },
+                    onClick = { onAction(SearchShowClicked(item.showId)) },
                 )
             }
         }

--- a/features/search/ui/src/main/kotlin/com/thomaskioko/tvmaniac/search/ui/components/HorizontalShowContentRow.kt
+++ b/features/search/ui/src/main/kotlin/com/thomaskioko/tvmaniac/search/ui/components/HorizontalShowContentRow.kt
@@ -68,13 +68,13 @@ internal fun HorizontalShowContentRow(
         ) {
             items(
                 items = tvShows,
-                key = { it.traktId },
+                key = { it.showId },
                 contentType = { "HorizontalShowItem" },
             ) { tvShow ->
                 PosterBackdropCard(
                     imageUrl = tvShow.posterImageUrl,
                     title = tvShow.title,
-                    onClick = { onItemClicked(tvShow.traktId) },
+                    onClick = { onItemClicked(tvShow.showId) },
                 )
             }
         }
@@ -88,7 +88,7 @@ private fun HorizontalRowContentPreview() {
     HorizontalShowContentRow(
         tvShows = List(5) {
             ShowItem(
-                traktId = 84958,
+                showId = 84958,
                 tmdbId = 84958,
                 title = "Loki",
                 posterImageUrl = null,

--- a/features/season-details/nav/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/nav/SeasonDetailsUiParam.kt
+++ b/features/season-details/nav/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/nav/SeasonDetailsUiParam.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 public data class SeasonDetailsUiParam(
-    val showTraktId: Long,
+    val showId: Long,
     val seasonId: Long,
     val seasonNumber: Long,
     val forceRefresh: Boolean = false,

--- a/features/season-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/SeasonDetailsModel.kt
+++ b/features/season-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/SeasonDetailsModel.kt
@@ -12,13 +12,13 @@ import kotlinx.collections.immutable.persistentSetOf
 
 public sealed interface WatchOperation {
     public data class MarkEpisodeWatched(val params: MarkEpisodeWatchedParams) : WatchOperation
-    public data class MarkEpisodeUnwatched(val showTraktId: Long, val episodeId: Long) : WatchOperation
+    public data class MarkEpisodeUnwatched(val showId: Long, val episodeId: Long) : WatchOperation
     public data class MarkSeasonWatched(
-        val showTraktId: Long,
+        val showId: Long,
         val seasonNumber: Long,
         val markPreviousSeasons: Boolean = false,
     ) : WatchOperation
-    public data class MarkSeasonUnwatched(val showTraktId: Long, val seasonNumber: Long) : WatchOperation
+    public data class MarkSeasonUnwatched(val showId: Long, val seasonNumber: Long) : WatchOperation
 }
 
 public sealed interface SeasonDialogState {

--- a/features/season-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/SeasonDetailsPresenter.kt
+++ b/features/season-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/SeasonDetailsPresenter.kt
@@ -72,7 +72,7 @@ public class SeasonDetailsPresenter(
 ) : ComponentContext by componentContext {
 
     private val seasonDetailsParam: SeasonDetailsParam = SeasonDetailsParam(
-        showTraktId = param.showTraktId,
+        showId = param.showId,
         seasonId = param.seasonId,
         seasonNumber = param.seasonNumber,
     )
@@ -127,13 +127,13 @@ public class SeasonDetailsPresenter(
         observableSeasonDetailsInteractor(seasonDetailsParam)
         observeSeasonWatchProgressInteractor(
             ObserveSeasonWatchProgressParams(
-                showTraktId = param.showTraktId,
+                showId = param.showId,
                 seasonNumber = param.seasonNumber,
             ),
         )
         observeUnwatchedInPreviousSeasonsInteractor(
             ObserveUnwatchedInPreviousSeasonsParams(
-                showTraktId = param.showTraktId,
+                showId = param.showId,
                 seasonNumber = param.seasonNumber,
             ),
         )
@@ -157,7 +157,7 @@ public class SeasonDetailsPresenter(
                 is MarkEpisodeUnwatched -> updateState {
                     copy(
                         dialogState = SeasonDialogState.UnwatchEpisodeConfirmation(
-                            primaryOperation = WatchOperation.MarkEpisodeUnwatched(param.showTraktId, action.episodeId),
+                            primaryOperation = WatchOperation.MarkEpisodeUnwatched(param.showId, action.episodeId),
                         ),
                     )
                 }
@@ -173,7 +173,7 @@ public class SeasonDetailsPresenter(
 
     private suspend fun handleMarkEpisodeWatched(action: MarkEpisodeWatched) {
         val params = MarkEpisodeWatchedParams(
-            showTraktId = param.showTraktId,
+            showId = param.showId,
             episodeId = action.episodeId,
             seasonNumber = action.seasonNumber,
             episodeNumber = action.episodeNumber,
@@ -196,7 +196,7 @@ public class SeasonDetailsPresenter(
         updateState {
             copy(
                 dialogState = SeasonDialogState.UnwatchSeasonConfirmation(
-                    primaryOperation = WatchOperation.MarkSeasonUnwatched(param.showTraktId, param.seasonNumber),
+                    primaryOperation = WatchOperation.MarkSeasonUnwatched(param.showId, param.seasonNumber),
                 ),
             )
         }
@@ -207,14 +207,14 @@ public class SeasonDetailsPresenter(
             updateState {
                 copy(
                     dialogState = SeasonDialogState.MarkPreviousSeasonsConfirmation(
-                        primaryOperation = MarkSeasonWatched(param.showTraktId, param.seasonNumber, markPreviousSeasons = true),
-                        secondaryOperation = MarkSeasonWatched(param.showTraktId, param.seasonNumber, markPreviousSeasons = false),
+                        primaryOperation = MarkSeasonWatched(param.showId, param.seasonNumber, markPreviousSeasons = true),
+                        secondaryOperation = MarkSeasonWatched(param.showId, param.seasonNumber, markPreviousSeasons = false),
                     ),
                 )
             }
             return
         }
-        execute(MarkSeasonWatched(param.showTraktId, param.seasonNumber))
+        execute(MarkSeasonWatched(param.showId, param.seasonNumber))
     }
 
     private suspend fun handleToggleEpisodeWatched(episodeId: Long) {
@@ -226,7 +226,7 @@ public class SeasonDetailsPresenter(
             updateState {
                 copy(
                     dialogState = SeasonDialogState.UnwatchEpisodeConfirmation(
-                        primaryOperation = WatchOperation.MarkEpisodeUnwatched(param.showTraktId, episodeId),
+                        primaryOperation = WatchOperation.MarkEpisodeUnwatched(param.showId, episodeId),
                     ),
                 )
             }
@@ -283,15 +283,15 @@ public class SeasonDetailsPresenter(
                     markEpisodeWatchedInteractor(operation.params)
                 is WatchOperation.MarkEpisodeUnwatched ->
                     markEpisodeUnwatchedInteractor(
-                        MarkEpisodeUnwatchedParams(operation.showTraktId, operation.episodeId),
+                        MarkEpisodeUnwatchedParams(operation.showId, operation.episodeId),
                     )
                 is MarkSeasonWatched ->
                     markSeasonWatchedInteractor(
-                        MarkSeasonWatchedParams(operation.showTraktId, operation.seasonNumber, operation.markPreviousSeasons),
+                        MarkSeasonWatchedParams(operation.showId, operation.seasonNumber, operation.markPreviousSeasons),
                     )
                 is WatchOperation.MarkSeasonUnwatched ->
                     markSeasonUnwatchedInteractor(
-                        MarkSeasonUnwatchedParams(operation.showTraktId, operation.seasonNumber),
+                        MarkSeasonUnwatchedParams(operation.showId, operation.seasonNumber),
                     )
             }.collectStatus(episodeLoadingState, logger, uiMessageManager, errorToStringMapper = errorToStringMapper)
         } finally {
@@ -317,7 +317,7 @@ public class SeasonDetailsPresenter(
         coroutineScope.launch {
             fetchPreviousSeasonsInteractor(
                 FetchPreviousSeasonsParams(
-                    showTraktId = param.showTraktId,
+                    showId = param.showId,
                     seasonNumber = param.seasonNumber,
                 ),
             ).collectStatus(checkingPreviousSeasonsLoadingState, logger, uiMessageManager, errorToStringMapper = errorToStringMapper)

--- a/features/season-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/SeasonPresenterTest.kt
+++ b/features/season-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/SeasonPresenterTest.kt
@@ -267,7 +267,7 @@ class SeasonPresenterTest {
         castRepository.setSeasonCast(emptyList())
         episodeRepository.setSeasonWatchProgress(
             SeasonWatchProgress(
-                showTraktId = 1L,
+                showId = 1L,
                 seasonNumber = 1L,
                 watchedCount = 5,
                 totalCount = 10,
@@ -290,7 +290,7 @@ class SeasonPresenterTest {
         castRepository.setSeasonCast(emptyList())
         episodeRepository.setSeasonWatchProgress(
             SeasonWatchProgress(
-                showTraktId = 1L,
+                showId = 1L,
                 seasonNumber = 1L,
                 watchedCount = 10,
                 totalCount = 10,
@@ -313,7 +313,7 @@ class SeasonPresenterTest {
         castRepository.setSeasonCast(emptyList())
         episodeRepository.setSeasonWatchProgress(
             SeasonWatchProgress(
-                showTraktId = 1L,
+                showId = 1L,
                 seasonNumber = 1L,
                 watchedCount = 10,
                 totalCount = 10,
@@ -338,7 +338,7 @@ class SeasonPresenterTest {
         castRepository.setSeasonCast(emptyList())
         episodeRepository.setSeasonWatchProgress(
             SeasonWatchProgress(
-                showTraktId = 1L,
+                showId = 1L,
                 seasonNumber = 1L,
                 watchedCount = 10,
                 totalCount = 10,
@@ -401,7 +401,7 @@ class SeasonPresenterTest {
             cancelAndIgnoreRemainingEvents()
 
             episodeRepository.lastMarkEpisodeWatchedCall shouldBe MarkEpisodeWatchedCall(
-                showTraktId = 1,
+                showId = 1,
                 episodeId = 12345,
                 seasonNumber = 1,
                 episodeNumber = 1,
@@ -435,7 +435,7 @@ class SeasonPresenterTest {
         castRepository.setSeasonCast(emptyList())
         episodeRepository.setSeasonWatchProgress(
             SeasonWatchProgress(
-                showTraktId = 1L,
+                showId = 1L,
                 seasonNumber = 1L,
                 watchedCount = 10,
                 totalCount = 10,
@@ -515,7 +515,7 @@ class SeasonPresenterTest {
             finalState.updatingEpisodeIds.shouldBeEmpty()
 
             episodeRepository.lastMarkEpisodeWatchedCall shouldBe MarkEpisodeWatchedCall(
-                showTraktId = 1,
+                showId = 1,
                 episodeId = 12345,
                 seasonNumber = 1,
                 episodeNumber = 5,
@@ -589,7 +589,7 @@ class SeasonPresenterTest {
             finalState.updatingEpisodeIds.shouldBeEmpty()
 
             episodeRepository.lastMarkEpisodeWatchedCall shouldBe MarkEpisodeWatchedCall(
-                showTraktId = 1,
+                showId = 1,
                 episodeId = 12345,
                 seasonNumber = 1,
                 episodeNumber = 5,
@@ -623,7 +623,7 @@ class SeasonPresenterTest {
             finalState.updatingEpisodeIds.shouldBeEmpty()
 
             episodeRepository.lastMarkEpisodeUnwatchedCall shouldBe MarkEpisodeUnwatchedCall(
-                showTraktId = 1,
+                showId = 1,
                 episodeId = 12345,
             )
         }
@@ -676,7 +676,7 @@ class SeasonPresenterTest {
             finalState.dialogState.shouldBeInstanceOf<SeasonDialogState.Hidden>()
 
             episodeRepository.lastMarkSeasonWatchedCall shouldBe MarkSeasonWatchedCall(
-                showTraktId = 1,
+                showId = 1,
                 seasonNumber = 1,
                 markPreviousSeasons = true,
             )
@@ -709,7 +709,7 @@ class SeasonPresenterTest {
             finalState.dialogState.shouldBeInstanceOf<SeasonDialogState.Hidden>()
 
             episodeRepository.lastMarkSeasonWatchedCall shouldBe MarkSeasonWatchedCall(
-                showTraktId = 1,
+                showId = 1,
                 seasonNumber = 1,
                 markPreviousSeasons = false,
             )
@@ -802,7 +802,7 @@ class SeasonPresenterTest {
             cancelAndIgnoreRemainingEvents()
 
             episodeRepository.lastMarkSeasonWatchedCall shouldBe MarkSeasonWatchedCall(
-                showTraktId = 1,
+                showId = 1,
                 seasonNumber = 1,
                 markPreviousSeasons = false,
             )
@@ -815,7 +815,7 @@ class SeasonPresenterTest {
         seasonDetailsRepository.setSeasonsResult(initialDetails)
         castRepository.setSeasonCast(emptyList())
         episodeRepository.setSeasonWatchProgress(
-            SeasonWatchProgress(showTraktId = 1, seasonNumber = 1, watchedCount = 0, totalCount = 10),
+            SeasonWatchProgress(showId = 1, seasonNumber = 1, watchedCount = 0, totalCount = 10),
         )
 
         presenter.state.test {
@@ -825,7 +825,7 @@ class SeasonPresenterTest {
             loadedState.watchProgress shouldBe 0f
 
             episodeRepository.setSeasonWatchProgress(
-                SeasonWatchProgress(showTraktId = 1, seasonNumber = 1, watchedCount = 1, totalCount = 10),
+                SeasonWatchProgress(showId = 1, seasonNumber = 1, watchedCount = 1, totalCount = 10),
             )
 
             presenter.dispatch(
@@ -852,7 +852,7 @@ class SeasonPresenterTest {
         seasonDetailsRepository.setSeasonsResult(initialDetails)
         castRepository.setSeasonCast(emptyList())
         episodeRepository.setSeasonWatchProgress(
-            SeasonWatchProgress(showTraktId = 1, seasonNumber = 1, watchedCount = 5, totalCount = 10),
+            SeasonWatchProgress(showId = 1, seasonNumber = 1, watchedCount = 5, totalCount = 10),
         )
 
         presenter.state.test {
@@ -871,7 +871,7 @@ class SeasonPresenterTest {
             dialogDismissedState.dialogState.shouldBeInstanceOf<SeasonDialogState.Hidden>()
 
             episodeRepository.setSeasonWatchProgress(
-                SeasonWatchProgress(showTraktId = 1, seasonNumber = 1, watchedCount = 4, totalCount = 10),
+                SeasonWatchProgress(showId = 1, seasonNumber = 1, watchedCount = 4, totalCount = 10),
             )
             testDispatcher.scheduler.advanceUntilIdle()
 
@@ -887,7 +887,7 @@ class SeasonPresenterTest {
         seasonDetailsRepository.setSeasonsResult(initialDetails)
         castRepository.setSeasonCast(emptyList())
         episodeRepository.setSeasonWatchProgress(
-            SeasonWatchProgress(showTraktId = 1, seasonNumber = 1, watchedCount = 9, totalCount = 10),
+            SeasonWatchProgress(showId = 1, seasonNumber = 1, watchedCount = 9, totalCount = 10),
         )
 
         presenter.state.test {
@@ -896,7 +896,7 @@ class SeasonPresenterTest {
             loadedState.isSeasonWatched shouldBe false
 
             episodeRepository.setSeasonWatchProgress(
-                SeasonWatchProgress(showTraktId = 1, seasonNumber = 1, watchedCount = 10, totalCount = 10),
+                SeasonWatchProgress(showId = 1, seasonNumber = 1, watchedCount = 10, totalCount = 10),
             )
 
             presenter.dispatch(
@@ -923,7 +923,7 @@ class SeasonPresenterTest {
         seasonDetailsRepository.setSeasonsResult(initialDetails)
         castRepository.setSeasonCast(emptyList())
         episodeRepository.setSeasonWatchProgress(
-            SeasonWatchProgress(showTraktId = 1, seasonNumber = 1, watchedCount = 3, totalCount = 10),
+            SeasonWatchProgress(showId = 1, seasonNumber = 1, watchedCount = 3, totalCount = 10),
         )
         episodeRepository.setUnwatchedCountInPreviousSeasons(0L)
 
@@ -934,7 +934,7 @@ class SeasonPresenterTest {
             loadedState.isSeasonWatched shouldBe false
 
             episodeRepository.setSeasonWatchProgress(
-                SeasonWatchProgress(showTraktId = 1, seasonNumber = 1, watchedCount = 10, totalCount = 10),
+                SeasonWatchProgress(showId = 1, seasonNumber = 1, watchedCount = 10, totalCount = 10),
             )
 
             presenter.dispatch(MarkSeasonAsWatched(hasUnwatchedInPreviousSeasons = false))
@@ -955,7 +955,7 @@ class SeasonPresenterTest {
         seasonDetailsRepository.setSeasonsResult(initialDetails)
         castRepository.setSeasonCast(emptyList())
         episodeRepository.setSeasonWatchProgress(
-            SeasonWatchProgress(showTraktId = 1, seasonNumber = 1, watchedCount = 10, totalCount = 10),
+            SeasonWatchProgress(showId = 1, seasonNumber = 1, watchedCount = 10, totalCount = 10),
         )
 
         presenter.state.test {
@@ -974,7 +974,7 @@ class SeasonPresenterTest {
             dialogDismissedState.dialogState.shouldBeInstanceOf<SeasonDialogState.Hidden>()
 
             episodeRepository.setSeasonWatchProgress(
-                SeasonWatchProgress(showTraktId = 1, seasonNumber = 1, watchedCount = 9, totalCount = 10),
+                SeasonWatchProgress(showId = 1, seasonNumber = 1, watchedCount = 9, totalCount = 10),
             )
             testDispatcher.scheduler.advanceUntilIdle()
 
@@ -991,7 +991,7 @@ class SeasonPresenterTest {
         seasonDetailsRepository.setSeasonsResult(initialDetails)
         castRepository.setSeasonCast(emptyList())
         episodeRepository.setSeasonWatchProgress(
-            SeasonWatchProgress(showTraktId = 1, seasonNumber = 1, watchedCount = 10, totalCount = 10),
+            SeasonWatchProgress(showId = 1, seasonNumber = 1, watchedCount = 10, totalCount = 10),
         )
 
         presenter.state.test {
@@ -1011,7 +1011,7 @@ class SeasonPresenterTest {
             dialogDismissedState.dialogState.shouldBeInstanceOf<SeasonDialogState.Hidden>()
 
             episodeRepository.setSeasonWatchProgress(
-                SeasonWatchProgress(showTraktId = 1, seasonNumber = 1, watchedCount = 0, totalCount = 10),
+                SeasonWatchProgress(showId = 1, seasonNumber = 1, watchedCount = 0, totalCount = 10),
             )
 
             val updatedState = awaitItem()
@@ -1093,7 +1093,7 @@ class SeasonPresenterTest {
             cancelAndIgnoreRemainingEvents()
 
             episodeRepository.lastMarkEpisodeWatchedCall shouldBe MarkEpisodeWatchedCall(
-                showTraktId = 1,
+                showId = 1,
                 episodeId = 12345,
                 seasonNumber = 1,
                 episodeNumber = 1,
@@ -1108,7 +1108,7 @@ class SeasonPresenterTest {
         seasonDetailsRepository.setSeasonsResult(initialDetails)
         castRepository.setSeasonCast(emptyList())
         episodeRepository.setSeasonWatchProgress(
-            SeasonWatchProgress(showTraktId = 1, seasonNumber = 1, watchedCount = 10, totalCount = 10),
+            SeasonWatchProgress(showId = 1, seasonNumber = 1, watchedCount = 10, totalCount = 10),
         )
 
         presenter.state.test {
@@ -1129,7 +1129,7 @@ class SeasonPresenterTest {
         seasonDetailsRepository.setSeasonsResult(initialDetails)
         castRepository.setSeasonCast(emptyList())
         episodeRepository.setSeasonWatchProgress(
-            SeasonWatchProgress(showTraktId = 1, seasonNumber = 1, watchedCount = 0, totalCount = 10),
+            SeasonWatchProgress(showId = 1, seasonNumber = 1, watchedCount = 0, totalCount = 10),
         )
         episodeRepository.setUnwatchedCountInPreviousSeasons(0L)
 
@@ -1145,7 +1145,7 @@ class SeasonPresenterTest {
             cancelAndIgnoreRemainingEvents()
 
             episodeRepository.lastMarkSeasonWatchedCall shouldBe MarkSeasonWatchedCall(
-                showTraktId = 1,
+                showId = 1,
                 seasonNumber = 1,
                 markPreviousSeasons = false,
             )
@@ -1158,7 +1158,7 @@ class SeasonPresenterTest {
         seasonDetailsRepository.setSeasonsResult(initialDetails)
         castRepository.setSeasonCast(emptyList())
         episodeRepository.setSeasonWatchProgress(
-            SeasonWatchProgress(showTraktId = 1, seasonNumber = 1, watchedCount = 0, totalCount = 10),
+            SeasonWatchProgress(showId = 1, seasonNumber = 1, watchedCount = 0, totalCount = 10),
         )
         episodeRepository.setUnwatchedCountInPreviousSeasons(5)
 
@@ -1181,7 +1181,7 @@ class SeasonPresenterTest {
         return SeasonDetailsPresenter(
             componentContext = DefaultComponentContext(lifecycle = lifecycle),
             param = SeasonDetailsUiParam(
-                showTraktId = 1,
+                showId = 1,
                 seasonId = 1,
                 seasonNumber = 1,
             ),

--- a/features/season-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/data/MockData.kt
+++ b/features/season-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/data/MockData.kt
@@ -27,7 +27,7 @@ internal fun buildSeasonDetailsLoaded(
 
 internal fun buildSeasonDetailsWithEpisodes(
     seasonId: Long = 12343,
-    showTraktId: Long = 84958,
+    showId: Long = 84958,
     showTmdbId: Long = 84958,
     name: String = "Season 01",
     seasonOverview: String =
@@ -47,7 +47,7 @@ internal fun buildSeasonDetailsWithEpisodes(
         episodes = episodes,
         seasonNumber = seasonNumber,
         showTitle = showTitle,
-        showTraktId = showTraktId,
+        showId = showId,
         showTmdbId = showTmdbId,
     )
 }

--- a/features/show-details/nav/src/commonMain/kotlin/com/thomaskioko/tvmaniac/showdetails/nav/model/ShowDetailsParam.kt
+++ b/features/show-details/nav/src/commonMain/kotlin/com/thomaskioko/tvmaniac/showdetails/nav/model/ShowDetailsParam.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 public data class ShowDetailsParam(
-    val id: Long,
+    val showId: Long,
     val forceRefresh: Boolean = false,
 )

--- a/features/show-details/nav/src/commonMain/kotlin/com/thomaskioko/tvmaniac/showdetails/nav/model/ShowSeasonDetailsParam.kt
+++ b/features/show-details/nav/src/commonMain/kotlin/com/thomaskioko/tvmaniac/showdetails/nav/model/ShowSeasonDetailsParam.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 public data class ShowSeasonDetailsParam(
-    val showTraktId: Long,
+    val showId: Long,
     val seasonId: Long,
     val seasonNumber: Long,
     val selectedSeasonIndex: Int,

--- a/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/ShowDetailsAction.kt
+++ b/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/ShowDetailsAction.kt
@@ -14,20 +14,20 @@ public data object ReloadShowDetails : ShowDetailsAction
 
 public data class SeasonClicked(val params: ShowSeasonDetailsParam) : ShowDetailsAction
 
-public data class DetailShowClicked(val id: Long) : ShowDetailsAction
+public data class DetailShowClicked(val showId: Long) : ShowDetailsAction
 
 public data class WatchTrailerClicked(val id: Long) : ShowDetailsAction
 
 public data class FollowShowClicked(val isInLibrary: Boolean) : ShowDetailsAction
 
 public data class MarkEpisodeWatched(
-    val showTraktId: Long,
+    val showId: Long,
     val episodeId: Long,
     val seasonNumber: Long,
     val episodeNumber: Long,
 ) : ShowDetailsAction
 
 public data class MarkEpisodeUnwatched(
-    val showTraktId: Long,
+    val showId: Long,
     val episodeId: Long,
 ) : ShowDetailsAction

--- a/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/ShowDetailsMapper.kt
+++ b/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/ShowDetailsMapper.kt
@@ -69,9 +69,9 @@ public class ShowDetailsMapper(
 
     public fun mapContinueTrackingEpisodes(
         episodes: ImmutableList<EpisodeDetails>,
-        showTraktId: Long,
+        showId: Long,
     ): ImmutableList<ContinueTrackingEpisodeModel> =
-        episodes.map { it.toContinueTrackingModel(showTraktId) }.toImmutableList()
+        episodes.map { it.toContinueTrackingModel(showId) }.toImmutableList()
 
     private fun String.localizeStatus(): String {
         val key = when (lowercase()) {
@@ -98,7 +98,7 @@ public class ShowDetailsMapper(
     private fun List<DomainShow>.toShowList(): ImmutableList<ShowModel> =
         map {
             ShowModel(
-                traktId = it.traktId,
+                showId = it.showId,
                 title = it.title,
                 posterImageUrl = it.posterImageUrl,
                 backdropImageUrl = it.backdropImageUrl,
@@ -137,13 +137,13 @@ public class ShowDetailsMapper(
             )
         }.toImmutableList()
 
-    private fun EpisodeDetails.toContinueTrackingModel(showTraktId: Long): ContinueTrackingEpisodeModel {
+    private fun EpisodeDetails.toContinueTrackingModel(showId: Long): ContinueTrackingEpisodeModel {
         val seasonStr = "S${seasonNumber.toString().padStart(2, '0')}"
         val episodeStr = "E${episodeNumber.toString().padStart(2, '0')}"
         return ContinueTrackingEpisodeModel(
             episodeId = id,
             seasonId = seasonId,
-            showTraktId = showTraktId,
+            showId = showId,
             episodeNumber = episodeNumber,
             seasonNumber = seasonNumber,
             episodeNumberFormatted = "$seasonStr | $episodeStr",

--- a/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/ShowDetailsPresenter.kt
+++ b/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/ShowDetailsPresenter.kt
@@ -87,7 +87,7 @@ public class ShowDetailsPresenter(
     @Suppress("UNUSED_PARAMETER") dispatchers: AppCoroutineDispatchers,
 ) : ComponentContext by componentContext {
 
-    private val showTraktId: Long = param.id
+    private val showId: Long = param.showId
     private val showDetailsLoadingState = ObservableLoadingCounter()
     private val similarShowsLoadingState = ObservableLoadingCounter()
     private val episodeActionLoadingState = ObservableLoadingCounter()
@@ -100,9 +100,9 @@ public class ShowDetailsPresenter(
     public val stateValue: Value<ShowDetailsContent> = state.asValue(coroutineScope)
 
     init {
-        observableShowDetailsInteractor(showTraktId)
-        observableShowMetadataInteractor(showTraktId)
-        observeShowWatchProgressInteractor(showTraktId)
+        observableShowDetailsInteractor(showId)
+        observableShowMetadataInteractor(showId)
+        observeShowWatchProgressInteractor(showId)
 
         observableShowDetailsInteractor.flow
             .onEach { details ->
@@ -115,7 +115,7 @@ public class ShowDetailsPresenter(
                 _state.update {
                     it.copy(
                         showDetails = mapper.applyMetadata(it.showDetails, metadata),
-                        continueTrackingEpisodes = mapper.mapContinueTrackingEpisodes(metadata.continueTrackingEpisodes, showTraktId),
+                        continueTrackingEpisodes = mapper.mapContinueTrackingEpisodes(metadata.continueTrackingEpisodes, showId),
                         continueTrackingScrollIndex = metadata.continueTrackingScrollIndex,
                     )
                 }
@@ -153,7 +153,7 @@ public class ShowDetailsPresenter(
                 navigator.navigateTo(
                     SeasonDetailsRoute(
                         SeasonDetailsUiParam(
-                            showTraktId = action.params.showTraktId,
+                            showId = action.params.showId,
                             seasonId = action.params.seasonId,
                             seasonNumber = action.params.seasonNumber,
                         ),
@@ -161,15 +161,15 @@ public class ShowDetailsPresenter(
                 )
             }
 
-            is DetailShowClicked -> navigator.pushToFront(ShowDetailsRoute(ShowDetailsParam(id = action.id)))
+            is DetailShowClicked -> navigator.pushToFront(ShowDetailsRoute(ShowDetailsParam(showId = action.showId)))
             is WatchTrailerClicked -> navigator.navigateTo(TrailersRoute(action.id))
             is FollowShowClicked -> {
                 coroutineScope.launch {
                     if (action.isInLibrary) {
-                        followedShowsRepository.removeFollowedShow(showTraktId)
-                        notificationManager.cancelNotificationsForShow(showTraktId)
+                        followedShowsRepository.removeFollowedShow(showId)
+                        notificationManager.cancelNotificationsForShow(showId)
                     } else {
-                        followShowInteractor(FollowShowInteractor.Param(traktId = showTraktId))
+                        followShowInteractor(FollowShowInteractor.Param(showId = showId))
                             .collectStatus(episodeActionLoadingState, logger, uiMessageManager, errorToStringMapper = errorToStringMapper)
 
                         syncTraktCalendarInteractor(SyncTraktCalendarInteractor.Params(forceRefresh = true))
@@ -186,12 +186,12 @@ public class ShowDetailsPresenter(
             DetailBackClicked -> navigator.navigateBack()
             ReloadShowDetails -> refreshShowContent()
             is ShowDetailsMessageShown -> coroutineScope.launch { uiMessageManager.clearMessage(action.id) }
-            OpenShowList -> navigator.navigateTo(ShowListRoute(ShowListParam(showId = showTraktId)))
+            OpenShowList -> navigator.navigateTo(ShowListRoute(ShowListParam(showId = showId)))
 
             is MarkEpisodeWatched -> launchEpisodeMark(action.episodeId) {
                 markEpisodeWatchedInteractor(
                     MarkEpisodeWatchedParams(
-                        showTraktId = action.showTraktId,
+                        showId = action.showId,
                         episodeId = action.episodeId,
                         seasonNumber = action.seasonNumber,
                         episodeNumber = action.episodeNumber,
@@ -203,7 +203,7 @@ public class ShowDetailsPresenter(
             is MarkEpisodeUnwatched -> launchEpisodeMark(action.episodeId) {
                 markEpisodeUnwatchedInteractor(
                     MarkEpisodeUnwatchedParams(
-                        showTraktId = action.showTraktId,
+                        showId = action.showId,
                         episodeId = action.episodeId,
                     ),
                 ).collectStatus(episodeActionLoadingState, logger, uiMessageManager, errorToStringMapper = errorToStringMapper)
@@ -213,12 +213,12 @@ public class ShowDetailsPresenter(
 
     private fun observeShowDetails(forceReload: Boolean = false) {
         coroutineScope.launch {
-            showDetailsInteractor(ShowDetailsInteractor.Param(showTraktId, forceReload))
+            showDetailsInteractor(ShowDetailsInteractor.Param(showId, forceReload))
                 .collectStatus(showDetailsLoadingState, logger, uiMessageManager, errorToStringMapper = errorToStringMapper)
         }
 
         coroutineScope.launch {
-            similarShowsInteractor(SimilarShowsInteractor.Param(showTraktId, forceReload))
+            similarShowsInteractor(SimilarShowsInteractor.Param(showId, forceReload))
                 .collectStatus(similarShowsLoadingState, logger, uiMessageManager, errorToStringMapper = errorToStringMapper)
         }
     }

--- a/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/model/ContinueTrackingEpisodeModel.kt
+++ b/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/model/ContinueTrackingEpisodeModel.kt
@@ -3,7 +3,7 @@ package com.thomaskioko.tvmaniac.presenter.showdetails.model
 public data class ContinueTrackingEpisodeModel(
     val episodeId: Long,
     val seasonId: Long,
-    val showTraktId: Long,
+    val showId: Long,
     val episodeNumber: Long,
     val seasonNumber: Long,
     val episodeNumberFormatted: String,

--- a/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/model/ShowModel.kt
+++ b/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/model/ShowModel.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.presenter.showdetails.model
 
 public data class ShowModel(
-    val traktId: Long,
+    val showId: Long,
     val title: String,
     val posterImageUrl: String?,
     val backdropImageUrl: String?,

--- a/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/MockData.kt
+++ b/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/MockData.kt
@@ -112,7 +112,7 @@ val testContinueTrackingResult = ContinueTrackingResult(
 )
 
 val testShowWatchProgress = ShowWatchProgress(
-    showTraktId = 84958L,
+    showId = 84958L,
     watchedCount = 5,
     totalCount = 10,
 )
@@ -134,13 +134,13 @@ val testSeasonsWithProgress = listOf(
 
 val testSeasonWatchProgress = listOf(
     SeasonWatchProgress(
-        showTraktId = 84958L,
+        showId = 84958L,
         seasonNumber = 1L,
         watchedCount = 8,
         totalCount = 10,
     ),
     SeasonWatchProgress(
-        showTraktId = 84958L,
+        showId = 84958L,
         seasonNumber = 2L,
         watchedCount = 3,
         totalCount = 12,
@@ -149,7 +149,7 @@ val testSeasonWatchProgress = listOf(
 
 val testPartialSeasonProgress = listOf(
     SeasonWatchProgress(
-        showTraktId = 84958L,
+        showId = 84958L,
         seasonNumber = 1L,
         watchedCount = 5,
         totalCount = 10,
@@ -158,7 +158,7 @@ val testPartialSeasonProgress = listOf(
 
 val testCompletedSeasonProgress = listOf(
     SeasonWatchProgress(
-        showTraktId = 84958L,
+        showId = 84958L,
         seasonNumber = 1L,
         watchedCount = 10,
         totalCount = 10,

--- a/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/ShowDetailsPresenterTest.kt
+++ b/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/ShowDetailsPresenterTest.kt
@@ -152,7 +152,7 @@ class ShowDetailsPresenterTest {
             ),
             similarShows = persistentListOf(
                 ShowModel(
-                    traktId = 18495,
+                    showId = 18495,
                     title = "Loki",
                     posterImageUrl = "/kEl2t3OhXc3Zb9FBh1AuYzRTgZp.jpg",
                     backdropImageUrl = "/kEl2t3OhXc3Zb9FBh1AuYzRTgZp.jpg",
@@ -232,7 +232,7 @@ class ShowDetailsPresenterTest {
         presenter.dispatch(
             SeasonClicked(
                 ShowSeasonDetailsParam(
-                    showTraktId = 2,
+                    showId = 2,
                     selectedSeasonIndex = 2,
                     seasonNumber = 0,
                     seasonId = 0,
@@ -292,7 +292,7 @@ class ShowDetailsPresenterTest {
 
             presenter.dispatch(
                 MarkEpisodeWatched(
-                    showTraktId = 84958,
+                    showId = 84958,
                     episodeId = 1001,
                     seasonNumber = 1,
                     episodeNumber = 1,
@@ -302,7 +302,7 @@ class ShowDetailsPresenterTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             episodeRepository.lastMarkEpisodeWatchedCall shouldBe MarkEpisodeWatchedCall(
-                showTraktId = 84958,
+                showId = 84958,
                 episodeId = 1001,
                 seasonNumber = 1,
                 episodeNumber = 1,
@@ -319,7 +319,7 @@ class ShowDetailsPresenterTest {
 
             presenter.dispatch(
                 MarkEpisodeUnwatched(
-                    showTraktId = 84958,
+                    showId = 84958,
                     episodeId = 1001,
                 ),
             )
@@ -327,7 +327,7 @@ class ShowDetailsPresenterTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             episodeRepository.lastMarkEpisodeUnwatchedCall shouldBe MarkEpisodeUnwatchedCall(
-                showTraktId = 84958,
+                showId = 84958,
                 episodeId = 1001,
             )
         }
@@ -497,7 +497,7 @@ class ShowDetailsPresenterTest {
 
         presenter.dispatch(
             MarkEpisodeWatched(
-                showTraktId = 84958,
+                showId = 84958,
                 episodeId = 1001,
                 seasonNumber = 1,
                 episodeNumber = 1,
@@ -704,7 +704,7 @@ class ShowDetailsPresenterTest {
     }
 
     private fun buildShowDetailsPresenter(
-        param: ShowDetailsParam = ShowDetailsParam(id = 84958),
+        param: ShowDetailsParam = ShowDetailsParam(showId = 84958),
         onShowFollowed: () -> Unit = {},
     ): ShowDetailsPresenter {
         val notificationRationale = object : NotificationRationale {

--- a/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/ShowDetailsPresenterTest.kt
+++ b/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/ShowDetailsPresenterTest.kt
@@ -14,7 +14,7 @@ import com.thomaskioko.tvmaniac.data.library.testing.FakeLibraryRepository
 import com.thomaskioko.tvmaniac.data.showdetails.testing.FakeShowDetailsRepository
 import com.thomaskioko.tvmaniac.data.watchproviders.testing.FakeWatchProviderRepository
 import com.thomaskioko.tvmaniac.datastore.testing.FakeDatastoreRepository
-import com.thomaskioko.tvmaniac.db.SelectByShowTraktId
+import com.thomaskioko.tvmaniac.db.SelectByShowId
 import com.thomaskioko.tvmaniac.db.ShowCast
 import com.thomaskioko.tvmaniac.db.ShowSeasons
 import com.thomaskioko.tvmaniac.db.SimilarShows
@@ -692,7 +692,7 @@ class ShowDetailsPresenterTest {
         seasonResult: List<ShowSeasons> = emptyList(),
         watchProviderResult: List<WatchProviders> = emptyList(),
         similarShowResult: List<SimilarShows> = emptyList(),
-        trailersResult: List<SelectByShowTraktId> = emptyList(),
+        trailersResult: List<SelectByShowId> = emptyList(),
     ) {
         showDetailsRepository.setShowDetailsResult(showDetailResult)
         trailerRepository.setYoutubePlayerInstalled(isYoutubeInstalled)

--- a/features/show-details/ui/src/main/kotlin/com/thomaskioko/tvmaniac/showdetails/ui/DetailPreviewParameterProvider.kt
+++ b/features/show-details/ui/src/main/kotlin/com/thomaskioko/tvmaniac/showdetails/ui/DetailPreviewParameterProvider.kt
@@ -54,7 +54,7 @@ internal val showDetailsContent = ShowDetailsContent(
         ),
         similarShows = persistentListOf(
             ShowModel(
-                traktId = 1232,
+                showId = 1232,
                 title = "Loki",
                 posterImageUrl = "/kEl2t3OhXc3Zb9FBh1AuYzRTgZp.jpg",
                 backdropImageUrl = "/kEl2t3OhXc3Zb9FBh1AuYzRTgZp.jpg",
@@ -74,7 +74,7 @@ internal val showDetailsContent = ShowDetailsContent(
         ContinueTrackingEpisodeModel(
             episodeId = 121L,
             seasonId = 1L,
-            showTraktId = 1L,
+            showId = 1L,
             episodeNumber = 1,
             seasonNumber = 2,
             episodeNumberFormatted = "S01 | E01",
@@ -87,7 +87,7 @@ internal val showDetailsContent = ShowDetailsContent(
         ContinueTrackingEpisodeModel(
             episodeId = 122L,
             seasonId = 1L,
-            showTraktId = 1L,
+            showId = 1L,
             episodeNumber = 2,
             seasonNumber = 2,
             episodeNumberFormatted = "S01 | E02",
@@ -100,7 +100,7 @@ internal val showDetailsContent = ShowDetailsContent(
         ContinueTrackingEpisodeModel(
             episodeId = 123L,
             seasonId = 1L,
-            showTraktId = 1L,
+            showId = 1L,
             episodeNumber = 3,
             seasonNumber = 2,
             episodeNumberFormatted = "S01 | E03",

--- a/features/show-details/ui/src/main/kotlin/com/thomaskioko/tvmaniac/showdetails/ui/ShowDetailScreen.kt
+++ b/features/show-details/ui/src/main/kotlin/com/thomaskioko/tvmaniac/showdetails/ui/ShowDetailScreen.kt
@@ -241,14 +241,14 @@ internal fun LazyColumnContent(
                         if (episode.isWatched) {
                             onAction(
                                 MarkEpisodeUnwatched(
-                                    showTraktId = episode.showTraktId,
+                                    showId = episode.showId,
                                     episodeId = episode.episodeId,
                                 ),
                             )
                         } else {
                             onAction(
                                 MarkEpisodeWatched(
-                                    showTraktId = episode.showTraktId,
+                                    showId = episode.showId,
                                     episodeId = episode.episodeId,
                                     seasonNumber = episode.seasonNumber,
                                     episodeNumber = episode.episodeNumber,
@@ -830,12 +830,12 @@ private fun HorizontalRowContent(
         ) {
             items(
                 items = items,
-                key = { it.traktId },
+                key = { it.showId },
                 contentType = { "ShowModel" },
             ) { tvShow ->
                 PosterCard(
                     imageUrl = tvShow.posterImageUrl,
-                    onClick = { onShowClicked(tvShow.traktId) },
+                    onClick = { onShowClicked(tvShow.showId) },
                     title = tvShow.title,
                 )
             }

--- a/features/show-details/ui/src/main/kotlin/com/thomaskioko/tvmaniac/showdetails/ui/components/ContinueTrackingCard.kt
+++ b/features/show-details/ui/src/main/kotlin/com/thomaskioko/tvmaniac/showdetails/ui/components/ContinueTrackingCard.kt
@@ -157,7 +157,7 @@ private fun ContinueTrackingCardPreview() {
         episode = ContinueTrackingEpisodeModel(
             episodeId = 123L,
             seasonId = 1L,
-            showTraktId = 1L,
+            showId = 1L,
             episodeNumber = 3,
             seasonNumber = 2,
             episodeNumberFormatted = "S02 | E03",
@@ -179,7 +179,7 @@ private fun ContinueTrackingCardWatchedPreview() {
         episode = ContinueTrackingEpisodeModel(
             episodeId = 123L,
             seasonId = 1L,
-            showTraktId = 1L,
+            showId = 1L,
             episodeNumber = 2,
             seasonNumber = 2,
             episodeNumberFormatted = "S02 | E02",
@@ -201,7 +201,7 @@ private fun ContinueTrackingCardFuturePreview() {
         episode = ContinueTrackingEpisodeModel(
             episodeId = 123L,
             seasonId = 1L,
-            showTraktId = 1L,
+            showId = 1L,
             episodeNumber = 5,
             seasonNumber = 2,
             episodeNumberFormatted = "S02 | E05",
@@ -223,7 +223,7 @@ private fun ContinueTrackingCardUnknownAirDatePreview() {
         episode = ContinueTrackingEpisodeModel(
             episodeId = 123L,
             seasonId = 1L,
-            showTraktId = 1L,
+            showId = 1L,
             episodeNumber = 6,
             seasonNumber = 2,
             episodeNumberFormatted = "S02 | E06",

--- a/features/show-details/ui/src/main/kotlin/com/thomaskioko/tvmaniac/showdetails/ui/components/ContinueTrackingSection.kt
+++ b/features/show-details/ui/src/main/kotlin/com/thomaskioko/tvmaniac/showdetails/ui/components/ContinueTrackingSection.kt
@@ -117,7 +117,7 @@ private fun ContinueTrackingSectionPreview() {
             ContinueTrackingEpisodeModel(
                 episodeId = 1L,
                 seasonId = 1L,
-                showTraktId = 1L,
+                showId = 1L,
                 episodeNumber = 1,
                 seasonNumber = 2,
                 episodeNumberFormatted = "S02 | E01",
@@ -130,7 +130,7 @@ private fun ContinueTrackingSectionPreview() {
             ContinueTrackingEpisodeModel(
                 episodeId = 2L,
                 seasonId = 1L,
-                showTraktId = 1L,
+                showId = 1L,
                 episodeNumber = 2,
                 seasonNumber = 2,
                 episodeNumberFormatted = "S02 | E02",
@@ -143,7 +143,7 @@ private fun ContinueTrackingSectionPreview() {
             ContinueTrackingEpisodeModel(
                 episodeId = 3L,
                 seasonId = 1L,
-                showTraktId = 1L,
+                showId = 1L,
                 episodeNumber = 3,
                 seasonNumber = 2,
                 episodeNumberFormatted = "S02 | E03",

--- a/features/show-list/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/showlist/ShowListPresenter.kt
+++ b/features/show-list/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/showlist/ShowListPresenter.kt
@@ -165,7 +165,7 @@ public class ShowListPresenter(
                 toggleShowInListInteractor(
                     ToggleShowInListInteractor.Params(
                         listId = listId,
-                        traktShowId = param.showId,
+                        showId = param.showId,
                         isCurrentlyInList = isCurrentlyInList,
                     ),
                 ).collectStatus(

--- a/features/start-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/presenter/Mapper.kt
+++ b/features/start-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/presenter/Mapper.kt
@@ -14,7 +14,7 @@ internal fun List<StartWatchingShow>.toStartWatchingItems(
         .sortedWith(sortComparator(sortOption))
         .map {
             StartWatchingItem(
-                traktId = it.traktId,
+                showId = it.showId,
                 title = it.title,
                 posterImageUrl = it.posterPath,
                 year = it.year,

--- a/features/start-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/presenter/StartWatchingAction.kt
+++ b/features/start-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/presenter/StartWatchingAction.kt
@@ -2,7 +2,7 @@ package com.thomaskioko.tvmaniac.startwatching.presenter
 
 public sealed interface StartWatchingAction
 
-public data class StartWatchingShowClicked(val traktId: Long) : StartWatchingAction
+public data class StartWatchingShowClicked(val showId: Long) : StartWatchingAction
 
 public data class StartWatchingMessageShown(val id: Long) : StartWatchingAction
 

--- a/features/start-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/presenter/StartWatchingPresenter.kt
+++ b/features/start-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/presenter/StartWatchingPresenter.kt
@@ -93,14 +93,14 @@ public class StartWatchingPresenter(
 
     public fun dispatch(action: StartWatchingAction) {
         when (action) {
-            is StartWatchingShowClicked -> navigateToShowDetails(action.traktId)
+            is StartWatchingShowClicked -> navigateToShowDetails(action.showId)
             is StartWatchingMessageShown -> clearMessage(action.id)
             is RefreshStartWatching -> syncStartWatching(action.forceRefresh)
         }
     }
 
-    private fun navigateToShowDetails(traktId: Long) {
-        navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(id = traktId)))
+    private fun navigateToShowDetails(showId: Long) {
+        navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(showId = showId)))
     }
 
     private fun syncStartWatching(forceRefresh: Boolean) {

--- a/features/start-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/presenter/model/StartWatchingItem.kt
+++ b/features/start-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/presenter/model/StartWatchingItem.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.startwatching.presenter.model
 
 public data class StartWatchingItem(
-    val traktId: Long,
+    val showId: Long,
     val title: String,
     val posterImageUrl: String?,
     val year: String?,

--- a/features/start-watching/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/startwatching/presenter/StartWatchingPresenterTest.kt
+++ b/features/start-watching/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/startwatching/presenter/StartWatchingPresenterTest.kt
@@ -19,13 +19,13 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 
 private val startWatchingShows = listOf(
-    StartWatchingShow(traktId = 1, tmdbId = 1, title = "Breaking Bad", posterPath = "/1.jpg", year = "2008", inLibrary = true),
-    StartWatchingShow(traktId = 2, tmdbId = 2, title = "Better Call Saul", posterPath = "/2.jpg", year = "2015", inLibrary = true),
+    StartWatchingShow(showId = 1, tmdbId = 1, title = "Breaking Bad", posterPath = "/1.jpg", year = "2008", inLibrary = true),
+    StartWatchingShow(showId = 2, tmdbId = 2, title = "Better Call Saul", posterPath = "/2.jpg", year = "2015", inLibrary = true),
 )
 
 private val expectedItems = listOf(
-    StartWatchingItem(traktId = 1, title = "Breaking Bad", posterImageUrl = "/1.jpg", year = "2008"),
-    StartWatchingItem(traktId = 2, title = "Better Call Saul", posterImageUrl = "/2.jpg", year = "2015"),
+    StartWatchingItem(showId = 1, title = "Breaking Bad", posterImageUrl = "/1.jpg", year = "2008"),
+    StartWatchingItem(showId = 2, title = "Better Call Saul", posterImageUrl = "/2.jpg", year = "2015"),
 )
 
 class StartWatchingPresenterTest {

--- a/features/start-watching/ui/src/main/kotlin/com/thomaskioko/tvmaniac/startwatching/ui/StartWatchingPreviewParameterProvider.kt
+++ b/features/start-watching/ui/src/main/kotlin/com/thomaskioko/tvmaniac/startwatching/ui/StartWatchingPreviewParameterProvider.kt
@@ -7,9 +7,9 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 internal val previewStartWatchingItems: ImmutableList<StartWatchingItem> = persistentListOf(
-    StartWatchingItem(traktId = 1, title = "Breaking Bad", posterImageUrl = null, year = "2008"),
-    StartWatchingItem(traktId = 2, title = "Better Call Saul", posterImageUrl = null, year = "2015"),
-    StartWatchingItem(traktId = 3, title = "Severance", posterImageUrl = null, year = "2022"),
+    StartWatchingItem(showId = 1, title = "Breaking Bad", posterImageUrl = null, year = "2008"),
+    StartWatchingItem(showId = 2, title = "Better Call Saul", posterImageUrl = null, year = "2015"),
+    StartWatchingItem(showId = 3, title = "Severance", posterImageUrl = null, year = "2022"),
 )
 
 internal class StartWatchingPreviewParameterProvider : PreviewParameterProvider<StartWatchingState> {

--- a/features/start-watching/ui/src/main/kotlin/com/thomaskioko/tvmaniac/startwatching/ui/StartWatchingScreen.kt
+++ b/features/start-watching/ui/src/main/kotlin/com/thomaskioko/tvmaniac/startwatching/ui/StartWatchingScreen.kt
@@ -95,15 +95,15 @@ private fun StartWatchingGrid(
     ) {
         items(
             items = items,
-            key = { it.traktId },
+            key = { it.showId },
         ) { item ->
             PosterCard(
                 imageUrl = item.posterImageUrl,
                 title = item.title,
-                onClick = { onShowClicked(item.traktId) },
+                onClick = { onShowClicked(item.showId) },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .testTag(StartWatchingTestTags.showCard(item.traktId)),
+                    .testTag(StartWatchingTestTags.showCard(item.showId)),
             )
         }
     }

--- a/features/trailers/nav/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trailers/nav/TrailersRoute.kt
+++ b/features/trailers/nav/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trailers/nav/TrailersRoute.kt
@@ -4,4 +4,4 @@ import com.thomaskioko.tvmaniac.navigation.NavRoute
 import kotlinx.serialization.Serializable
 
 @Serializable
-public data class TrailersRoute(public val traktShowId: Long) : NavRoute
+public data class TrailersRoute(public val showId: Long) : NavRoute

--- a/features/trailers/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/trailers/Mapper.kt
+++ b/features/trailers/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/trailers/Mapper.kt
@@ -1,11 +1,11 @@
 package com.thomaskioko.tvmaniac.presenter.trailers
 
-import com.thomaskioko.tvmaniac.db.SelectByShowTraktId
+import com.thomaskioko.tvmaniac.db.SelectByShowId
 import com.thomaskioko.tvmaniac.presenter.trailers.model.Trailer
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
-internal fun List<SelectByShowTraktId>.toTrailerList(): ImmutableList<Trailer> {
+internal fun List<SelectByShowId>.toTrailerList(): ImmutableList<Trailer> {
     return map { trailer ->
         Trailer(
             showTmdbId = trailer.show_tmdb_id.id,

--- a/features/trailers/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/trailers/TrailersPresenter.kt
+++ b/features/trailers/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/trailers/TrailersPresenter.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.launch
 @AssistedInject
 public class TrailersPresenter(
     componentContext: ComponentContext,
-    @Assisted private val traktShowId: Long,
+    @Assisted private val showId: Long,
     private val repository: TrailerRepository,
 ) {
 
@@ -55,7 +55,7 @@ public class TrailersPresenter(
     }
 
     private suspend fun observeTrailerInfo() {
-        repository.observeTrailers(traktShowId)
+        repository.observeTrailers(showId)
             .collectLatest { result ->
                 _state.update {
                     TrailersContent(
@@ -68,6 +68,6 @@ public class TrailersPresenter(
 
     @AssistedFactory
     public fun interface Factory {
-        public fun create(traktShowId: Long): TrailersPresenter
+        public fun create(showId: Long): TrailersPresenter
     }
 }

--- a/features/trailers/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/trailers/TrailersPresenterTest.kt
+++ b/features/trailers/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/trailers/TrailersPresenterTest.kt
@@ -33,7 +33,7 @@ internal class TrailersPresenterTest {
 
         presenter = TrailersPresenter(
             componentContext = DefaultComponentContext(lifecycle = lifecycle),
-            traktShowId = 84958,
+            showId = 84958,
             repository = repository,
         )
     }

--- a/features/upnext/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextAction.kt
+++ b/features/upnext/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextAction.kt
@@ -4,10 +4,10 @@ import com.thomaskioko.tvmaniac.domain.continuewatching.model.UpNextSortOption
 
 public sealed interface UpNextAction
 
-public data class UpNextShowClicked(val showTraktId: Long) : UpNextAction
+public data class UpNextShowClicked(val showId: Long) : UpNextAction
 
 public data class MarkWatched(
-    val showTraktId: Long,
+    val showId: Long,
     val episodeId: Long,
     val seasonNumber: Long,
     val episodeNumber: Long,
@@ -19,14 +19,14 @@ public data object RefreshUpNext : UpNextAction
 
 public data class UpNextMessageShown(val id: Long) : UpNextAction
 
-public data class OpenShow(val showTraktId: Long) : UpNextAction
+public data class OpenShow(val showId: Long) : UpNextAction
 
 public data class OpenSeason(
-    val showTraktId: Long,
+    val showId: Long,
     val seasonId: Long,
     val seasonNumber: Long,
 ) : UpNextAction
 
-public data class UnfollowShow(val showTraktId: Long) : UpNextAction
+public data class UnfollowShow(val showId: Long) : UpNextAction
 
 public data class UpNextEpisodeLongPressed(val episodeId: Long) : UpNextAction

--- a/features/upnext/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextPresenter.kt
+++ b/features/upnext/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextPresenter.kt
@@ -103,22 +103,22 @@ public class UpNextPresenter(
 
     public fun dispatch(action: UpNextAction) {
         when (action) {
-            is UpNextShowClicked -> navigateToSeasonFromEpisode(action.showTraktId)
+            is UpNextShowClicked -> navigateToSeasonFromEpisode(action.showId)
             is MarkWatched -> markEpisodeWatched(action)
             is UpNextChangeSortOption -> changeSortOption(action.sortOption)
             is RefreshUpNext -> refreshUpNext(isUserInitiated = true)
             is UpNextMessageShown -> clearMessage(action.id)
-            is OpenShow -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(id = action.showTraktId)))
+            is OpenShow -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(showId = action.showId)))
             is OpenSeason -> navigator.navigateTo(
                 SeasonDetailsRoute(
                     SeasonDetailsUiParam(
-                        showTraktId = action.showTraktId,
+                        showId = action.showId,
                         seasonId = action.seasonId,
                         seasonNumber = action.seasonNumber,
                     ),
                 ),
             )
-            is UnfollowShow -> unfollowShow(action.showTraktId)
+            is UnfollowShow -> unfollowShow(action.showId)
             is UpNextEpisodeLongPressed -> navigator.navigateTo(
                 EpisodeSheetRoute(EpisodeSheetParam(episodeId = action.episodeId, source = ScreenSource.UP_NEXT)),
             )
@@ -150,7 +150,7 @@ public class UpNextPresenter(
             try {
                 markEpisodeWatchedInteractor(
                     MarkEpisodeWatchedParams(
-                        showTraktId = action.showTraktId,
+                        showId = action.showId,
                         episodeId = action.episodeId,
                         seasonNumber = action.seasonNumber,
                         episodeNumber = action.episodeNumber,
@@ -176,13 +176,13 @@ public class UpNextPresenter(
         }
     }
 
-    private fun navigateToSeasonFromEpisode(showTraktId: Long) {
-        val episode = state.value.episodes.firstOrNull { it.showTraktId == showTraktId }
+    private fun navigateToSeasonFromEpisode(showId: Long) {
+        val episode = state.value.episodes.firstOrNull { it.showId == showId }
         if (episode?.seasonId != null && episode.seasonNumber != null) {
             navigator.navigateTo(
                 SeasonDetailsRoute(
                     SeasonDetailsUiParam(
-                        showTraktId = showTraktId,
+                        showId = showId,
                         seasonId = episode.seasonId,
                         seasonNumber = episode.seasonNumber,
                     ),
@@ -191,9 +191,9 @@ public class UpNextPresenter(
         }
     }
 
-    private fun unfollowShow(showTraktId: Long) {
+    private fun unfollowShow(showId: Long) {
         coroutineScope.launch {
-            unfollowShowInteractor.executeSync(showTraktId)
+            unfollowShowInteractor.executeSync(showId)
         }
     }
 
@@ -208,7 +208,7 @@ private fun UpNextEpisode.toUiModel(): UpNextEpisodeUiModel {
     val season = seasonNumber.toString().padStart(2, '0')
     val episode = episodeNumber.toString().padStart(2, '0')
     return UpNextEpisodeUiModel(
-        showTraktId = showTraktId,
+        showId = showId,
         showTmdbId = showTmdbId,
         showName = showName,
         imageUrl = stillPath ?: showPoster,

--- a/features/upnext/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/model/UpNextEpisodeUiModel.kt
+++ b/features/upnext/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/model/UpNextEpisodeUiModel.kt
@@ -1,7 +1,7 @@
 package com.thomaskioko.tvmaniac.presentation.upnext.model
 
 public data class UpNextEpisodeUiModel(
-    val showTraktId: Long,
+    val showId: Long,
     val showTmdbId: Long,
     val showName: String,
     val imageUrl: String?,

--- a/features/upnext/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextPresenterTest.kt
+++ b/features/upnext/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextPresenterTest.kt
@@ -87,8 +87,8 @@ internal class UpNextPresenterTest {
     @Test
     fun `should display episodes given episodes are available`() = runTest {
         val episodes = listOf(
-            createTestNextEpisode(showTraktId = 1, showName = "Show 1"),
-            createTestNextEpisode(showTraktId = 2, showName = "Show 2"),
+            createTestNextEpisode(showId = 1, showName = "Show 1"),
+            createTestNextEpisode(showId = 2, showName = "Show 2"),
         )
         upNextRepository.setNextEpisodesForWatchlist(episodes)
 
@@ -107,8 +107,8 @@ internal class UpNextPresenterTest {
     @Test
     fun `should sort episodes by last watched given sort option is LAST_WATCHED`() = runTest {
         val episodes = listOf(
-            createTestNextEpisode(showTraktId = 1, showName = "Old Show", lastWatchedAt = 1000L),
-            createTestNextEpisode(showTraktId = 2, showName = "New Show", lastWatchedAt = 2000L),
+            createTestNextEpisode(showId = 1, showName = "Old Show", lastWatchedAt = 1000L),
+            createTestNextEpisode(showId = 2, showName = "New Show", lastWatchedAt = 2000L),
         )
         upNextRepository.setNextEpisodesForWatchlist(episodes)
         upNextRepository.setUpNextSortOption(UpNextSortOption.LAST_WATCHED.name)
@@ -128,8 +128,8 @@ internal class UpNextPresenterTest {
     @Test
     fun `should sort episodes by air date given sort option is AIR_DATE`() = runTest {
         val episodes = listOf(
-            createTestNextEpisode(showTraktId = 1, showName = "Old Episode", firstAired = 1000L),
-            createTestNextEpisode(showTraktId = 2, showName = "New Episode", firstAired = 2000L),
+            createTestNextEpisode(showId = 1, showName = "Old Episode", firstAired = 1000L),
+            createTestNextEpisode(showId = 2, showName = "New Episode", firstAired = 2000L),
         )
         upNextRepository.setNextEpisodesForWatchlist(episodes)
         upNextRepository.setUpNextSortOption(UpNextSortOption.AIR_DATE.name)
@@ -151,8 +151,8 @@ internal class UpNextPresenterTest {
         dateTimeProvider.setCurrentTimeMillis(5000L)
 
         val episodes = listOf(
-            createTestNextEpisode(showTraktId = 1, showName = "Aired Show", firstAired = 3000L),
-            createTestNextEpisode(showTraktId = 2, showName = "Future Show", firstAired = 10000L),
+            createTestNextEpisode(showId = 1, showName = "Aired Show", firstAired = 3000L),
+            createTestNextEpisode(showId = 2, showName = "Future Show", firstAired = 10000L),
         )
         upNextRepository.setNextEpisodesForWatchlist(episodes)
 
@@ -172,8 +172,8 @@ internal class UpNextPresenterTest {
         dateTimeProvider.setCurrentTimeMillis(5000L)
 
         val episodes = listOf(
-            createTestNextEpisode(showTraktId = 1, showName = "No Air Date", firstAired = null),
-            createTestNextEpisode(showTraktId = 2, showName = "Aired Show", firstAired = 3000L),
+            createTestNextEpisode(showId = 1, showName = "No Air Date", firstAired = null),
+            createTestNextEpisode(showId = 2, showName = "Aired Show", firstAired = 3000L),
         )
         upNextRepository.setNextEpisodesForWatchlist(episodes)
 
@@ -212,7 +212,7 @@ internal class UpNextPresenterTest {
 
             presenter.dispatch(
                 MarkWatched(
-                    showTraktId = 123L,
+                    showId = 123L,
                     episodeId = 456L,
                     seasonNumber = 1L,
                     episodeNumber = 5L,
@@ -221,7 +221,7 @@ internal class UpNextPresenterTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             val call = episodeRepository.lastMarkEpisodeWatchedCall
-            call?.showTraktId shouldBe 123L
+            call?.showId shouldBe 123L
             call?.episodeId shouldBe 456L
             call?.seasonNumber shouldBe 1L
             call?.episodeNumber shouldBe 5L
@@ -232,7 +232,7 @@ internal class UpNextPresenterTest {
 
     @Test
     fun `should navigate to season details given ShowClicked action is dispatched`() = runTest {
-        val episode = createTestNextEpisode(showTraktId = 999, showName = "Test Show")
+        val episode = createTestNextEpisode(showId = 999, showName = "Test Show")
         upNextRepository.setNextEpisodesForWatchlist(listOf(episode))
 
         val presenter = createPresenter()
@@ -241,11 +241,11 @@ internal class UpNextPresenterTest {
             skipItems(1)
             awaitItem()
 
-            presenter.dispatch(UpNextShowClicked(showTraktId = 999L))
+            presenter.dispatch(UpNextShowClicked(showId = 999L))
 
             navigator.lastNavigatedRoute shouldBe SeasonDetailsRoute(
                 SeasonDetailsUiParam(
-                    showTraktId = 999L,
+                    showId = 999L,
                     seasonId = 9990L,
                     seasonNumber = 1L,
                 ),
@@ -256,8 +256,8 @@ internal class UpNextPresenterTest {
 
     @Test
     fun `should remove episode from list given episode is marked as watched`() = runTest {
-        val episode1 = createTestNextEpisode(showTraktId = 1, showName = "Show 1")
-        val episode2 = createTestNextEpisode(showTraktId = 2, showName = "Show 2")
+        val episode1 = createTestNextEpisode(showId = 1, showName = "Show 1")
+        val episode2 = createTestNextEpisode(showId = 2, showName = "Show 2")
         upNextRepository.setNextEpisodesForWatchlist(listOf(episode1, episode2))
 
         val presenter = createPresenter()
@@ -267,12 +267,12 @@ internal class UpNextPresenterTest {
 
             val initialState = awaitItem()
             initialState.episodes shouldHaveSize 2
-            initialState.episodes.any { it.showTraktId == 1L } shouldBe true
-            initialState.episodes.any { it.showTraktId == 2L } shouldBe true
+            initialState.episodes.any { it.showId == 1L } shouldBe true
+            initialState.episodes.any { it.showId == 2L } shouldBe true
 
             presenter.dispatch(
                 MarkWatched(
-                    showTraktId = episode1.showTraktId,
+                    showId = episode1.showId,
                     episodeId = 100L,
                     seasonNumber = 1L,
                     episodeNumber = 1L,
@@ -285,15 +285,15 @@ internal class UpNextPresenterTest {
 
             val updatedState = expectMostRecentItem()
             updatedState.episodes shouldHaveSize 1
-            updatedState.episodes.any { it.showTraktId == 1L } shouldBe false
-            updatedState.episodes.any { it.showTraktId == 2L } shouldBe true
+            updatedState.episodes.any { it.showId == 1L } shouldBe false
+            updatedState.episodes.any { it.showId == 2L } shouldBe true
             updatedState.updatingEpisodeIds.shouldBeEmpty()
         }
     }
 
     @Test
     fun `should populate updatingEpisodeIds while mark watched is in flight`() = runTest {
-        val episode = createTestNextEpisode(showTraktId = 1, showName = "Show 1")
+        val episode = createTestNextEpisode(showId = 1, showName = "Show 1")
         upNextRepository.setNextEpisodesForWatchlist(listOf(episode))
 
         val presenter = createPresenter()
@@ -305,7 +305,7 @@ internal class UpNextPresenterTest {
 
             presenter.dispatch(
                 MarkWatched(
-                    showTraktId = episode.showTraktId,
+                    showId = episode.showId,
                     episodeId = 100L,
                     seasonNumber = 1L,
                     episodeNumber = 1L,
@@ -324,7 +324,7 @@ internal class UpNextPresenterTest {
     @Test
     fun `should map all episode fields to ui model correctly`() = runTest {
         val episode = NextEpisodeWithShow(
-            showTraktId = 42L,
+            showId = 42L,
             showTmdbId = 84L,
             episodeId = 100L,
             episodeName = "Pilot",
@@ -355,7 +355,7 @@ internal class UpNextPresenterTest {
             state.episodes shouldHaveSize 1
 
             val uiModel = state.episodes[0]
-            uiModel.showTraktId shouldBe 42L
+            uiModel.showId shouldBe 42L
             uiModel.showTmdbId shouldBe 84L
             uiModel.episodeId shouldBe 100L
             uiModel.episodeName shouldBe "Pilot"
@@ -379,7 +379,7 @@ internal class UpNextPresenterTest {
     @Test
     fun `should refresh data given auth state changes to logged in`() = runTest {
         val episodes = listOf(
-            createTestNextEpisode(showTraktId = 1, showName = "Show 1"),
+            createTestNextEpisode(showId = 1, showName = "Show 1"),
         )
         upNextRepository.setNextEpisodesForWatchlist(episodes)
 
@@ -433,7 +433,7 @@ internal class UpNextPresenterTest {
     @Test
     fun `should not show loading given sync in progress and episodes present`() = runTest {
         upNextRepository.setNextEpisodesForWatchlist(
-            listOf(createTestNextEpisode(showTraktId = 1, showName = "Show 1")),
+            listOf(createTestNextEpisode(showId = 1, showName = "Show 1")),
         )
         syncObserver.setSyncing(true)
 
@@ -504,16 +504,16 @@ internal class UpNextPresenterTest {
     }
 
     private fun createTestNextEpisode(
-        showTraktId: Long,
+        showId: Long,
         showName: String,
         lastWatchedAt: Long? = null,
         firstAired: Long? = null,
     ): NextEpisodeWithShow = NextEpisodeWithShow(
-        showTraktId = showTraktId,
-        showTmdbId = showTraktId,
-        episodeId = showTraktId * 100,
+        showId = showId,
+        showTmdbId = showId,
+        episodeId = showId * 100,
         episodeName = "Episode 1",
-        seasonId = showTraktId * 10,
+        seasonId = showId * 10,
         seasonNumber = 1L,
         episodeNumber = 1L,
         runtime = 45L,

--- a/features/upnext/ui/src/main/kotlin/com/thomaskioko/tvmaniac/ui/upnext/UpNextListItem.kt
+++ b/features/upnext/ui/src/main/kotlin/com/thomaskioko/tvmaniac/ui/upnext/UpNextListItem.kt
@@ -59,7 +59,7 @@ internal fun UpNextListItem(
             .fillMaxWidth()
             .height(140.dp)
             .padding(horizontal = 8.dp)
-            .clickable(onClick = { onItemClicked(item.showTraktId) }),
+            .clickable(onClick = { onItemClicked(item.showId) }),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface,
         ),
@@ -67,16 +67,16 @@ internal fun UpNextListItem(
     ) {
         Row(
             modifier = Modifier
-                .testTag(UpNextTestTags.episodeRow(item.showTraktId))
+                .testTag(UpNextTestTags.episodeRow(item.showId))
                 .combinedClickable(
-                    onClick = { onItemClicked(item.showTraktId) },
+                    onClick = { onItemClicked(item.showId) },
                     onLongClick = onLongPress,
                 ),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             PosterCard(
                 imageUrl = item.imageUrl,
-                onClick = { onItemClicked(item.showTraktId) },
+                onClick = { onItemClicked(item.showId) },
                 title = item.showName,
                 aspectRatio = 100f / 140f,
             )
@@ -94,7 +94,7 @@ internal fun UpNextListItem(
             ) {
                 TextTitlePill(
                     showName = item.showName,
-                    onClick = { onItemClicked(item.showTraktId) },
+                    onClick = { onItemClicked(item.showId) },
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -161,7 +161,7 @@ internal fun UpNextListItem(
                 modifier = Modifier
                     .padding(12.dp)
                     .size(28.dp)
-                    .testTag(UpNextTestTags.watchedButton(item.showTraktId)),
+                    .testTag(UpNextTestTags.watchedButton(item.showId)),
                 shape = CircleShape,
                 color = grey,
             ) {

--- a/features/upnext/ui/src/main/kotlin/com/thomaskioko/tvmaniac/ui/upnext/UpNextScreen.kt
+++ b/features/upnext/ui/src/main/kotlin/com/thomaskioko/tvmaniac/ui/upnext/UpNextScreen.kt
@@ -91,7 +91,7 @@ internal fun UpNextScreenContent(
 ) {
     val listState = rememberLazyListState()
 
-    LaunchedEffect(state.episodes.firstOrNull()?.showTraktId, state.sortOption) {
+    LaunchedEffect(state.episodes.firstOrNull()?.showId, state.sortOption) {
         listState.animateScrollToItem(0)
     }
 
@@ -173,7 +173,7 @@ private fun UpNextLoadedContent(
     ) {
         items(
             items = state.episodes,
-            key = { it.showTraktId },
+            key = { it.showId },
             contentType = { "UpNextItem" },
         ) { episode ->
             UpNextListItem(
@@ -183,7 +183,7 @@ private fun UpNextLoadedContent(
                 onMarkWatched = {
                     onAction(
                         MarkWatched(
-                            showTraktId = episode.showTraktId,
+                            showId = episode.showId,
                             episodeId = episode.episodeId!!,
                             seasonNumber = episode.seasonNumber!!,
                             episodeNumber = episode.episodeNumber!!,

--- a/features/upnext/ui/src/main/kotlin/com/thomaskioko/tvmaniac/ui/upnext/preview/UpNextPreviewParameterProvider.kt
+++ b/features/upnext/ui/src/main/kotlin/com/thomaskioko/tvmaniac/ui/upnext/preview/UpNextPreviewParameterProvider.kt
@@ -38,7 +38,7 @@ internal class UpNextStatePreviewParameterProvider : PreviewParameterProvider<Up
 internal class UpNextEpisodePreviewParameterProvider : PreviewParameterProvider<UpNextEpisodeUiModel> {
     override val values: Sequence<UpNextEpisodeUiModel> = sequenceOf(
         UpNextEpisodeUiModel(
-            showTraktId = 1,
+            showId = 1,
             showTmdbId = 1396,
             showName = "Breaking Bad",
             imageUrl = null,
@@ -61,7 +61,7 @@ internal class UpNextEpisodePreviewParameterProvider : PreviewParameterProvider<
             formattedRuntime = "47m",
         ),
         UpNextEpisodeUiModel(
-            showTraktId = 2,
+            showId = 2,
             showTmdbId = 1399,
             showName = "Game of Thrones: A Very Long Title That Wraps",
             imageUrl = null,
@@ -84,7 +84,7 @@ internal class UpNextEpisodePreviewParameterProvider : PreviewParameterProvider<
             formattedRuntime = "52m",
         ),
         UpNextEpisodeUiModel(
-            showTraktId = 3,
+            showId = 3,
             showTmdbId = 66732,
             showName = "Stranger Things",
             imageUrl = null,
@@ -111,7 +111,7 @@ internal class UpNextEpisodePreviewParameterProvider : PreviewParameterProvider<
 
 private fun previewEpisodes() = listOf(
     UpNextEpisodeUiModel(
-        showTraktId = 1,
+        showId = 1,
         showTmdbId = 1396,
         showName = "Breaking Bad",
         showStatus = "Ended",
@@ -134,7 +134,7 @@ private fun previewEpisodes() = listOf(
         imageUrl = null,
     ),
     UpNextEpisodeUiModel(
-        showTraktId = 2,
+        showId = 2,
         showTmdbId = 1399,
         showName = "Game of Thrones",
         showStatus = "Ended",
@@ -157,7 +157,7 @@ private fun previewEpisodes() = listOf(
         imageUrl = null,
     ),
     UpNextEpisodeUiModel(
-        showTraktId = 3,
+        showId = 3,
         showTmdbId = 66732,
         showName = "Stranger Things",
         showStatus = "Returning Series",
@@ -180,7 +180,7 @@ private fun previewEpisodes() = listOf(
         imageUrl = null,
     ),
     UpNextEpisodeUiModel(
-        showTraktId = 4,
+        showId = 4,
         showTmdbId = 94997,
         showName = "House of the Dragon",
         imageUrl = null,

--- a/features/upnext/ui/src/test/kotlin/com/thomaskioko/tvmaniac/ui/upnext/roborrazi/UpNextScreenshotTest.kt
+++ b/features/upnext/ui/src/test/kotlin/com/thomaskioko/tvmaniac/ui/upnext/roborrazi/UpNextScreenshotTest.kt
@@ -108,7 +108,7 @@ class UpNextScreenshotTest {
 
 private fun sampleEpisodes() = listOf(
     UpNextEpisodeUiModel(
-        showTraktId = 1,
+        showId = 1,
         showTmdbId = 1396,
         showName = "Breaking Bad",
         imageUrl = null,
@@ -131,7 +131,7 @@ private fun sampleEpisodes() = listOf(
         formattedRuntime = "47m",
     ),
     UpNextEpisodeUiModel(
-        showTraktId = 2,
+        showId = 2,
         showTmdbId = 1399,
         showName = "Game of Thrones",
         imageUrl = null,
@@ -154,7 +154,7 @@ private fun sampleEpisodes() = listOf(
         formattedRuntime = "52m",
     ),
     UpNextEpisodeUiModel(
-        showTraktId = 3,
+        showId = 3,
         showTmdbId = 66732,
         showName = "Stranger Things",
         imageUrl = null,

--- a/ios/Packages/Calendar/Sources/Calendar/CalendarScreen.swift
+++ b/ios/Packages/Calendar/Sources/Calendar/CalendarScreen.swift
@@ -180,7 +180,7 @@ public struct CalendarPageContent: View {
 
     private func calendarEpisodeItem(episode: SwiftCalendarEpisodeItem) -> some View {
         Button {
-            onEpisodeCardClicked(episode.episodeTraktId)
+            onEpisodeCardClicked(episode.episodeId)
         } label: {
             VStack(spacing: 0) {
                 HStack(spacing: theme.spacing.small) {
@@ -370,8 +370,8 @@ public struct CalendarScreen: View {
                         dateLabel: "Today, Jan 31, 2026",
                         episodes: [
                             SwiftCalendarEpisodeItem(
-                                showTraktId: 1,
-                                episodeTraktId: 100,
+                                showId: 1,
+                                episodeId: 100,
                                 showTitle: "Severance",
                                 posterUrl: nil,
                                 episodeInfo: "S02E01 · Hello, Ms. Cobel",
@@ -385,8 +385,8 @@ public struct CalendarScreen: View {
                         dateLabel: "Tomorrow, Feb 1, 2026",
                         episodes: [
                             SwiftCalendarEpisodeItem(
-                                showTraktId: 2,
-                                episodeTraktId: 200,
+                                showId: 2,
+                                episodeId: 200,
                                 showTitle: "Hell's Paradise",
                                 posterUrl: nil,
                                 episodeInfo: "S02E04 · The Battle Begins",

--- a/ios/Packages/Calendar/Sources/Calendar/Mapper+Extensions.swift
+++ b/ios/Packages/Calendar/Sources/Calendar/Mapper+Extensions.swift
@@ -14,8 +14,8 @@ public extension TvManiac.CalendarDateGroup {
 public extension TvManiac.CalendarEpisodeItem {
     func toSwift() -> SwiftCalendarEpisodeItem {
         .init(
-            showTraktId: showTraktId,
-            episodeTraktId: episodeTraktId,
+            showId: showId,
+            episodeId: episodeId,
             showTitle: showTitle,
             posterUrl: posterUrl,
             episodeInfo: episodeInfo,

--- a/ios/Packages/Calendar/Sources/Calendar/SwiftCalendarDateGroup.swift
+++ b/ios/Packages/Calendar/Sources/Calendar/SwiftCalendarDateGroup.swift
@@ -19,8 +19,8 @@ public struct SwiftCalendarDateGroup: Identifiable, Equatable {
 
 public struct SwiftCalendarEpisodeItem: Identifiable, Equatable {
     public let id: String
-    public let showTraktId: Int64
-    public let episodeTraktId: Int64
+    public let showId: Int64
+    public let episodeId: Int64
     public let showTitle: String
     public let posterUrl: String?
     public let episodeInfo: String
@@ -34,8 +34,8 @@ public struct SwiftCalendarEpisodeItem: Identifiable, Equatable {
     public let formattedAirDate: String?
 
     public init(
-        showTraktId: Int64,
-        episodeTraktId: Int64,
+        showId: Int64,
+        episodeId: Int64,
         showTitle: String,
         posterUrl: String?,
         episodeInfo: String,
@@ -48,9 +48,9 @@ public struct SwiftCalendarEpisodeItem: Identifiable, Equatable {
         runtime: Int32? = nil,
         formattedAirDate: String? = nil
     ) {
-        id = "\(showTraktId)_\(episodeTraktId)"
-        self.showTraktId = showTraktId
-        self.episodeTraktId = episodeTraktId
+        id = "\(showId)_\(episodeId)"
+        self.showId = showId
+        self.episodeId = episodeId
         self.showTitle = showTitle
         self.posterUrl = posterUrl
         self.episodeInfo = episodeInfo

--- a/ios/Packages/Calendar/Tests/CalendarTests/CalendarScreenTest.swift
+++ b/ios/Packages/Calendar/Tests/CalendarTests/CalendarScreenTest.swift
@@ -12,8 +12,8 @@ class CalendarScreenTest: SnapshotTestCase {
             dateLabel: "Today, Jan 31, 2026",
             episodes: [
                 SwiftCalendarEpisodeItem(
-                    showTraktId: 1,
-                    episodeTraktId: 100,
+                    showId: 1,
+                    episodeId: 100,
                     showTitle: "Severance",
                     posterUrl: nil,
                     episodeInfo: "S02E01 · Hello, Ms. Cobel",
@@ -27,8 +27,8 @@ class CalendarScreenTest: SnapshotTestCase {
             dateLabel: "Tomorrow, Feb 1, 2026",
             episodes: [
                 SwiftCalendarEpisodeItem(
-                    showTraktId: 2,
-                    episodeTraktId: 200,
+                    showId: 2,
+                    episodeId: 200,
                     showTitle: "Hell's Paradise",
                     posterUrl: nil,
                     episodeInfo: "S02E04 · The Battle Begins",

--- a/ios/Packages/Components/Sources/Components/GridView.swift
+++ b/ios/Packages/Components/Sources/Components/GridView.swift
@@ -36,7 +36,7 @@ public struct GridView: View {
         )
         ScrollView(.vertical, showsIndicators: false) {
             LazyVGrid(columns: resolvedColumns, spacing: spacing ?? theme.spacing.xxSmall) {
-                ForEach(items, id: \.traktId) { item in
+                ForEach(items, id: \.showId) { item in
                     PosterItemView(
                         title: item.title,
                         posterUrl: item.posterUrl,
@@ -46,7 +46,7 @@ public struct GridView: View {
                     .aspectRatio(contentMode: .fill)
                     .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
                     .clipped()
-                    .onTapGesture { onAction(item.traktId) }
+                    .onTapGesture { onAction(item.showId) }
                 }
             }.padding(.all, theme.spacing.xSmall)
         }
@@ -57,32 +57,32 @@ public struct GridView: View {
     GridView(
         items: [
             .init(
-                traktId: 1234,
+                showId: 1234,
                 title: "Arcane",
                 posterUrl: "https://image.tmdb.org/t/p/w780/fqldf2t8ztc9aiwn3k6mlX3tvRT.jpg"
             ),
             .init(
-                traktId: 123,
+                showId: 123,
                 title: "The Lord of the Rings: The Rings of Power",
                 posterUrl: "https://image.tmdb.org/t/p/w780/NNC08YmJFFlLi1prBkK8quk3dp.jpg"
             ),
             .init(
-                traktId: 12346,
+                showId: 12346,
                 title: "Kaos",
                 posterUrl: "https://image.tmdb.org/t/p/w780/9Piw6Zju39bn3enIDLZzPfjMTBR.jpg"
             ),
             .init(
-                traktId: 124,
+                showId: 124,
                 title: "Terminator",
                 posterUrl: "https://image.tmdb.org/t/p/w780/woH18JkZMYhMSWqtHkPA4F6Gd1z.jpg"
             ),
             .init(
-                traktId: 123_346,
+                showId: 123_346,
                 title: "The Perfect Couple",
                 posterUrl: "https://image.tmdb.org/t/p/w780//3buRSGVnutw8x4Lww0t70k5dG6R.jpg"
             ),
             .init(
-                traktId: 2346,
+                showId: 2346,
                 title: "One Piece",
                 posterUrl: "https://image.tmdb.org/t/p/w780/2rmK7mnchw9Xr3XdiTFSxTTLXqv.jpg"
             ),

--- a/ios/Packages/Components/Sources/Components/HorizontalShowContentView.swift
+++ b/ios/Packages/Components/Sources/Components/HorizontalShowContentView.swift
@@ -67,10 +67,10 @@ public struct HorizontalShowContentView: View {
     private var scrollContent: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: spacing ?? theme.spacing.xSmall) {
-                ForEach(items, id: \.traktId) { item in
+                ForEach(items, id: \.showId) { item in
                     cardView(for: item)
                         .contentShape(Rectangle())
-                        .onTapGesture { onClick(item.traktId) }
+                        .onTapGesture { onClick(item.showId) }
                         .accessibilityElement(children: .combine)
                         .accessibilityLabel("\(item.title), tap to view details")
                 }
@@ -112,8 +112,8 @@ public struct HorizontalShowContentView: View {
             chevronStyle: .chevronOnly,
             cardStyle: .poster,
             items: [
-                .init(traktId: 1234, title: "Arcane", posterUrl: nil, backdropUrl: nil, inLibrary: false),
-                .init(traktId: 123, title: "The Rings of Power", posterUrl: nil, backdropUrl: nil, inLibrary: false),
+                .init(showId: 1234, title: "Arcane", posterUrl: nil, backdropUrl: nil, inLibrary: false),
+                .init(showId: 123, title: "The Rings of Power", posterUrl: nil, backdropUrl: nil, inLibrary: false),
             ],
             onClick: { _ in }
         )
@@ -122,8 +122,8 @@ public struct HorizontalShowContentView: View {
             title: "Coming Soon",
             cardStyle: .backdrop,
             items: [
-                .init(traktId: 12346, title: "Kaos", posterUrl: nil, backdropUrl: nil, inLibrary: false),
-                .init(traktId: 124, title: "Terminator", posterUrl: nil, backdropUrl: nil, inLibrary: false),
+                .init(showId: 12346, title: "Kaos", posterUrl: nil, backdropUrl: nil, inLibrary: false),
+                .init(showId: 124, title: "Terminator", posterUrl: nil, backdropUrl: nil, inLibrary: false),
             ],
             onClick: { _ in }
         )
@@ -133,7 +133,7 @@ public struct HorizontalShowContentView: View {
             subtitle: "Non-stop thrill and action",
             chevronStyle: .chevronOnly,
             items: [
-                .init(traktId: 2346, title: "One Piece", posterUrl: nil, backdropUrl: nil, inLibrary: false),
+                .init(showId: 2346, title: "One Piece", posterUrl: nil, backdropUrl: nil, inLibrary: false),
             ],
             onClick: { _ in }
         )

--- a/ios/Packages/Components/Sources/Components/SnapCarousel.swift
+++ b/ios/Packages/Components/Sources/Components/SnapCarousel.swift
@@ -51,7 +51,7 @@ public struct SnapCarousel<Content: View>: View {
             let adjustmentWidth = (trailingSpace / 2) - resolvedSpacing
 
             HStack(spacing: resolvedSpacing) {
-                ForEach(list, id: \.traktId) { item in
+                ForEach(list, id: \.showId) { item in
                     content(item)
                         .frame(width: proxy.size.width - trailingSpace)
                         .padding(.leading, currentIndex == 0 ? theme.spacing.xxxLarge : 0)
@@ -92,21 +92,21 @@ public struct SnapCarousel<Content: View>: View {
             index: .constant(2),
             items: [
                 .init(
-                    traktId: 1234,
+                    showId: 1234,
                     title: "Arcane",
                     posterUrl: "https://image.tmdb.org/t/p/w780/fqldf2t8ztc9aiwn3k6mlX3tvRT.jpg",
                     backdropUrl: nil,
                     inLibrary: false
                 ),
                 .init(
-                    traktId: 123,
+                    showId: 123,
                     title: "The Lord of the Rings: The Rings of Power",
                     posterUrl: "https://image.tmdb.org/t/p/w780/NNC08YmJFFlLi1prBkK8quk3dp.jpg",
                     backdropUrl: nil,
                     inLibrary: false
                 ),
                 .init(
-                    traktId: 12346,
+                    showId: 12346,
                     title: "Kaos",
                     posterUrl: "https://image.tmdb.org/t/p/w780/9Piw6Zju39bn3enIDLZzPfjMTBR.jpg",
                     backdropUrl: nil,

--- a/ios/Packages/Components/Tests/ComponentsTests/GridViewTest.swift
+++ b/ios/Packages/Components/Tests/ComponentsTests/GridViewTest.swift
@@ -10,37 +10,37 @@ class GridViewTest: SnapshotTestCase {
         GridView(
             items: [
                 .init(
-                    traktId: 1234,
+                    showId: 1234,
                     title: "Arcane",
                     posterUrl: "",
                     inLibrary: false
                 ),
                 .init(
-                    traktId: 123,
+                    showId: 123,
                     title: "The Lord of the Rings: The Rings of Power",
                     posterUrl: "",
                     inLibrary: false
                 ),
                 .init(
-                    traktId: 12346,
+                    showId: 12346,
                     title: "Kaos",
                     posterUrl: "",
                     inLibrary: false
                 ),
                 .init(
-                    traktId: 124,
+                    showId: 124,
                     title: "Terminator",
                     posterUrl: "",
                     inLibrary: false
                 ),
                 .init(
-                    traktId: 123_346,
+                    showId: 123_346,
                     title: "The Perfect Couple",
                     posterUrl: "",
                     inLibrary: false
                 ),
                 .init(
-                    traktId: 2346,
+                    showId: 2346,
                     title: "One Piece",
                     posterUrl: "",
                     inLibrary: false

--- a/ios/Packages/Components/Tests/ComponentsTests/HorizontalShowContentViewTest.swift
+++ b/ios/Packages/Components/Tests/ComponentsTests/HorizontalShowContentViewTest.swift
@@ -7,9 +7,9 @@ import XCTest
 
 class HorizontalShowContentViewTest: SnapshotTestCase {
     private let sampleItems: [SwiftShow] = [
-        .init(traktId: 124, title: "Terminator", posterUrl: "", backdropUrl: nil, inLibrary: false),
-        .init(traktId: 123_346, title: "The Perfect Couple", posterUrl: "", backdropUrl: nil, inLibrary: false),
-        .init(traktId: 2346, title: "One Piece", posterUrl: "", backdropUrl: nil, inLibrary: false),
+        .init(showId: 124, title: "Terminator", posterUrl: "", backdropUrl: nil, inLibrary: false),
+        .init(showId: 123_346, title: "The Perfect Couple", posterUrl: "", backdropUrl: nil, inLibrary: false),
+        .init(showId: 2346, title: "One Piece", posterUrl: "", backdropUrl: nil, inLibrary: false),
     ]
 
     func test_HorizontalShowContentView_Metallic() {

--- a/ios/Packages/Discover/Sources/Discover/DiscoverScreen.swift
+++ b/ios/Packages/Discover/Sources/Discover/DiscoverScreen.swift
@@ -304,7 +304,7 @@ public struct DiscoverScreen: View {
                 processorHeight: CarouselConstants.fixedImageHeight
             )
             .onTapGesture {
-                onShowClicked(item.traktId)
+                onShowClicked(item.showId)
             }
         }
     }

--- a/ios/Packages/Discover/Sources/Discover/DiscoverTab.swift
+++ b/ios/Packages/Discover/Sources/Discover/DiscoverTab.swift
@@ -21,7 +21,7 @@ public struct DiscoverTab: View {
             currentIndex: $currentIndex,
             toast: $toast,
             selectedEpisode: .constant(nil),
-            onShowClicked: { id in presenter.dispatch(action: ShowClicked(traktId: id)) },
+            onShowClicked: { id in presenter.dispatch(action: ShowClicked(showId: id)) },
             onSearchClicked: { presenter.dispatch(action: SearchIconClicked()) },
             onRefresh: { presenter.dispatch(action: RefreshData()) },
             onTrendingClicked: { presenter.dispatch(action: TrendingClicked()) },
@@ -31,7 +31,7 @@ public struct DiscoverTab: View {
             onStartWatchingMoreClicked: { presenter.dispatch(action: StartWatchingMoreClicked()) },
             onNextEpisodeClicked: { episode in
                 presenter.dispatch(action: DiscoverEpisodeLongPressed(
-                    showTraktId: episode.showTraktId,
+                    showId: episode.showId,
                     episodeId: episode.episodeId
                 ))
             },

--- a/ios/Packages/Discover/Tests/DiscoverTests/DiscoverScreenTest.swift
+++ b/ios/Packages/Discover/Tests/DiscoverTests/DiscoverScreenTest.swift
@@ -9,7 +9,7 @@ import XCTest
 class DiscoverScreenTest: SnapshotTestCase {
     private let sampleShows: [SwiftShow] = [
         SwiftShow(
-            traktId: 1,
+            showId: 1,
             title: "Breaking Bad",
             posterUrl: nil,
             backdropUrl: nil,
@@ -17,7 +17,7 @@ class DiscoverScreenTest: SnapshotTestCase {
             overview: "A chemistry teacher diagnosed with cancer turns to manufacturing methamphetamine."
         ),
         SwiftShow(
-            traktId: 2,
+            showId: 2,
             title: "Game of Thrones",
             posterUrl: nil,
             backdropUrl: nil,
@@ -27,14 +27,14 @@ class DiscoverScreenTest: SnapshotTestCase {
     ]
 
     private let samplePosters: [SwiftShow] = [
-        SwiftShow(traktId: 1, title: "Breaking Bad", posterUrl: nil, inLibrary: false),
-        SwiftShow(traktId: 2, title: "Game of Thrones", posterUrl: nil, inLibrary: false),
-        SwiftShow(traktId: 3, title: "The Wire", posterUrl: nil, inLibrary: false),
+        SwiftShow(showId: 1, title: "Breaking Bad", posterUrl: nil, inLibrary: false),
+        SwiftShow(showId: 2, title: "Game of Thrones", posterUrl: nil, inLibrary: false),
+        SwiftShow(showId: 3, title: "The Wire", posterUrl: nil, inLibrary: false),
     ]
 
     private let sampleEpisodes: [SwiftNextEpisode] = [
         SwiftNextEpisode(
-            showTraktId: 1,
+            showId: 1,
             showName: "Breaking Bad",
             imageUrl: nil,
             episodeId: 101,
@@ -48,7 +48,7 @@ class DiscoverScreenTest: SnapshotTestCase {
             totalCount: 8
         ),
         SwiftNextEpisode(
-            showTraktId: 2,
+            showId: 2,
             showName: "Game of Thrones",
             imageUrl: nil,
             episodeId: 201,

--- a/ios/Packages/Home/Sources/Home/ProgressTab.swift
+++ b/ios/Packages/Home/Sources/Home/ProgressTab.swift
@@ -64,8 +64,8 @@ struct ProgressTab: View {
             onNextWeek: {
                 presenter.calendarPresenter.dispatch(action: NavigateToNextWeek())
             },
-            onEpisodeCardClicked: { episodeTraktId in
-                presenter.calendarPresenter.dispatch(action: EpisodeCardClicked(episodeTraktId: episodeTraktId))
+            onEpisodeCardClicked: { episodeId in
+                presenter.calendarPresenter.dispatch(action: EpisodeCardClicked(episodeId: episodeId))
             }
         )
     }

--- a/ios/Packages/Home/Sources/Home/UpNextPageContent.swift
+++ b/ios/Packages/Home/Sources/Home/UpNextPageContent.swift
@@ -47,15 +47,15 @@ struct UpNextPageContent: View {
                         ForEach(episodesSwift, id: \.episodeId) { episode in
                             UpNextListItemView(
                                 episode: episode,
-                                onItemClicked: { showTraktId, _ in
-                                    presenter.dispatch(action: UpNextShowClicked(showTraktId: showTraktId))
+                                onItemClicked: { showId, _ in
+                                    presenter.dispatch(action: UpNextShowClicked(showId: showId))
                                 },
-                                onShowTitleClicked: { showTraktId in
-                                    presenter.dispatch(action: UpNextShowClicked(showTraktId: showTraktId))
+                                onShowTitleClicked: { showId in
+                                    presenter.dispatch(action: UpNextShowClicked(showId: showId))
                                 },
                                 onMarkWatched: {
                                     presenter.dispatch(action: MarkWatched(
-                                        showTraktId: episode.showTraktId,
+                                        showId: episode.showId,
                                         episodeId: episode.episodeId,
                                         seasonNumber: episode.seasonNumber,
                                         episodeNumber: episode.episodeNumberValue
@@ -73,7 +73,7 @@ struct UpNextPageContent: View {
                     }
                 }
             }
-            .onChange(of: episodesSwift.first?.showTraktId) { _, _ in
+            .onChange(of: episodesSwift.first?.showId) { _, _ in
                 withAnimation {
                     if let firstId = episodesSwift.first?.episodeId {
                         proxy.scrollTo(firstId, anchor: .top)

--- a/ios/Packages/Library/Sources/Library/LibraryListItemView.swift
+++ b/ios/Packages/Library/Sources/Library/LibraryListItemView.swift
@@ -111,7 +111,7 @@ public struct LibraryListItemView: View {
     VStack(spacing: 16) {
         LibraryListItemView(
             item: SwiftLibraryItem(
-                traktId: 1,
+                showId: 1,
                 title: "Breaking Bad",
                 posterUrl: nil,
                 year: "2008",
@@ -130,7 +130,7 @@ public struct LibraryListItemView: View {
 
         LibraryListItemView(
             item: SwiftLibraryItem(
-                traktId: 2,
+                showId: 2,
                 title: "Game of Thrones: A Very Long Title That Should Wrap",
                 posterUrl: nil,
                 year: "2011",

--- a/ios/Packages/Library/Sources/Library/LibraryScreen.swift
+++ b/ios/Packages/Library/Sources/Library/LibraryScreen.swift
@@ -221,9 +221,9 @@ public struct LibraryScreen: View {
                     )
                     .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
                     .clipped()
-                    .matchedGeometryEffect(id: item.traktId, in: animation)
+                    .matchedGeometryEffect(id: item.showId, in: animation)
                     .onTapGesture {
-                        onShowClicked(item.traktId)
+                        onShowClicked(item.showId)
                     }
                 }
             }
@@ -240,7 +240,7 @@ public struct LibraryScreen: View {
                     LibraryListItemView(
                         item: item,
                         onItemClicked: {
-                            onShowClicked(item.traktId)
+                            onShowClicked(item.showId)
                         }
                     )
                 }
@@ -275,15 +275,15 @@ public struct LibraryScreen: View {
 
 public struct LibraryGridItem: Identifiable, Equatable {
     public var id: Int64 {
-        traktId
+        showId
     }
 
-    public let traktId: Int64
+    public let showId: Int64
     public let title: String
     public let posterImageUrl: String?
 
-    public init(traktId: Int64, title: String, posterImageUrl: String?) {
-        self.traktId = traktId
+    public init(showId: Int64, title: String, posterImageUrl: String?) {
+        self.showId = showId
         self.title = title
         self.posterImageUrl = posterImageUrl
     }

--- a/ios/Packages/Library/Sources/Library/LibraryTab.swift
+++ b/ios/Packages/Library/Sources/Library/LibraryTab.swift
@@ -24,7 +24,7 @@ public struct LibraryTab: View {
             },
             onToggleSearch: { presenter.dispatch(action: ToggleSearchActive()) },
             onSortClicked: { showSortOptions = true },
-            onShowClicked: { id in presenter.dispatch(action: LibraryShowClicked(traktId: id)) }
+            onShowClicked: { id in presenter.dispatch(action: LibraryShowClicked(showId: id)) }
         )
         .sheet(isPresented: $showSortOptions) {
             SortOptionsSheet(
@@ -63,7 +63,7 @@ private extension LibraryState {
             isSearchActive: isSearchActive,
             query: query,
             gridItems: Array(items).map {
-                LibraryGridItem(traktId: $0.traktId, title: $0.title, posterImageUrl: $0.posterImageUrl)
+                LibraryGridItem(showId: $0.showId, title: $0.title, posterImageUrl: $0.posterImageUrl)
             },
             listItems: Array(items).map { $0.toSwift() }
         )

--- a/ios/Packages/Library/Sources/Library/Mapper+Extensions.swift
+++ b/ios/Packages/Library/Sources/Library/Mapper+Extensions.swift
@@ -7,7 +7,7 @@ import TvManiacKit
 public extension TvManiac.LibraryShowItem {
     func toSwift() -> SwiftLibraryItem {
         .init(
-            traktId: traktId,
+            showId: showId,
             title: title,
             posterUrl: posterImageUrl,
             year: year,

--- a/ios/Packages/Library/Sources/Library/SwiftLibraryItem.swift
+++ b/ios/Packages/Library/Sources/Library/SwiftLibraryItem.swift
@@ -4,10 +4,10 @@ import Models
 
 public struct SwiftLibraryItem: Identifiable, Equatable {
     public var id: Int64 {
-        traktId
+        showId
     }
 
-    public let traktId: Int64
+    public let showId: Int64
     public let title: String
     public let posterUrl: String?
     public let year: String?
@@ -19,7 +19,7 @@ public struct SwiftLibraryItem: Identifiable, Equatable {
     public let watchProviders: [SwiftProviders]
 
     public init(
-        traktId: Int64,
+        showId: Int64,
         title: String,
         posterUrl: String?,
         year: String?,
@@ -30,7 +30,7 @@ public struct SwiftLibraryItem: Identifiable, Equatable {
         genres: [String]?,
         watchProviders: [SwiftProviders]
     ) {
-        self.traktId = traktId
+        self.showId = showId
         self.title = title
         self.posterUrl = posterUrl
         self.year = year

--- a/ios/Packages/Library/Tests/LibraryTests/LibraryScreenTest.swift
+++ b/ios/Packages/Library/Tests/LibraryTests/LibraryScreenTest.swift
@@ -8,10 +8,10 @@ import XCTest
 
 class LibraryScreenTest: SnapshotTestCase {
     private let sampleGridItems: [LibraryGridItem] = [
-        LibraryGridItem(traktId: 1, title: "Breaking Bad", posterImageUrl: nil),
-        LibraryGridItem(traktId: 2, title: "Game of Thrones", posterImageUrl: nil),
-        LibraryGridItem(traktId: 3, title: "The Wire", posterImageUrl: nil),
-        LibraryGridItem(traktId: 4, title: "Stranger Things", posterImageUrl: nil),
+        LibraryGridItem(showId: 1, title: "Breaking Bad", posterImageUrl: nil),
+        LibraryGridItem(showId: 2, title: "Game of Thrones", posterImageUrl: nil),
+        LibraryGridItem(showId: 3, title: "The Wire", posterImageUrl: nil),
+        LibraryGridItem(showId: 4, title: "Stranger Things", posterImageUrl: nil),
     ]
 
     func test_LibraryScreen_Loading() {
@@ -94,7 +94,7 @@ class LibraryScreenTest: SnapshotTestCase {
 
     private let sampleListItems: [SwiftLibraryItem] = [
         SwiftLibraryItem(
-            traktId: 1,
+            showId: 1,
             title: "Breaking Bad",
             posterUrl: nil,
             year: "2008",
@@ -106,7 +106,7 @@ class LibraryScreenTest: SnapshotTestCase {
             watchProviders: []
         ),
         SwiftLibraryItem(
-            traktId: 2,
+            showId: 2,
             title: "Game of Thrones",
             posterUrl: nil,
             year: "2011",
@@ -118,7 +118,7 @@ class LibraryScreenTest: SnapshotTestCase {
             watchProviders: []
         ),
         SwiftLibraryItem(
-            traktId: 3,
+            showId: 3,
             title: "The Wire",
             posterUrl: nil,
             year: "2002",
@@ -130,7 +130,7 @@ class LibraryScreenTest: SnapshotTestCase {
             watchProviders: []
         ),
         SwiftLibraryItem(
-            traktId: 4,
+            showId: 4,
             title: "Stranger Things",
             posterUrl: nil,
             year: "2016",

--- a/ios/Packages/Models/Sources/Models/ShowPosterImage.swift
+++ b/ios/Packages/Models/Sources/Models/ShowPosterImage.swift
@@ -2,21 +2,21 @@ import Foundation
 
 public struct ShowPosterImage: Identifiable, Equatable {
     public var id: Int64 {
-        traktId
+        showId
     }
 
-    public let traktId: Int64
+    public let showId: Int64
     public let title: String
     public let posterUrl: String?
     public let inLibrary: Bool
 
     public init(
-        traktId: Int64,
+        showId: Int64,
         title: String,
         posterUrl: String?,
         inLibrary: Bool = false
     ) {
-        self.traktId = traktId
+        self.showId = showId
         self.title = title
         self.posterUrl = posterUrl
         self.inLibrary = inLibrary

--- a/ios/Packages/Models/Sources/Models/SwiftContinueTrackingEpisode.swift
+++ b/ios/Packages/Models/Sources/Models/SwiftContinueTrackingEpisode.swift
@@ -7,7 +7,7 @@ public struct SwiftContinueTrackingEpisode: Identifiable {
 
     public let episodeId: Int64
     public let seasonId: Int64
-    public let showTraktId: Int64
+    public let showId: Int64
     public let episodeNumber: Int64
     public let seasonNumber: Int64
     public let episodeNumberFormatted: String
@@ -20,7 +20,7 @@ public struct SwiftContinueTrackingEpisode: Identifiable {
     public init(
         episodeId: Int64,
         seasonId: Int64,
-        showTraktId: Int64,
+        showId: Int64,
         episodeNumber: Int64,
         seasonNumber: Int64,
         episodeNumberFormatted: String,
@@ -32,7 +32,7 @@ public struct SwiftContinueTrackingEpisode: Identifiable {
     ) {
         self.episodeId = episodeId
         self.seasonId = seasonId
-        self.showTraktId = showTraktId
+        self.showId = showId
         self.episodeNumber = episodeNumber
         self.seasonNumber = seasonNumber
         self.episodeNumberFormatted = episodeNumberFormatted

--- a/ios/Packages/Models/Sources/Models/SwiftNextEpisode.swift
+++ b/ios/Packages/Models/Sources/Models/SwiftNextEpisode.swift
@@ -8,7 +8,7 @@ public enum SwiftEpisodeBadge {
 
 public struct SwiftNextEpisode: Identifiable {
     public let id: UUID = .init()
-    public let showTraktId: Int64
+    public let showId: Int64
     public let showName: String
     public let imageUrl: String?
     public let episodeId: Int64
@@ -27,7 +27,7 @@ public struct SwiftNextEpisode: Identifiable {
     public let voteCount: Int64?
 
     public init(
-        showTraktId: Int64,
+        showId: Int64,
         showName: String,
         imageUrl: String?,
         episodeId: Int64,
@@ -45,7 +45,7 @@ public struct SwiftNextEpisode: Identifiable {
         rating: Double? = nil,
         voteCount: Int64? = nil
     ) {
-        self.showTraktId = showTraktId
+        self.showId = showId
         self.showName = showName
         self.imageUrl = imageUrl
         self.episodeId = episodeId

--- a/ios/Packages/Models/Sources/Models/SwiftShow.swift
+++ b/ios/Packages/Models/Sources/Models/SwiftShow.swift
@@ -2,10 +2,10 @@ import Foundation
 
 public struct SwiftShow: Identifiable, Equatable {
     public var id: Int64 {
-        traktId
+        showId
     }
 
-    public let traktId: Int64
+    public let showId: Int64
     public let title: String
     public let posterUrl: String?
     public let backdropUrl: String?
@@ -13,14 +13,14 @@ public struct SwiftShow: Identifiable, Equatable {
     public let overview: String?
 
     public init(
-        traktId: Int64,
+        showId: Int64,
         title: String,
         posterUrl: String?,
         backdropUrl: String? = nil,
         inLibrary: Bool,
         overview: String? = nil
     ) {
-        self.traktId = traktId
+        self.showId = showId
         self.title = title
         self.posterUrl = posterUrl
         self.backdropUrl = backdropUrl

--- a/ios/Packages/Models/Sources/Models/SwiftShowGenre.swift
+++ b/ios/Packages/Models/Sources/Models/SwiftShowGenre.swift
@@ -2,13 +2,13 @@ import Foundation
 
 public struct SwiftShowGenre: Identifiable {
     public let id: UUID = .init()
-    public let traktId: Int64
+    public let showId: Int64
     public let tmdbId: Int64
     public let name: String
     public let imageUrl: String?
 
-    public init(traktId: Int64, tmdbId: Int64, name: String, imageUrl: String?) {
-        self.traktId = traktId
+    public init(showId: Int64, tmdbId: Int64, name: String, imageUrl: String?) {
+        self.showId = showId
         self.tmdbId = tmdbId
         self.name = name
         self.imageUrl = imageUrl

--- a/ios/Packages/MoreShows/Sources/MoreShows/MoreShowsScreen.swift
+++ b/ios/Packages/MoreShows/Sources/MoreShows/MoreShowsScreen.swift
@@ -76,7 +76,7 @@ public struct MoreShowsScreen: View {
                     .aspectRatio(contentMode: .fill)
                     .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
                     .clipped()
-                    .onTapGesture { onAction(item.traktId) }
+                    .onTapGesture { onAction(item.showId) }
                     .onAppear {
                         if let index = state.items.firstIndex(of: item) {
                             onItemAppear(index)
@@ -125,7 +125,7 @@ public struct MoreShowsScreen: View {
         .scrollPosition(id: $scrollPosition)
         .onChange(of: scrollPosition) { _, newPosition in
             guard let newPosition, state.hasNextPage, !state.isLoadingMore else { return }
-            if let index = state.items.firstIndex(where: { $0.traktId == newPosition }),
+            if let index = state.items.firstIndex(where: { $0.showId == newPosition }),
                index >= state.items.count - 6
             {
                 onLoadMore()
@@ -163,12 +163,12 @@ public struct MoreShowsScreen: View {
         state: MoreShowsScreen.State(
             title: "Popular",
             items: [
-                .init(traktId: 1, title: "Arcane", posterUrl: nil),
-                .init(traktId: 2, title: "Loki", posterUrl: nil),
-                .init(traktId: 3, title: "The Bear", posterUrl: nil),
-                .init(traktId: 4, title: "Severance", posterUrl: nil),
-                .init(traktId: 5, title: "Shogun", posterUrl: nil),
-                .init(traktId: 6, title: "Fallout", posterUrl: nil),
+                .init(showId: 1, title: "Arcane", posterUrl: nil),
+                .init(showId: 2, title: "Loki", posterUrl: nil),
+                .init(showId: 3, title: "The Bear", posterUrl: nil),
+                .init(showId: 4, title: "Severance", posterUrl: nil),
+                .init(showId: 5, title: "Shogun", posterUrl: nil),
+                .init(showId: 6, title: "Fallout", posterUrl: nil),
             ],
             isLoadingMore: false,
             hasNextPage: false,
@@ -191,9 +191,9 @@ public struct MoreShowsScreen: View {
         state: MoreShowsScreen.State(
             title: "Trending",
             items: [
-                .init(traktId: 1, title: "Arcane", posterUrl: nil),
-                .init(traktId: 2, title: "Loki", posterUrl: nil),
-                .init(traktId: 3, title: "The Bear", posterUrl: nil),
+                .init(showId: 1, title: "Arcane", posterUrl: nil),
+                .init(showId: 2, title: "Loki", posterUrl: nil),
+                .init(showId: 3, title: "The Bear", posterUrl: nil),
             ],
             isLoadingMore: true,
             hasNextPage: true,

--- a/ios/Packages/MoreShows/Sources/MoreShows/MoreShowsView.swift
+++ b/ios/Packages/MoreShows/Sources/MoreShows/MoreShowsView.swift
@@ -25,7 +25,7 @@ public struct MoreShowsView: View {
                 presenter.loadMore()
             },
             onAction: { id in
-                presenter.dispatch(action: MoreShowClicked(traktId: id))
+                presenter.dispatch(action: MoreShowClicked(showId: id))
             },
             onBack: {
                 presenter.dispatch(action: MoreBackClicked())

--- a/ios/Packages/MoreShows/Tests/MoreShowsTests/MoreShowsScreenTest.swift
+++ b/ios/Packages/MoreShows/Tests/MoreShowsTests/MoreShowsScreenTest.swift
@@ -8,12 +8,12 @@ import XCTest
 
 class MoreShowsScreenTest: SnapshotTestCase {
     private let sampleItems: [ShowPosterImage] = [
-        .init(traktId: 1, title: "Arcane", posterUrl: nil),
-        .init(traktId: 2, title: "Loki", posterUrl: nil),
-        .init(traktId: 3, title: "The Bear", posterUrl: nil),
-        .init(traktId: 4, title: "Severance", posterUrl: nil),
-        .init(traktId: 5, title: "Shogun", posterUrl: nil),
-        .init(traktId: 6, title: "Fallout", posterUrl: nil),
+        .init(showId: 1, title: "Arcane", posterUrl: nil),
+        .init(showId: 2, title: "Loki", posterUrl: nil),
+        .init(showId: 3, title: "The Bear", posterUrl: nil),
+        .init(showId: 4, title: "Severance", posterUrl: nil),
+        .init(showId: 5, title: "Shogun", posterUrl: nil),
+        .init(showId: 6, title: "Fallout", posterUrl: nil),
     ]
 
     func test_MoreShowsScreen() {

--- a/ios/Packages/MyShows/Sources/MyShows/MyShowsGridItem.swift
+++ b/ios/Packages/MyShows/Sources/MyShows/MyShowsGridItem.swift
@@ -5,16 +5,16 @@ import SwiftUI
 
 public struct MyShowsGridItem: Identifiable, Equatable {
     public var id: Int64 {
-        traktId
+        showId
     }
 
-    public let traktId: Int64
+    public let showId: Int64
     public let title: String
     public let posterImageUrl: String?
     public let watchProgress: Float
 
-    public init(traktId: Int64, title: String, posterImageUrl: String?, watchProgress: Float) {
-        self.traktId = traktId
+    public init(showId: Int64, title: String, posterImageUrl: String?, watchProgress: Float) {
+        self.showId = showId
         self.title = title
         self.posterImageUrl = posterImageUrl
         self.watchProgress = watchProgress

--- a/ios/Packages/MyShows/Sources/MyShows/MyShowsScreen.swift
+++ b/ios/Packages/MyShows/Sources/MyShows/MyShowsScreen.swift
@@ -209,9 +209,9 @@ public struct MyShowsScreen: View {
                 }
                 .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
                 .clipped()
-                .matchedGeometryEffect(id: item.traktId, in: animation)
+                .matchedGeometryEffect(id: item.showId, in: animation)
                 .onTapGesture {
-                    onShowClicked(item.traktId)
+                    onShowClicked(item.showId)
                 }
             }
         }

--- a/ios/Packages/MyShows/Sources/MyShows/MyShowsTab.swift
+++ b/ios/Packages/MyShows/Sources/MyShows/MyShowsTab.swift
@@ -193,20 +193,20 @@ public struct MyShowsTab: View {
                 staleEpisodes: staleEpisodesSwift
             ),
             onShowClicked: { id in
-                continueWatchingPresenter.dispatch(action: ContinueWatchingShowClicked(traktId: id))
+                continueWatchingPresenter.dispatch(action: ContinueWatchingShowClicked(showId: id))
             },
-            onEpisodeClicked: { showTraktId, episodeId in
+            onEpisodeClicked: { showId, episodeId in
                 continueWatchingPresenter.dispatch(action: UpNextEpisodeClicked(
-                    showTraktId: showTraktId,
+                    showId: showId,
                     episodeId: episodeId
                 ))
             },
-            onShowTitleClicked: { showTraktId in
-                continueWatchingPresenter.dispatch(action: ShowTitleClicked(showTraktId: showTraktId))
+            onShowTitleClicked: { showId in
+                continueWatchingPresenter.dispatch(action: ShowTitleClicked(showId: showId))
             },
             onMarkWatched: { episode in
                 continueWatchingPresenter.dispatch(action: MarkUpNextEpisodeWatched(
-                    showTraktId: episode.showTraktId,
+                    showId: episode.showId,
                     episodeId: episode.episodeId,
                     seasonNumber: episode.seasonNumber,
                     episodeNumber: episode.episodeNumberValue
@@ -230,8 +230,8 @@ public struct MyShowsTab: View {
         } else {
             GridView(
                 items: startWatchingState.items.map { $0.toSwift() },
-                onAction: { traktId in
-                    startWatchingPresenter.dispatch(action: StartWatchingShowClicked(traktId: traktId))
+                onAction: { showId in
+                    startWatchingPresenter.dispatch(action: StartWatchingShowClicked(showId: showId))
                 }
             )
             .refreshable {
@@ -258,7 +258,7 @@ private extension ContinueWatchingState {
             query: query,
             watchNextGridItems: Array(watchNextItems).map {
                 MyShowsGridItem(
-                    traktId: $0.traktId,
+                    showId: $0.showId,
                     title: $0.title,
                     posterImageUrl: $0.posterImageUrl,
                     watchProgress: $0.watchProgress
@@ -266,7 +266,7 @@ private extension ContinueWatchingState {
             },
             staleGridItems: Array(staleItems).map {
                 MyShowsGridItem(
-                    traktId: $0.traktId,
+                    showId: $0.showId,
                     title: $0.title ?? "",
                     posterImageUrl: $0.posterImageUrl,
                     watchProgress: $0.watchProgress

--- a/ios/Packages/MyShows/Tests/MyShowsTests/MyShowsScreenTest.swift
+++ b/ios/Packages/MyShows/Tests/MyShowsTests/MyShowsScreenTest.swift
@@ -8,8 +8,8 @@ import XCTest
 
 class MyShowsScreenTest: SnapshotTestCase {
     private let sampleGridItems: [MyShowsGridItem] = [
-        MyShowsGridItem(traktId: 1, title: "Breaking Bad", posterImageUrl: nil, watchProgress: 0.7),
-        MyShowsGridItem(traktId: 2, title: "Game of Thrones", posterImageUrl: nil, watchProgress: 0.3),
+        MyShowsGridItem(showId: 1, title: "Breaking Bad", posterImageUrl: nil, watchProgress: 0.7),
+        MyShowsGridItem(showId: 2, title: "Game of Thrones", posterImageUrl: nil, watchProgress: 0.3),
     ]
 
     private func makeState(
@@ -61,8 +61,8 @@ class MyShowsScreenTest: SnapshotTestCase {
 
     func test_MyShowsScreen_GridMode_WithStale() {
         let staleItems: [MyShowsGridItem] = [
-            MyShowsGridItem(traktId: 3, title: "The Wire", posterImageUrl: nil, watchProgress: 0.2),
-            MyShowsGridItem(traktId: 4, title: "Severance", posterImageUrl: nil, watchProgress: 0.5),
+            MyShowsGridItem(showId: 3, title: "The Wire", posterImageUrl: nil, watchProgress: 0.2),
+            MyShowsGridItem(showId: 4, title: "Severance", posterImageUrl: nil, watchProgress: 0.5),
         ]
         screen(state: makeState(watchNextGridItems: sampleGridItems, staleGridItems: staleItems))
             .appPreview()

--- a/ios/Packages/Profile/Sources/Profile/ProfileTab.swift
+++ b/ios/Packages/Profile/Sources/Profile/ProfileTab.swift
@@ -22,7 +22,7 @@ public struct ProfileTab: View {
             onLoginClicked: { presenter.dispatch(action: ProfileActionLoginClicked()) },
             onViewListsClicked: { presenter.dispatch(action: ProfileActionViewListsClicked()) },
             onRetryLists: { presenter.dispatch(action: ProfileActionRefreshProfile()) },
-            onShowClicked: { traktId in presenter.dispatch(action: ProfileActionShowClicked(traktId: traktId)) },
+            onShowClicked: { showId in presenter.dispatch(action: ProfileActionShowClicked(showId: showId)) },
             onRetryProgress: { presenter.dispatch(action: ProfileActionRefreshProfile()) }
         )
         .onChange(of: uiState.errorMessage) { _, errorMessage in
@@ -151,7 +151,7 @@ private extension SectionState {
         case let content as SectionStateContent<ProfileShowItem>:
             let items = content.items.compactMap { $0 as? ProfileShowItem }.map { item in
                 SwiftProfileShow(
-                    id: item.traktId,
+                    id: item.showId,
                     title: item.title,
                     posterUrl: item.posterUrl
                 )
@@ -173,7 +173,7 @@ private extension SectionState {
         case let content as SectionStateContent<ProfileRecentItem>:
             let items = content.items.compactMap { $0 as? ProfileRecentItem }.map { item in
                 SwiftProfileRecentShow(
-                    traktId: item.traktId,
+                    showId: item.showId,
                     title: item.title,
                     posterUrl: item.posterUrl,
                     episodeLabel: item.episodeLabel

--- a/ios/Packages/Profile/Sources/Profile/RecentlyWatchedSectionView.swift
+++ b/ios/Packages/Profile/Sources/Profile/RecentlyWatchedSectionView.swift
@@ -70,7 +70,7 @@ public struct RecentlyWatchedSectionView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(alignment: .top, spacing: theme.spacing.small) {
                     ForEach(shows) { show in
-                        Button(action: { onShowClick(show.traktId) }) {
+                        Button(action: { onShowClick(show.showId) }) {
                             episodeCard(show)
                         }
                         .buttonStyle(.plain)
@@ -111,8 +111,8 @@ public struct RecentlyWatchedSectionView: View {
 #Preview {
     RecentlyWatchedSectionView(
         recentlyWatched: .content([
-            SwiftProfileRecentShow(traktId: 1, title: "Breaking Bad", posterUrl: nil, episodeLabel: "S5E14"),
-            SwiftProfileRecentShow(traktId: 2, title: "Game of Thrones", posterUrl: nil, episodeLabel: "S8E3"),
+            SwiftProfileRecentShow(showId: 1, title: "Breaking Bad", posterUrl: nil, episodeLabel: "S5E14"),
+            SwiftProfileRecentShow(showId: 2, title: "Game of Thrones", posterUrl: nil, episodeLabel: "S8E3"),
         ]),
         title: "Recently Watched",
         retryLabel: "Retry",

--- a/ios/Packages/Profile/Sources/Profile/SwiftProfile.swift
+++ b/ios/Packages/Profile/Sources/Profile/SwiftProfile.swift
@@ -85,22 +85,22 @@ public struct SwiftProfileShow: Identifiable, Equatable {
 }
 
 public struct SwiftProfileRecentShow: Identifiable, Equatable {
-    public let traktId: Int64
+    public let showId: Int64
     public let title: String
     public let posterUrl: String?
     public let episodeLabel: String
 
     public var id: String {
-        "\(traktId)-\(episodeLabel)"
+        "\(showId)-\(episodeLabel)"
     }
 
     public init(
-        traktId: Int64,
+        showId: Int64,
         title: String,
         posterUrl: String?,
         episodeLabel: String
     ) {
-        self.traktId = traktId
+        self.showId = showId
         self.title = title
         self.posterUrl = posterUrl
         self.episodeLabel = episodeLabel

--- a/ios/Packages/Profile/Tests/ProfileTests/ProfileScreenTest.swift
+++ b/ios/Packages/Profile/Tests/ProfileTests/ProfileScreenTest.swift
@@ -129,9 +129,9 @@ class ProfileScreenTest: SnapshotTestCase {
     ]
 
     private let sampleRecentShows: [SwiftProfileRecentShow] = [
-        SwiftProfileRecentShow(traktId: 1, title: "Breaking Bad", posterUrl: nil, episodeLabel: "S5E14"),
-        SwiftProfileRecentShow(traktId: 2, title: "Game of Thrones", posterUrl: nil, episodeLabel: "S8E3"),
-        SwiftProfileRecentShow(traktId: 3, title: "Stranger Things", posterUrl: nil, episodeLabel: "S4E9"),
+        SwiftProfileRecentShow(showId: 1, title: "Breaking Bad", posterUrl: nil, episodeLabel: "S5E14"),
+        SwiftProfileRecentShow(showId: 2, title: "Game of Thrones", posterUrl: nil, episodeLabel: "S8E3"),
+        SwiftProfileRecentShow(showId: 3, title: "Stranger Things", posterUrl: nil, episodeLabel: "S4E9"),
     ]
 
     private func authenticatedState(userLists: SwiftSectionState<SwiftProfileList>) -> ProfileScreen.State {

--- a/ios/Packages/Search/Sources/Search/Mapper+Extensions.swift
+++ b/ios/Packages/Search/Sources/Search/Mapper+Extensions.swift
@@ -6,7 +6,7 @@ public extension TvManiac.ShowItem {
     func toSwift() -> SwiftSearchShow {
         .init(
             tmdbId: tmdbId,
-            traktId: traktId,
+            showId: showId,
             title: title,
             overview: overview,
             status: status,

--- a/ios/Packages/Search/Sources/Search/SearchResultListView.swift
+++ b/ios/Packages/Search/Sources/Search/SearchResultListView.swift
@@ -32,7 +32,7 @@ public struct SearchResultListView: View {
                         )
                         .padding(.horizontal, theme.spacing.xSmall)
                         .onTapGesture {
-                            onClick(item.traktId)
+                            onClick(item.showId)
                         }
                     }
                 }
@@ -47,7 +47,7 @@ public struct SearchResultListView: View {
             items: [
                 .init(
                     tmdbId: 44234,
-                    traktId: 44234,
+                    showId: 44234,
                     title: "The Penguin",
                     overview: "Follow Oswald Oz Cobb’s quest for control as he seeks to fill the power vacuum left by the death of Carmine Falcone, transforming from a disfigured nobody to a noted mobster in Gotham City.",
                     status: "Ended",
@@ -57,7 +57,7 @@ public struct SearchResultListView: View {
                 ),
                 .init(
                     tmdbId: 1234,
-                    traktId: 44234,
+                    showId: 44234,
                     title: "The Lord of the Rings: The Rings of Power",
                     overview: "In 1997, a haunted scientist brushes his family aside for an all-consuming project. In 2022, a renegade fighter battles a powerful robot for vital data.",
                     status: "Ended",
@@ -67,7 +67,7 @@ public struct SearchResultListView: View {
                 ),
                 .init(
                     tmdbId: 124,
-                    traktId: 44234,
+                    showId: 44234,
                     title: "Kaos",
                     overview: "In 1997, a haunted scientist brushes his family aside for an all-consuming project. In 2022, a renegade fighter battles a powerful robot for vital data.",
                     status: "Ended",
@@ -77,7 +77,7 @@ public struct SearchResultListView: View {
                 ),
                 .init(
                     tmdbId: 234,
-                    traktId: 44234,
+                    showId: 44234,
                     title: "Terminator",
                     overview: "In 1997, a haunted scientist brushes his family aside for an all-consuming project. In 2022, a renegade fighter battles a powerful robot for vital data.",
                     status: "Ended",

--- a/ios/Packages/Search/Sources/Search/SearchScreenPreviews.swift
+++ b/ios/Packages/Search/Sources/Search/SearchScreenPreviews.swift
@@ -32,8 +32,8 @@ import SwiftUI
                         name: "Action",
                         subtitle: "High-octane thrills",
                         shows: [
-                            .init(traktId: 1, title: "Arcane", posterUrl: nil, backdropUrl: nil, inLibrary: false),
-                            .init(traktId: 2, title: "The Penguin", posterUrl: nil, backdropUrl: nil, inLibrary: false),
+                            .init(showId: 1, title: "Arcane", posterUrl: nil, backdropUrl: nil, inLibrary: false),
+                            .init(showId: 2, title: "The Penguin", posterUrl: nil, backdropUrl: nil, inLibrary: false),
                         ]
                     ),
                     SwiftGenreRow(
@@ -41,8 +41,8 @@ import SwiftUI
                         name: "Drama",
                         subtitle: "Compelling stories",
                         shows: [
-                            .init(traktId: 3, title: "Kaos", posterUrl: nil, backdropUrl: nil, inLibrary: false),
-                            .init(traktId: 4, title: "One Piece", posterUrl: nil, backdropUrl: nil, inLibrary: false),
+                            .init(showId: 3, title: "Kaos", posterUrl: nil, backdropUrl: nil, inLibrary: false),
+                            .init(showId: 4, title: "One Piece", posterUrl: nil, backdropUrl: nil, inLibrary: false),
                         ]
                     ),
                 ],
@@ -70,14 +70,14 @@ import SwiftUI
             screenState: .searchResults(
                 results: [
                     .init(
-                        tmdbId: 44234, traktId: 44234, title: "The Penguin",
+                        tmdbId: 44234, showId: 44234, title: "The Penguin",
                         overview: "Follow Oswald Oz Cobb's quest for control.",
                         status: "Ended",
                         imageUrl: "https://image.tmdb.org/t/p/w780/VSRmtRlYgd0pBISf7d34TAwWgB.jpg",
                         year: "2024", voteAverage: 8.5
                     ),
                     .init(
-                        tmdbId: 1234, traktId: 1234, title: "Kaos",
+                        tmdbId: 1234, showId: 1234, title: "Kaos",
                         overview: "A renegade fighter battles a powerful robot.",
                         status: "Ended",
                         imageUrl: "https://image.tmdb.org/t/p/w780/9Piw6Zju39bn3enIDLZzPfjMTBR.jpg",

--- a/ios/Packages/Search/Sources/Search/SearchTab.swift
+++ b/ios/Packages/Search/Sources/Search/SearchTab.swift
@@ -27,7 +27,7 @@ public struct SearchTab: View {
         SearchScreen(
             state: uiState.toState(categoryLabels: categoryLabels),
             query: searchQueryBinding,
-            onShowClicked: { id in presenter.dispatch(action: SearchShowClicked(id: id)) },
+            onShowClicked: { id in presenter.dispatch(action: SearchShowClicked(showId: id)) },
             onRetry: { presenter.dispatch(action: ReloadShowContent()) },
             onBack: { presenter.dispatch(action: BackClicked__()) },
             onCategoryChanged: { label in

--- a/ios/Packages/Search/Sources/Search/SwiftSearchShow.swift
+++ b/ios/Packages/Search/Sources/Search/SwiftSearchShow.swift
@@ -5,7 +5,7 @@ import Models
 public struct SwiftSearchShow: Identifiable {
     public let id: UUID = .init()
     public let tmdbId: Int64
-    public let traktId: Int64
+    public let showId: Int64
     public let title: String
     public let overview: String?
     public let status: String?
@@ -15,7 +15,7 @@ public struct SwiftSearchShow: Identifiable {
 
     public init(
         tmdbId: Int64,
-        traktId: Int64,
+        showId: Int64,
         title: String,
         overview: String?,
         status: String?,
@@ -24,7 +24,7 @@ public struct SwiftSearchShow: Identifiable {
         voteAverage: Double?
     ) {
         self.tmdbId = tmdbId
-        self.traktId = traktId
+        self.showId = showId
         self.title = title
         self.overview = overview
         self.status = status

--- a/ios/Packages/Search/Tests/SearchTests/SearchScreenTest.swift
+++ b/ios/Packages/Search/Tests/SearchTests/SearchScreenTest.swift
@@ -13,9 +13,9 @@ class SearchScreenTest: SnapshotTestCase {
             name: "Action",
             subtitle: "Non-stop thrills and action",
             shows: [
-                .init(traktId: 1, title: "Arcane", posterUrl: nil, backdropUrl: nil, inLibrary: false),
-                .init(traktId: 2, title: "The Penguin", posterUrl: nil, backdropUrl: nil, inLibrary: false),
-                .init(traktId: 3, title: "Reacher", posterUrl: nil, backdropUrl: nil, inLibrary: false),
+                .init(showId: 1, title: "Arcane", posterUrl: nil, backdropUrl: nil, inLibrary: false),
+                .init(showId: 2, title: "The Penguin", posterUrl: nil, backdropUrl: nil, inLibrary: false),
+                .init(showId: 3, title: "Reacher", posterUrl: nil, backdropUrl: nil, inLibrary: false),
             ]
         ),
         SwiftGenreRow(
@@ -23,22 +23,22 @@ class SearchScreenTest: SnapshotTestCase {
             name: "Drama",
             subtitle: "Compelling stories",
             shows: [
-                .init(traktId: 4, title: "Kaos", posterUrl: nil, backdropUrl: nil, inLibrary: false),
-                .init(traktId: 5, title: "One Piece", posterUrl: nil, backdropUrl: nil, inLibrary: false),
+                .init(showId: 4, title: "Kaos", posterUrl: nil, backdropUrl: nil, inLibrary: false),
+                .init(showId: 5, title: "One Piece", posterUrl: nil, backdropUrl: nil, inLibrary: false),
             ]
         ),
     ]
 
     private let sampleResults: [SwiftSearchShow] = [
         .init(
-            tmdbId: 44234, traktId: 44234, title: "The Penguin",
+            tmdbId: 44234, showId: 44234, title: "The Penguin",
             overview: "Follow Oswald Oz Cobb's quest for control as he seeks to fill the power vacuum.",
             status: "Ended",
             imageUrl: nil,
             year: "2024", voteAverage: 8.5
         ),
         .init(
-            tmdbId: 1234, traktId: 1234, title: "Kaos",
+            tmdbId: 1234, showId: 1234, title: "Kaos",
             overview: "A renegade fighter battles a powerful robot for vital data.",
             status: "Ended",
             imageUrl: nil,

--- a/ios/Packages/SeasonDetails/Sources/SeasonDetails/ImageGalleryContentView.swift
+++ b/ios/Packages/SeasonDetails/Sources/SeasonDetails/ImageGalleryContentView.swift
@@ -52,37 +52,37 @@ public struct ImageGalleryContentView: View {
     ImageGalleryContentView(
         items: [
             .init(
-                traktId: 1234,
+                showId: 1234,
                 title: "Arcane",
                 posterUrl: "https://image.tmdb.org/t/p/w780/fqldf2t8ztc9aiwn3k6mlX3tvRT.jpg",
                 inLibrary: false
             ),
             .init(
-                traktId: 123,
+                showId: 123,
                 title: "The Lord of the Rings: The Rings of Power",
                 posterUrl: "https://image.tmdb.org/t/p/w780/NNC08YmJFFlLi1prBkK8quk3dp.jpg",
                 inLibrary: false
             ),
             .init(
-                traktId: 12346,
+                showId: 12346,
                 title: "Kaos",
                 posterUrl: "https://image.tmdb.org/t/p/w780/9Piw6Zju39bn3enIDLZzPfjMTBR.jpg",
                 inLibrary: false
             ),
             .init(
-                traktId: 124,
+                showId: 124,
                 title: "Terminator",
                 posterUrl: "https://image.tmdb.org/t/p/w780/woH18JkZMYhMSWqtHkPA4F6Gd1z.jpg",
                 inLibrary: false
             ),
             .init(
-                traktId: 123_346,
+                showId: 123_346,
                 title: "The Perfect Couple",
                 posterUrl: "https://image.tmdb.org/t/p/w780//3buRSGVnutw8x4Lww0t70k5dG6R.jpg",
                 inLibrary: false
             ),
             .init(
-                traktId: 2346,
+                showId: 2346,
                 title: "One Piece",
                 posterUrl: "https://image.tmdb.org/t/p/w780/2rmK7mnchw9Xr3XdiTFSxTTLXqv.jpg",
                 inLibrary: false

--- a/ios/Packages/ShowDetails/Sources/ShowDetails/ShowDetailsView.swift
+++ b/ios/Packages/ShowDetails/Sources/ShowDetails/ShowDetailsView.swift
@@ -31,7 +31,7 @@ public struct ShowDetailsView: View {
             },
             onSeasonClicked: { index, season in
                 let params = ShowSeasonDetailsParam(
-                    showTraktId: season.tvShowId,
+                    showId: season.tvShowId,
                     seasonId: season.seasonId,
                     seasonNumber: season.seasonNumber,
                     selectedSeasonIndex: Int32(index)
@@ -39,17 +39,17 @@ public struct ShowDetailsView: View {
                 presenter.dispatch(action: SeasonClicked(params: params))
             },
             onShowClicked: { id in
-                presenter.dispatch(action: DetailShowClicked(id: id))
+                presenter.dispatch(action: DetailShowClicked(showId: id))
             },
             onMarkEpisodeWatched: { episode in
                 if episode.isWatched {
                     presenter.dispatch(action: MarkEpisodeUnwatched(
-                        showTraktId: episode.showTraktId,
+                        showId: episode.showId,
                         episodeId: episode.episodeId
                     ))
                 } else {
                     presenter.dispatch(action: MarkEpisodeWatched(
-                        showTraktId: episode.showTraktId,
+                        showId: episode.showId,
                         episodeId: episode.episodeId,
                         seasonNumber: episode.seasonNumber,
                         episodeNumber: episode.episodeNumber

--- a/ios/Packages/ShowDetails/Sources/ShowDetails/ShowInfoView.swift
+++ b/ios/Packages/ShowDetails/Sources/ShowDetails/ShowInfoView.swift
@@ -287,21 +287,21 @@ public struct ShowInfoView: View {
             ],
             similarShows: [
                 .init(
-                    traktId: 1234,
+                    showId: 1234,
                     title: "Arcane",
                     posterUrl: "https://image.tmdb.org/t/p/w780/fqldf2t8ztc9aiwn3k6mlX3tvRT.jpg",
                     backdropUrl: nil,
                     inLibrary: false
                 ),
                 .init(
-                    traktId: 123,
+                    showId: 123,
                     title: "The Lord of the Rings: The Rings of Power",
                     posterUrl: "https://image.tmdb.org/t/p/w780/NNC08YmJFFlLi1prBkK8quk3dp.jpg",
                     backdropUrl: nil,
                     inLibrary: false
                 ),
                 .init(
-                    traktId: 12346,
+                    showId: 12346,
                     title: "Kaos",
                     posterUrl: "https://image.tmdb.org/t/p/w780/9Piw6Zju39bn3enIDLZzPfjMTBR.jpg",
                     backdropUrl: nil,

--- a/ios/Packages/ShowDetails/Tests/ShowDetailsTests/ShowInfoViewTest.swift
+++ b/ios/Packages/ShowDetails/Tests/ShowDetailsTests/ShowInfoViewTest.swift
@@ -91,15 +91,15 @@ class ShowInfoViewTest: SnapshotTestCase {
 
     private var showList: [SwiftShow] {
         [
-            .init(traktId: 1234, title: "Arcane", posterUrl: "", backdropUrl: nil, inLibrary: false),
+            .init(showId: 1234, title: "Arcane", posterUrl: "", backdropUrl: nil, inLibrary: false),
             .init(
-                traktId: 123,
+                showId: 123,
                 title: "The Lord of the Rings: The Rings of Power",
                 posterUrl: "",
                 backdropUrl: nil,
                 inLibrary: false
             ),
-            .init(traktId: 12346, title: "Kaos", posterUrl: "", backdropUrl: nil, inLibrary: false),
+            .init(showId: 12346, title: "Kaos", posterUrl: "", backdropUrl: nil, inLibrary: false),
         ]
     }
 }

--- a/ios/Packages/TvManiacKit/Sources/TvManiacKit/Extensions/Mapper+Extensions.swift
+++ b/ios/Packages/TvManiacKit/Sources/TvManiacKit/Extensions/Mapper+Extensions.swift
@@ -25,7 +25,7 @@ public extension TvManiac.ImageQuality {
 public extension TvManiac.ContinueWatchingItem {
     func toSwift() -> ShowPosterImage {
         .init(
-            traktId: traktId,
+            showId: showId,
             title: title,
             posterUrl: posterImageUrl,
             inLibrary: true
@@ -36,7 +36,7 @@ public extension TvManiac.ContinueWatchingItem {
 public extension TvManiac.StartWatchingItem {
     func toSwift() -> ShowPosterImage {
         .init(
-            traktId: traktId,
+            showId: showId,
             title: title,
             posterUrl: posterImageUrl,
             inLibrary: true
@@ -47,7 +47,7 @@ public extension TvManiac.StartWatchingItem {
 public extension TvManiac.SeasonImagesModel {
     func toSwift() -> ShowPosterImage {
         .init(
-            traktId: id,
+            showId: id,
             title: "",
             posterUrl: imageUrl,
             inLibrary: false
@@ -58,7 +58,7 @@ public extension TvManiac.SeasonImagesModel {
 public extension TvManiac.TvShow {
     func toSwift() -> ShowPosterImage {
         .init(
-            traktId: traktId,
+            showId: showId,
             title: title,
             posterUrl: posterImageUrl,
             inLibrary: inLibrary
@@ -69,7 +69,7 @@ public extension TvManiac.TvShow {
 public extension TvManiac.DiscoverShow {
     func toSwift() -> SwiftShow {
         .init(
-            traktId: traktId,
+            showId: showId,
             title: title,
             posterUrl: posterImageUrl,
             backdropUrl: nil,
@@ -81,7 +81,7 @@ public extension TvManiac.DiscoverShow {
 
 public extension TvManiac.ShowGenre {
     func toSwift() -> SwiftShowGenre {
-        .init(traktId: id, tmdbId: id, name: name, imageUrl: posterUrl)
+        .init(showId: id, tmdbId: id, name: name, imageUrl: posterUrl)
     }
 }
 
@@ -93,7 +93,7 @@ public extension TvManiac.GenreRowModel {
             subtitle: subtitle,
             shows: shows.map { show in
                 SwiftShow(
-                    traktId: show.traktId,
+                    showId: show.showId,
                     title: show.title,
                     posterUrl: show.posterImageUrl,
                     inLibrary: show.inLibrary
@@ -106,7 +106,7 @@ public extension TvManiac.GenreRowModel {
 public extension TvManiac.ShowModel {
     func toSwift() -> SwiftShow {
         .init(
-            traktId: traktId,
+            showId: showId,
             title: title,
             posterUrl: posterImageUrl,
             backdropUrl: nil,
@@ -166,7 +166,7 @@ public extension String {
 public extension TvManiac.TvShow {
     func toSwift() -> SwiftShow {
         .init(
-            traktId: traktId,
+            showId: showId,
             title: title,
             posterUrl: posterImageUrl,
             inLibrary: inLibrary
@@ -195,7 +195,7 @@ public extension TvManiac.EpisodeDetailsModel {
 public extension TvManiac.SeasonImagesModel {
     func toSwift() -> SwiftShow {
         .init(
-            traktId: id,
+            showId: id,
             title: "",
             posterUrl: imageUrl,
             inLibrary: false
@@ -206,7 +206,7 @@ public extension TvManiac.SeasonImagesModel {
 public extension TvManiac.NextEpisodeUiModel {
     func toSwift() -> SwiftNextEpisode {
         .init(
-            showTraktId: showTraktId,
+            showId: showId,
             showName: showName,
             imageUrl: imageUrl,
             episodeId: episodeId,
@@ -227,7 +227,7 @@ public extension TvManiac.NextEpisodeUiModel {
 public extension TvManiac.ShowItem {
     func toSwift() -> SwiftShow {
         .init(
-            traktId: traktId,
+            showId: showId,
             title: title,
             posterUrl: posterImageUrl,
             backdropUrl: nil,
@@ -241,7 +241,7 @@ public extension TvManiac.ContinueTrackingEpisodeModel {
         .init(
             episodeId: episodeId,
             seasonId: seasonId,
-            showTraktId: showTraktId,
+            showId: showId,
             episodeNumber: episodeNumber,
             seasonNumber: seasonNumber,
             episodeNumberFormatted: episodeNumberFormatted,
@@ -257,7 +257,7 @@ public extension TvManiac.ContinueTrackingEpisodeModel {
 public extension TvManiac.UpNextEpisodeItem {
     func toSwift() -> SwiftNextEpisode {
         .init(
-            showTraktId: showTraktId,
+            showId: showId,
             showName: showName,
             imageUrl: stillImage,
             episodeId: episodeId,
@@ -284,7 +284,7 @@ public extension TvManiac.EpisodeBadge {
 public extension TvManiac.UpNextEpisodeUiModel {
     func toSwift() -> SwiftNextEpisode {
         .init(
-            showTraktId: showTraktId,
+            showId: showId,
             showName: showName,
             imageUrl: imageUrl,
             episodeId: episodeId?.int64Value ?? 0,

--- a/ios/Packages/UpNext/Sources/UpNext/ContinueTrackingCard.swift
+++ b/ios/Packages/UpNext/Sources/UpNext/ContinueTrackingCard.swift
@@ -116,7 +116,7 @@ private enum DimensionConstants {
             episode: SwiftContinueTrackingEpisode(
                 episodeId: 123,
                 seasonId: 1,
-                showTraktId: 1,
+                showId: 1,
                 episodeNumber: 3,
                 seasonNumber: 2,
                 episodeNumberFormatted: "S02 | E03",
@@ -135,7 +135,7 @@ private enum DimensionConstants {
             episode: SwiftContinueTrackingEpisode(
                 episodeId: 122,
                 seasonId: 1,
-                showTraktId: 1,
+                showId: 1,
                 episodeNumber: 2,
                 seasonNumber: 2,
                 episodeNumberFormatted: "S02 | E02",
@@ -154,7 +154,7 @@ private enum DimensionConstants {
             episode: SwiftContinueTrackingEpisode(
                 episodeId: 124,
                 seasonId: 1,
-                showTraktId: 1,
+                showId: 1,
                 episodeNumber: 5,
                 seasonNumber: 2,
                 episodeNumberFormatted: "S02 | E05",
@@ -173,7 +173,7 @@ private enum DimensionConstants {
             episode: SwiftContinueTrackingEpisode(
                 episodeId: 125,
                 seasonId: 1,
-                showTraktId: 1,
+                showId: 1,
                 episodeNumber: 6,
                 seasonNumber: 2,
                 episodeNumberFormatted: "S02 | E06",

--- a/ios/Packages/UpNext/Sources/UpNext/ContinueTrackingSection.swift
+++ b/ios/Packages/UpNext/Sources/UpNext/ContinueTrackingSection.swift
@@ -87,7 +87,7 @@ public struct ContinueTrackingSection: View {
                 SwiftContinueTrackingEpisode(
                     episodeId: 1,
                     seasonId: 1,
-                    showTraktId: 1,
+                    showId: 1,
                     episodeNumber: 1,
                     seasonNumber: 2,
                     episodeNumberFormatted: "S02 | E01 (E14)",
@@ -100,7 +100,7 @@ public struct ContinueTrackingSection: View {
                 SwiftContinueTrackingEpisode(
                     episodeId: 2,
                     seasonId: 1,
-                    showTraktId: 1,
+                    showId: 1,
                     episodeNumber: 2,
                     seasonNumber: 2,
                     episodeNumberFormatted: "S02 | E02 (E15)",
@@ -113,7 +113,7 @@ public struct ContinueTrackingSection: View {
                 SwiftContinueTrackingEpisode(
                     episodeId: 3,
                     seasonId: 1,
-                    showTraktId: 1,
+                    showId: 1,
                     episodeNumber: 3,
                     seasonNumber: 2,
                     episodeNumberFormatted: "S02 | E03 (E16)",
@@ -126,7 +126,7 @@ public struct ContinueTrackingSection: View {
                 SwiftContinueTrackingEpisode(
                     episodeId: 4,
                     seasonId: 1,
-                    showTraktId: 1,
+                    showId: 1,
                     episodeNumber: 4,
                     seasonNumber: 2,
                     episodeNumberFormatted: "S02 | E04 (E17)",

--- a/ios/Packages/UpNext/Sources/UpNext/NextEpisodeCard.swift
+++ b/ios/Packages/UpNext/Sources/UpNext/NextEpisodeCard.swift
@@ -95,7 +95,7 @@ private enum DimensionConstants {
     VStack {
         NextEpisodeCard(
             episode: SwiftNextEpisode(
-                showTraktId: 1,
+                showId: 1,
                 showName: "The Walking Dead: Daryl Dixon",
                 imageUrl: "/still.jpg",
                 episodeId: 123,

--- a/ios/Packages/UpNext/Sources/UpNext/NextEpisodesSection.swift
+++ b/ios/Packages/UpNext/Sources/UpNext/NextEpisodesSection.swift
@@ -66,7 +66,7 @@ public struct NextEpisodesSection: View {
             title: "Up Next",
             episodes: [
                 SwiftNextEpisode(
-                    showTraktId: 123,
+                    showId: 123,
                     showName: "The Walking Dead: Daryl Dixon",
                     imageUrl: "https://image.tmdb.org/t/p/w780/ydlY3iPfeOAvu8gVqrxPoMvzNCn.jpg",
                     episodeId: 456,
@@ -77,7 +77,7 @@ public struct NextEpisodesSection: View {
                     badge: .premiere
                 ),
                 SwiftNextEpisode(
-                    showTraktId: 124,
+                    showId: 124,
                     showName: "Wednesday",
                     imageUrl: "https://image.tmdb.org/t/p/w780/dC0oTEMAPnBzM0RU15qArHoqnH5.jpg",
                     episodeId: 789,

--- a/ios/Packages/UpNext/Sources/UpNext/UpNextListItemView.swift
+++ b/ios/Packages/UpNext/Sources/UpNext/UpNextListItemView.swift
@@ -55,7 +55,7 @@ public struct UpNextListItemView: View {
         .cornerRadius(UpNextListItemViewConstants.cornerRadius)
         .contentShape(Rectangle())
         .onTapGesture {
-            onItemClicked(episode.showTraktId, episode.episodeId)
+            onItemClicked(episode.showId, episode.episodeId)
         }
         .onLongPressGesture {
             onLongPress()
@@ -79,7 +79,7 @@ public struct UpNextListItemView: View {
         VStack(alignment: .leading, spacing: theme.spacing.xxSmall) {
             TextTitlePill(
                 title: episode.showName,
-                onTap: { onShowTitleClicked(episode.showTraktId) }
+                onTap: { onShowTitleClicked(episode.showId) }
             )
 
             Text(episodeInfoText)
@@ -163,7 +163,7 @@ private enum UpNextListItemViewConstants {
     VStack {
         UpNextListItemView(
             episode: SwiftNextEpisode(
-                showTraktId: 1,
+                showId: 1,
                 showName: "The Walking Dead: Daryl Dixon",
                 imageUrl: "/still.jpg",
                 episodeId: 123,

--- a/ios/Packages/UpNext/Sources/UpNext/WatchListItemView.swift
+++ b/ios/Packages/UpNext/Sources/UpNext/WatchListItemView.swift
@@ -34,7 +34,7 @@ public struct WatchListItemView: View {
 
     public var body: some View {
         Button(action: {
-            onItemClicked(episode.showTraktId, episode.episodeId)
+            onItemClicked(episode.showId, episode.episodeId)
         }) {
             HStack(alignment: .top, spacing: 0) {
                 posterView
@@ -66,7 +66,7 @@ public struct WatchListItemView: View {
         VStack(alignment: .leading, spacing: theme.spacing.xxSmall) {
             TextTitlePill(
                 title: episode.showName,
-                onTap: { onShowTitleClicked(episode.showTraktId) }
+                onTap: { onShowTitleClicked(episode.showId) }
             )
 
             HStack(spacing: theme.spacing.xxSmall) {
@@ -148,7 +148,7 @@ private enum WatchListItemViewConstants {
     VStack {
         WatchListItemView(
             episode: SwiftNextEpisode(
-                showTraktId: 1,
+                showId: 1,
                 showName: "The Walking Dead: Daryl Dixon",
                 imageUrl: "/still.jpg",
                 episodeId: 123,

--- a/ios/Packages/UpNext/Tests/UpNextTests/NextEpisodesSectionTest.swift
+++ b/ios/Packages/UpNext/Tests/UpNextTests/NextEpisodesSectionTest.swift
@@ -23,7 +23,7 @@ class NextEpisodesSectionTest: SnapshotTestCase {
             title: "Up Next",
             episodes: [
                 SwiftNextEpisode(
-                    showTraktId: 123,
+                    showId: 123,
                     showName: "The Walking Dead: Daryl Dixon",
                     imageUrl: "/still1.jpg",
                     episodeId: 456,
@@ -45,7 +45,7 @@ class NextEpisodesSectionTest: SnapshotTestCase {
             title: "Up Next",
             episodes: [
                 SwiftNextEpisode(
-                    showTraktId: 123,
+                    showId: 123,
                     showName: "The Walking Dead: Daryl Dixon",
                     imageUrl: "/still1.jpg",
                     episodeId: 456,
@@ -55,7 +55,7 @@ class NextEpisodesSectionTest: SnapshotTestCase {
                     overview: "Daryl washes ashore in France and struggles to piece together how he got there and why."
                 ),
                 SwiftNextEpisode(
-                    showTraktId: 124,
+                    showId: 124,
                     showName: "Wednesday",
                     imageUrl: "/still2.jpg",
                     episodeId: 789,
@@ -65,7 +65,7 @@ class NextEpisodesSectionTest: SnapshotTestCase {
                     overview: "Wednesday arrives at Nevermore Academy and immediately gets off on the wrong foot."
                 ),
                 SwiftNextEpisode(
-                    showTraktId: 125,
+                    showId: 125,
                     showName: "House of the Dragon",
                     imageUrl: "/still3.jpg",
                     episodeId: 790,
@@ -87,7 +87,7 @@ class NextEpisodesSectionTest: SnapshotTestCase {
             title: "Continue Watching",
             episodes: [
                 SwiftNextEpisode(
-                    showTraktId: 123,
+                    showId: 123,
                     showName: "The Walking Dead: Daryl Dixon",
                     imageUrl: "/still1.jpg",
                     episodeId: 456,
@@ -97,7 +97,7 @@ class NextEpisodesSectionTest: SnapshotTestCase {
                     overview: "Daryl washes ashore in France and struggles to piece together how he got there and why."
                 ),
                 SwiftNextEpisode(
-                    showTraktId: 124,
+                    showId: 124,
                     showName: "Wednesday",
                     imageUrl: "/still2.jpg",
                     episodeId: 789,
@@ -120,7 +120,7 @@ class NextEpisodesSectionTest: SnapshotTestCase {
             title: "Continue Watching",
             episodes: [
                 SwiftNextEpisode(
-                    showTraktId: 123,
+                    showId: 123,
                     showName: "The Walking Dead: Daryl Dixon",
                     imageUrl: nil,
                     episodeId: 456,

--- a/navigation/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/navigation/DefaultNavRouteSerializerTest.kt
+++ b/navigation/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/navigation/DefaultNavRouteSerializerTest.kt
@@ -40,7 +40,7 @@ internal class DefaultNavRouteSerializerTest {
 
     @Test
     fun `should round trip route with nested serializable param`() {
-        val route = ShowDetailsRoute(ShowDetailsParam(id = 1L, forceRefresh = true))
+        val route = ShowDetailsRoute(ShowDetailsParam(showId = 1L, forceRefresh = true))
 
         roundTrip(route) shouldBe route
     }
@@ -49,7 +49,7 @@ internal class DefaultNavRouteSerializerTest {
     fun `should round trip route with multi field nested param`() {
         val route = SeasonDetailsRoute(
             param = SeasonDetailsUiParam(
-                showTraktId = 10,
+                showId = 10,
                 seasonId = 20,
                 seasonNumber = 3,
                 forceRefresh = true,
@@ -85,11 +85,11 @@ internal class DefaultNavRouteSerializerTest {
 
     @Test
     fun `should preserve data class field values given ShowDetailsRoute round trip`() {
-        val original = ShowDetailsRoute(ShowDetailsParam(id = 123L, forceRefresh = true))
+        val original = ShowDetailsRoute(ShowDetailsParam(showId = 123L, forceRefresh = true))
 
         val restored = roundTrip(original).shouldBeInstanceOf<ShowDetailsRoute>()
 
-        restored.param.id shouldBe 123L
+        restored.param.showId shouldBe 123L
         restored.param.forceRefresh shouldBe true
     }
 
@@ -97,7 +97,7 @@ internal class DefaultNavRouteSerializerTest {
     fun `should preserve data class field values given SeasonDetailsRoute round trip`() {
         val original = SeasonDetailsRoute(
             param = SeasonDetailsUiParam(
-                showTraktId = 10,
+                showId = 10,
                 seasonId = 20,
                 seasonNumber = 3,
                 forceRefresh = true,
@@ -106,7 +106,7 @@ internal class DefaultNavRouteSerializerTest {
 
         val restored = roundTrip(original).shouldBeInstanceOf<SeasonDetailsRoute>()
 
-        restored.param.showTraktId shouldBe 10
+        restored.param.showId shouldBe 10
         restored.param.seasonId shouldBe 20
         restored.param.seasonNumber shouldBe 3
         restored.param.forceRefresh shouldBe true
@@ -121,11 +121,11 @@ internal class DefaultNavRouteSerializerTest {
 
     @Test
     fun `should preserve default values given ShowDetailsParam round trip`() {
-        val original = ShowDetailsRoute(ShowDetailsParam(id = 5L))
+        val original = ShowDetailsRoute(ShowDetailsParam(showId = 5L))
 
         val restored = roundTrip(original).shouldBeInstanceOf<ShowDetailsRoute>()
 
-        restored.param.id shouldBe 5L
+        restored.param.showId shouldBe 5L
         restored.param.forceRefresh shouldBe false
     }
 

--- a/navigation/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/navigation/MultiStackNavStateSerializerTest.kt
+++ b/navigation/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/navigation/MultiStackNavStateSerializerTest.kt
@@ -138,7 +138,7 @@ internal class MultiStackNavStateSerializerTest {
                         DiscoverTestRoot,
                         SeasonDetailsRoute(
                             SeasonDetailsUiParam(
-                                showTraktId = 1,
+                                showId = 1,
                                 seasonId = 2,
                                 seasonNumber = 3,
                                 forceRefresh = false,


### PR DESCRIPTION
## Description
This PR standardizes the naming of show and episode identifiers across the entire codebase, moving away from provider-specific naming (like `traktId`) to more generic and consistent terms (`showId`, `episodeId`).
