### PR TITLE
chore: Refactor authentication state checks

### DIFF
--- a/core/network-util/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/networkutil/api/extensions/StoreExtensions.kt
+++ b/core/network-util/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/networkutil/api/extensions/StoreExtensions.kt
@@ -57,9 +57,8 @@ public inline fun <Key : Any, reified Output : Any> apiFetcher(
  * This handles the case where the user is not logged in and the endpoint requires
  * authentication. The request is skipped as a no-op rather than surfacing an error.
  *
- * Note: Token expiry for authenticated users is handled upstream by Ktor's Auth plugin,
- * which triggers [TraktAuthRepository.refreshTokens] and emits [AuthError.TokenExpired]
- * for the presentation layer to handle.
+ * Note: Token expiry for authenticated users is handled upstream by the active provider's Ktor
+ * Auth plugin, which refreshes the token and surfaces a session-expired error to the presentation layer.
  *
  * @param onSkipped Optional callback invoked with a message when a fetch is skipped
  *   due to missing authentication. Useful for debug logging.
@@ -81,9 +80,8 @@ public suspend fun <Key : Any, Output : Any> Store<Key, Output>.get(
  * This handles the case where the user is not logged in and the endpoint requires
  * authentication. The request is skipped as a no-op rather than surfacing an error.
  *
- * Note: Token expiry for authenticated users is handled upstream by Ktor's Auth plugin,
- * which triggers [TraktAuthRepository.refreshTokens] and emits [AuthError.TokenExpired]
- * for the presentation layer to handle.
+ * Note: Token expiry for authenticated users is handled upstream by the active provider's Ktor
+ * Auth plugin, which refreshes the token and surfaces a session-expired error to the presentation layer.
  *
  * @param onSkipped Optional callback invoked with a message when a fetch is skipped
  *   due to missing authentication. Useful for debug logging.

--- a/data/episode/implementation/build.gradle.kts
+++ b/data/episode/implementation/build.gradle.kts
@@ -26,7 +26,6 @@ kotlin {
                 api(projects.data.followedshows.api)
                 api(projects.data.requestManager.api)
                 api(projects.data.syncActivity.api)
-                api(projects.data.traktauth.api)
                 api(projects.data.upnext.api)
                 api(projects.data.watchStatus.api)
 

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepository.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepository.kt
@@ -14,7 +14,6 @@ import com.thomaskioko.tvmaniac.followedshows.api.PendingAction
 import com.thomaskioko.tvmaniac.syncactivity.api.ActivitySyncRepository
 import com.thomaskioko.tvmaniac.syncactivity.api.ActivitySyncTypes
 import com.thomaskioko.tvmaniac.syncactivity.api.model.ActivityType
-import com.thomaskioko.tvmaniac.traktauth.api.TraktAuthRepository
 import com.thomaskioko.tvmaniac.watchstatus.api.ShowWatchStatusRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
@@ -35,7 +34,6 @@ public class DefaultWatchedEpisodeSyncRepository(
     private val datastoreRepository: DatastoreRepository,
     private val lastRequestStore: EpisodeWatchesLastRequestStore,
     private val syncRepository: ActivitySyncRepository,
-    private val traktAuthRepository: TraktAuthRepository,
     private val logger: Logger,
     private val watchStatusRepository: ShowWatchStatusRepository,
 ) : WatchedEpisodeSyncRepository {
@@ -46,16 +44,14 @@ public class DefaultWatchedEpisodeSyncRepository(
         sources.getActiveProvider(accountManager)
 
     override suspend fun syncPendingEpisodes() {
-        val authState = traktAuthRepository.getAuthState()
-        if (authState == null || !authState.isAuthorized) return
+        if (accountManager.getActiveProvider() == null) return
 
         processPendingEpisodesToUploads()
         processPendingEpisodesDeletes()
     }
 
     override suspend fun syncAllWatchedEpisodes(forceRefresh: Boolean) {
-        val authState = traktAuthRepository.getAuthState()
-        if (authState == null || !authState.isAuthorized) return
+        if (accountManager.getActiveProvider() == null) return
 
         syncMutex.withLock {
             val pendingUploads = dao.entriesByPendingAction(PendingAction.UPLOAD)
@@ -93,8 +89,7 @@ public class DefaultWatchedEpisodeSyncRepository(
     }
 
     override suspend fun syncShowEpisodeWatches(showId: Long, forceRefresh: Boolean) {
-        val authState = traktAuthRepository.getAuthState()
-        if (authState == null || !authState.isAuthorized) return
+        if (accountManager.getActiveProvider() == null) return
 
         val perShowExpired = lastRequestStore.isShowRequestExpired(showId)
         if (!forceRefresh && !perShowExpired) {

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepositoryTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepositoryTest.kt
@@ -1,10 +1,6 @@
 package com.thomaskioko.tvmaniac.episodes.implementation
 
-import com.thomaskioko.tvmaniac.accountmanager.api.AccountAuthState
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
-import com.thomaskioko.tvmaniac.accountmanager.api.AuthError
-import com.thomaskioko.tvmaniac.accountmanager.api.AuthState
-import com.thomaskioko.tvmaniac.accountmanager.api.TokenRefreshResult
 import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.logger.Logger
@@ -19,7 +15,6 @@ import com.thomaskioko.tvmaniac.episodes.implementation.dao.DefaultWatchedEpisod
 import com.thomaskioko.tvmaniac.followedshows.api.PendingAction
 import com.thomaskioko.tvmaniac.requestmanager.testing.FakeRequestManagerRepository
 import com.thomaskioko.tvmaniac.syncactivity.testing.FakeActivitySyncRepository
-import com.thomaskioko.tvmaniac.traktauth.api.TraktAuthRepository
 import com.thomaskioko.tvmaniac.util.testing.FakeDateTimeProvider
 import com.thomaskioko.tvmaniac.watchstatus.testing.FakeShowWatchStatusRepository
 import io.kotest.matchers.collections.shouldContainExactly
@@ -28,9 +23,6 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -54,7 +46,6 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
     private val fakeDateTimeProvider = FakeDateTimeProvider()
     private val datastoreRepository = FakeDatastoreRepository()
     private val requestManagerRepository = FakeRequestManagerRepository()
-    private val traktAuthRepository = AuthorizedFakeTraktAuthRepository()
     private val recordingDataSource = RecordingEpisodeWatchesDataSource()
     private val accountManager = FakeAccountManager().apply {
         setActiveProvider(AccountProvider.TRAKT)
@@ -78,7 +69,6 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
             datastoreRepository = datastoreRepository,
             lastRequestStore = EpisodeWatchesLastRequestStore(requestManagerRepository),
             syncRepository = syncRepository,
-            traktAuthRepository = traktAuthRepository,
             logger = NoOpLogger,
             watchStatusRepository = FakeShowWatchStatusRepository(),
         )
@@ -278,25 +268,4 @@ private class RecordingEpisodeWatchesDataSource : EpisodeWatchesDataSource {
 private object NoOpLogger : Logger {
     override fun error(message: String, throwable: Throwable) {}
     override fun error(tag: String, message: String) {}
-}
-
-private class AuthorizedFakeTraktAuthRepository : TraktAuthRepository {
-    private val _state = MutableStateFlow(AccountAuthState.LOGGED_IN)
-    private val _authState = MutableStateFlow<AuthState?>(
-        AuthState(accessToken = "test-access", refreshToken = "test-refresh", isAuthorized = true),
-    )
-    private val _authError = MutableStateFlow<AuthError?>(null)
-    private val _loginEvents = kotlinx.coroutines.flow.MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-
-    override val state: Flow<AccountAuthState> = _state.asStateFlow()
-    override val authState: Flow<AuthState?> = _authState.asStateFlow()
-    override val authError: Flow<AuthError?> = _authError.asStateFlow()
-    override val loginEvents: kotlinx.coroutines.flow.SharedFlow<Unit> = _loginEvents
-
-    override fun isLoggedIn(): Boolean = true
-    override suspend fun getAuthState(): AuthState? = _authState.value
-    override suspend fun refreshTokens(): TokenRefreshResult = TokenRefreshResult.NotLoggedIn
-    override suspend fun logout() {}
-    override suspend fun saveTokens(accessToken: String, refreshToken: String, expiresAtSeconds: Long) {}
-    override suspend fun setAuthError(error: AuthError?) {}
 }

--- a/data/favorites/implementation/build.gradle.kts
+++ b/data/favorites/implementation/build.gradle.kts
@@ -16,14 +16,13 @@ kotlin {
                 api(projects.api.trakt.api)
                 api(projects.core.base)
                 api(projects.core.util.api)
+                api(projects.data.accountManager.api)
                 api(projects.data.database.sqldelight)
                 api(projects.data.favorites.api)
                 api(projects.data.requestManager.api)
                 api(projects.data.shows.api)
-                api(projects.data.traktauth.api)
 
                 implementation(projects.core.networkUtil.api)
-                implementation(projects.data.accountManager.api)
                 implementation(libs.sqldelight.extensions)
             }
         }

--- a/data/favorites/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/favorites/implementation/DefaultFavoritesRepository.kt
+++ b/data/favorites/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/favorites/implementation/DefaultFavoritesRepository.kt
@@ -1,11 +1,11 @@
 package com.thomaskioko.tvmaniac.favorites.implementation
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.fresh
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.get
 import com.thomaskioko.tvmaniac.favorites.api.FavoriteShow
 import com.thomaskioko.tvmaniac.favorites.api.FavoritesDao
 import com.thomaskioko.tvmaniac.favorites.api.FavoritesRepository
-import com.thomaskioko.tvmaniac.traktauth.api.TraktAuthRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
@@ -16,14 +16,13 @@ import kotlinx.coroutines.flow.Flow
 public class DefaultFavoritesRepository(
     private val dao: FavoritesDao,
     private val favoritesStore: FavoritesStore,
-    private val traktAuthRepository: TraktAuthRepository,
+    private val accountManager: AccountManager,
 ) : FavoritesRepository {
 
     override fun observeFavorites(): Flow<List<FavoriteShow>> = dao.observeFavoriteShows()
 
     override suspend fun syncFavorites(forceRefresh: Boolean) {
-        val authState = traktAuthRepository.getAuthState()
-        if (authState == null || !authState.isAuthorized) return
+        if (accountManager.getActiveProvider() == null) return
 
         when {
             forceRefresh -> favoritesStore.fresh(Unit)

--- a/data/library/implementation/build.gradle.kts
+++ b/data/library/implementation/build.gradle.kts
@@ -26,7 +26,6 @@ kotlin {
                 api(projects.data.requestManager.api)
                 api(projects.data.shows.api)
                 api(projects.data.syncActivity.api)
-                api(projects.data.traktauth.api)
                 api(projects.data.watchproviders.api)
 
                 implementation(libs.sqldelight.extensions)

--- a/data/library/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/DefaultLibraryRepository.kt
+++ b/data/library/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/DefaultLibraryRepository.kt
@@ -26,7 +26,6 @@ import com.thomaskioko.tvmaniac.followedshows.api.PendingAction
 import com.thomaskioko.tvmaniac.resourcemanager.api.RequestManagerRepository
 import com.thomaskioko.tvmaniac.resourcemanager.api.RequestTypeConfig.LIBRARY_SYNC
 import com.thomaskioko.tvmaniac.syncstate.api.SyncObserver
-import com.thomaskioko.tvmaniac.traktauth.api.TraktAuthRepository
 import com.thomaskioko.tvmaniac.util.api.FormatterUtil
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
@@ -54,7 +53,6 @@ public class DefaultLibraryRepository(
     private val sources: Set<LibraryRemoteDataSource>,
     private val accountManager: AccountManager,
     private val requestManagerRepository: RequestManagerRepository,
-    private val traktAuthRepository: TraktAuthRepository,
     private val transactionRunner: DatabaseTransactionRunner,
     private val formatterUtil: FormatterUtil,
     private val syncObserver: SyncObserver,
@@ -155,8 +153,7 @@ public class DefaultLibraryRepository(
     )
 
     override suspend fun syncLibrary(forceRefresh: Boolean) {
-        val authState = traktAuthRepository.getAuthState()
-        if (authState == null || !authState.isAuthorized) return
+        if (accountManager.getActiveProvider() == null) return
 
         if (flushPendingFollowActions() == PendingActionOutcome.BACK_OFF) return
 
@@ -170,8 +167,7 @@ public class DefaultLibraryRepository(
     }
 
     override suspend fun syncPendingFollowedShows() {
-        val authState = traktAuthRepository.getAuthState()
-        if (authState == null || !authState.isAuthorized) return
+        if (accountManager.getActiveProvider() == null) return
 
         val _ = flushPendingFollowActions()
     }

--- a/data/start-watching/implementation/build.gradle.kts
+++ b/data/start-watching/implementation/build.gradle.kts
@@ -17,15 +17,14 @@ kotlin {
                 api(projects.core.base)
                 api(projects.core.logger.api)
                 api(projects.core.util.api)
+                api(projects.data.accountManager.api)
                 api(projects.data.database.sqldelight)
                 api(projects.data.followedshows.api)
                 api(projects.data.requestManager.api)
                 api(projects.data.shows.api)
                 api(projects.data.startWatching.api)
-                api(projects.data.traktauth.api)
 
                 implementation(projects.core.networkUtil.api)
-                implementation(projects.data.accountManager.api)
                 implementation(libs.sqldelight.extensions)
             }
         }

--- a/data/start-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/implementation/DefaultStartWatchingRepository.kt
+++ b/data/start-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/implementation/DefaultStartWatchingRepository.kt
@@ -1,12 +1,12 @@
 package com.thomaskioko.tvmaniac.startwatching.implementation
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
 import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.fresh
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.get
 import com.thomaskioko.tvmaniac.startwatching.api.StartWatchingDao
 import com.thomaskioko.tvmaniac.startwatching.api.StartWatchingRepository
 import com.thomaskioko.tvmaniac.startwatching.api.StartWatchingShow
-import com.thomaskioko.tvmaniac.traktauth.api.TraktAuthRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
@@ -17,15 +17,14 @@ import kotlinx.coroutines.flow.Flow
 public class DefaultStartWatchingRepository(
     private val dao: StartWatchingDao,
     private val startWatchingStore: StartWatchingWatchlistStore,
-    private val traktAuthRepository: TraktAuthRepository,
+    private val accountManager: AccountManager,
     private val logger: Logger,
 ) : StartWatchingRepository {
 
     override fun observeStartWatching(): Flow<List<StartWatchingShow>> = dao.observeStartWatchingShows()
 
     override suspend fun syncWatchlist(forceRefresh: Boolean) {
-        val authState = traktAuthRepository.getAuthState()
-        if (authState == null || !authState.isAuthorized) return
+        if (accountManager.getActiveProvider() == null) return
 
         when {
             forceRefresh -> startWatchingStore.fresh(Unit) { logger.debug(TAG, it) }

--- a/domain/continue-watching/build.gradle.kts
+++ b/domain/continue-watching/build.gradle.kts
@@ -29,7 +29,6 @@ kotlin {
                 api(projects.data.datastore.api)
                 api(projects.data.episode.api)
                 api(projects.data.requestManager.api)
-                api(projects.data.traktauth.api)
                 api(projects.data.upnext.api)
                 api(projects.domain.showdetails)
                 api(projects.domain.syncActivity)

--- a/domain/continue-watching/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/ContinueWatchingSyncWorker.kt
+++ b/domain/continue-watching/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/ContinueWatchingSyncWorker.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.domain.continuewatching
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
 import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.core.tasks.api.BackgroundWorker
 import com.thomaskioko.tvmaniac.core.tasks.api.PeriodicTaskRequest
@@ -7,7 +8,6 @@ import com.thomaskioko.tvmaniac.core.tasks.api.TaskConstraints
 import com.thomaskioko.tvmaniac.core.tasks.api.WorkerResult
 import com.thomaskioko.tvmaniac.featureflags.FeatureFlag
 import com.thomaskioko.tvmaniac.featureflags.flags.ContinueWatchingNitroFlagQualifier
-import com.thomaskioko.tvmaniac.traktauth.api.TraktAuthRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoSet
 import dev.zacsweers.metro.SingleIn
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.first
 @ContributesIntoSet(AppScope::class)
 public class ContinueWatchingSyncWorker(
     private val syncContinueWatchingInteractor: Lazy<SyncContinueWatchingInteractor>,
-    private val traktAuthRepository: Lazy<TraktAuthRepository>,
+    private val accountManager: Lazy<AccountManager>,
     @ContinueWatchingNitroFlagQualifier
     private val nitroFlag: FeatureFlag<Boolean>,
     private val logger: Logger,
@@ -29,7 +29,7 @@ public class ContinueWatchingSyncWorker(
     override suspend fun doWork(): WorkerResult {
         logger.debug(TAG, "Continue Watching sync worker starting")
 
-        if (!traktAuthRepository.value.isLoggedIn()) {
+        if (accountManager.value.getActiveProvider() == null) {
             logger.debug(TAG, "User not logged in, skipping sync")
             return WorkerResult.Success
         }

--- a/domain/episode/build.gradle.kts
+++ b/domain/episode/build.gradle.kts
@@ -16,10 +16,10 @@ kotlin {
                 api(projects.core.logger.api)
                 api(projects.core.syncstate.api)
                 api(projects.core.tasks.api)
+                api(projects.data.accountManager.api)
                 api(projects.data.database.sqldelight)
                 api(projects.data.episode.api)
                 api(projects.data.library.api)
-                api(projects.data.traktauth.api)
 
                 implementation(projects.core.view)
             }
@@ -30,9 +30,9 @@ kotlin {
                 implementation(libs.bundles.unittest)
                 implementation(projects.core.logger.testing)
                 implementation(projects.core.syncstate.testing)
+                implementation(projects.data.accountManager.testing)
                 implementation(projects.data.episode.testing)
                 implementation(projects.data.library.testing)
-                implementation(projects.data.traktauth.testing)
             }
         }
     }

--- a/domain/episode/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/episode/PendingUploadsWorker.kt
+++ b/domain/episode/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/episode/PendingUploadsWorker.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.domain.episode
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
 import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.core.tasks.api.BackgroundWorker
 import com.thomaskioko.tvmaniac.core.tasks.api.PeriodicTaskRequest
@@ -9,7 +10,6 @@ import com.thomaskioko.tvmaniac.data.library.LibraryRepository
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeSyncRepository
 import com.thomaskioko.tvmaniac.syncstate.api.SyncError
 import com.thomaskioko.tvmaniac.syncstate.api.SyncObserver
-import com.thomaskioko.tvmaniac.traktauth.api.TraktAuthRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoSet
 import dev.zacsweers.metro.SingleIn
@@ -20,7 +20,7 @@ import kotlinx.coroutines.CancellationException
 public class PendingUploadsWorker(
     private val syncRepository: Lazy<WatchedEpisodeSyncRepository>,
     private val libraryRepository: Lazy<LibraryRepository>,
-    private val traktAuthRepository: Lazy<TraktAuthRepository>,
+    private val accountManager: Lazy<AccountManager>,
     private val syncObserver: SyncObserver,
     private val logger: Logger,
 ) : BackgroundWorker {
@@ -30,7 +30,7 @@ public class PendingUploadsWorker(
     override suspend fun doWork(): WorkerResult {
         logger.debug(TAG, "Pending uploads worker starting")
 
-        if (!traktAuthRepository.value.isLoggedIn()) {
+        if (accountManager.value.getActiveProvider() == null) {
             logger.debug(TAG, "User not logged in, skipping pending uploads sync")
             return WorkerResult.Success
         }

--- a/domain/episode/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/episode/PendingUploadsWorkerTest.kt
+++ b/domain/episode/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/episode/PendingUploadsWorkerTest.kt
@@ -1,14 +1,14 @@
 package com.thomaskioko.tvmaniac.domain.episode
 
 import app.cash.turbine.test
-import com.thomaskioko.tvmaniac.accountmanager.api.AccountAuthState
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
 import com.thomaskioko.tvmaniac.core.logger.fixture.FakeLogger
 import com.thomaskioko.tvmaniac.core.tasks.api.WorkerResult
 import com.thomaskioko.tvmaniac.data.library.testing.FakeLibraryRepository
 import com.thomaskioko.tvmaniac.episodes.testing.FakeWatchedEpisodeSyncRepository
 import com.thomaskioko.tvmaniac.syncstate.api.SyncError
 import com.thomaskioko.tvmaniac.syncstate.testing.FakeSyncObserver
-import com.thomaskioko.tvmaniac.traktauth.testing.FakeTraktAuthRepository
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
@@ -18,21 +18,21 @@ internal class PendingUploadsWorkerTest {
 
     private val syncRepository = FakeWatchedEpisodeSyncRepository()
     private val libraryRepository = FakeLibraryRepository()
-    private val authRepository = FakeTraktAuthRepository()
+    private val accountManager = FakeAccountManager()
     private val syncObserver = FakeSyncObserver()
     private val logger = FakeLogger()
 
     private val worker = PendingUploadsWorker(
         syncRepository = lazy { syncRepository },
         libraryRepository = lazy { libraryRepository },
-        traktAuthRepository = lazy { authRepository },
+        accountManager = lazy { accountManager },
         syncObserver = syncObserver,
         logger = logger,
     )
 
     @Test
     fun `should return Success when user is logged in and sync completes`() = runTest {
-        authRepository.setState(AccountAuthState.LOGGED_IN)
+        accountManager.setActiveProvider(AccountProvider.TRAKT)
         syncRepository.setPendingEpisodesError(null)
 
         val result = worker.doWork()
@@ -42,7 +42,7 @@ internal class PendingUploadsWorkerTest {
 
     @Test
     fun `should return Success without syncing when user is logged out`() = runTest {
-        authRepository.setState(AccountAuthState.LOGGED_OUT)
+        accountManager.setActiveProvider(null)
         syncRepository.setPendingEpisodesError(RuntimeException("should never run"))
 
         val result = worker.doWork()
@@ -53,7 +53,7 @@ internal class PendingUploadsWorkerTest {
 
     @Test
     fun `should flush pending followed shows when user is logged in`() = runTest {
-        authRepository.setState(AccountAuthState.LOGGED_IN)
+        accountManager.setActiveProvider(AccountProvider.TRAKT)
 
         worker.doWork().shouldBeInstanceOf<WorkerResult.Success>()
 
@@ -62,7 +62,7 @@ internal class PendingUploadsWorkerTest {
 
     @Test
     fun `should return Retry when syncPendingEpisodes throws`() = runTest {
-        authRepository.setState(AccountAuthState.LOGGED_IN)
+        accountManager.setActiveProvider(AccountProvider.TRAKT)
         syncRepository.setPendingEpisodesError(RuntimeException("network down"))
 
         val result = worker.doWork()
@@ -73,7 +73,7 @@ internal class PendingUploadsWorkerTest {
 
     @Test
     fun `should retry once and succeed when error cleared between attempts`() = runTest {
-        authRepository.setState(AccountAuthState.LOGGED_IN)
+        accountManager.setActiveProvider(AccountProvider.TRAKT)
 
         syncRepository.setPendingEpisodesError(RuntimeException("flaky"))
         worker.doWork().shouldBeInstanceOf<WorkerResult.Retry>()
@@ -84,7 +84,7 @@ internal class PendingUploadsWorkerTest {
 
     @Test
     fun `should log BackgroundSyncFailed given syncPendingEpisodes throws`() = runTest {
-        authRepository.setState(AccountAuthState.LOGGED_IN)
+        accountManager.setActiveProvider(AccountProvider.TRAKT)
         val cause = RuntimeException("rate limit 429")
         syncRepository.setPendingEpisodesError(cause)
 

--- a/domain/library/build.gradle.kts
+++ b/domain/library/build.gradle.kts
@@ -29,7 +29,6 @@ kotlin {
                 api(projects.data.datastore.api)
                 api(projects.data.followedshows.api)
                 api(projects.data.library.api)
-                api(projects.data.traktauth.api)
                 api(projects.domain.showdetails)
                 api(projects.domain.syncActivity)
 

--- a/domain/library/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/library/LibrarySyncWorker.kt
+++ b/domain/library/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/library/LibrarySyncWorker.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.domain.library
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
 import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.core.tasks.api.BackgroundWorker
 import com.thomaskioko.tvmaniac.core.tasks.api.PeriodicTaskRequest
@@ -7,7 +8,6 @@ import com.thomaskioko.tvmaniac.core.tasks.api.TaskConstraints
 import com.thomaskioko.tvmaniac.core.tasks.api.WorkerResult
 import com.thomaskioko.tvmaniac.syncstate.api.SyncError
 import com.thomaskioko.tvmaniac.syncstate.api.SyncObserver
-import com.thomaskioko.tvmaniac.traktauth.api.TraktAuthRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoSet
 import dev.zacsweers.metro.SingleIn
@@ -22,7 +22,7 @@ import kotlinx.coroutines.CancellationException
 @ContributesIntoSet(AppScope::class)
 public class LibrarySyncWorker(
     private val syncLibraryInteractor: Lazy<SyncLibraryInteractor>,
-    private val traktAuthRepository: Lazy<TraktAuthRepository>,
+    private val accountManager: Lazy<AccountManager>,
     private val syncObserver: SyncObserver,
     private val logger: Logger,
 ) : BackgroundWorker {
@@ -32,7 +32,7 @@ public class LibrarySyncWorker(
     override suspend fun doWork(): WorkerResult {
         logger.debug(TAG, "Library sync worker starting")
 
-        if (!traktAuthRepository.value.isLoggedIn()) {
+        if (accountManager.value.getActiveProvider() == null) {
             logger.debug(TAG, "User not logged in, skipping sync")
             return WorkerResult.Success
         }


### PR DESCRIPTION
## Description
This PR replaces the `TraktAuthRepository` dependency with `AccountManager` for authentication state checks across data and domain layers. This change centralizes account management and makes the authentication logic provider-agnostic, supporting future provider integrations. #727 

## Changes
- Replaced `TraktAuthRepository` with `AccountManager` in various repositories and background workers to verify authentication status.
- Updated background sync workers to check for active account providers instead of specific Trakt authentication state.
- Cleaned up module dependencies by removing `TraktAuthRepository` where it was replaced by `AccountManager`.
