### PR TITLE
refactor: Add Multiple Authentication Provider Support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -270,6 +270,7 @@ dependencies {
     androidTestImplementation(projects.core.integration.infra)
     androidTestImplementation(projects.core.integration.ui)
     androidTestImplementation(projects.core.testTags)
+    androidTestImplementation(projects.data.traktauth.api)
     androidTestImplementation(projects.data.traktauth.testing)
     androidTestImplementation(projects.core.locale.testing)
     androidTestImplementation(projects.core.util.testing)

--- a/app/src/main/kotlin/com/thomaskioko/tvmaniac/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/thomaskioko/tvmaniac/app/MainActivity.kt
@@ -39,7 +39,7 @@ public class MainActivity : ComponentActivity() {
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
-        graph.traktAuthManager.registerResult()
+        graph.authManagers.forEach { it.registerResult() }
 
         enableEdgeToEdge()
 

--- a/app/src/main/kotlin/com/thomaskioko/tvmaniac/app/di/ActivityGraph.kt
+++ b/app/src/main/kotlin/com/thomaskioko/tvmaniac/app/di/ActivityGraph.kt
@@ -3,6 +3,7 @@ package com.thomaskioko.tvmaniac.app.di
 import androidx.activity.ComponentActivity
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.defaultComponentContext
+import com.thomaskioko.tvmaniac.accountmanager.api.AuthManager
 import com.thomaskioko.tvmaniac.app.TvManicApplication
 import com.thomaskioko.tvmaniac.app.ui.di.AppRootProvider
 import com.thomaskioko.tvmaniac.core.base.ActivityScope
@@ -12,7 +13,6 @@ import com.thomaskioko.tvmaniac.navigation.Navigator
 import com.thomaskioko.tvmaniac.navigation.ui.ScreenContent
 import com.thomaskioko.tvmaniac.navigation.ui.SheetContent
 import com.thomaskioko.tvmaniac.presenter.root.RootPresenter
-import com.thomaskioko.tvmaniac.traktauth.api.TraktAuthManager
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.GraphExtension
@@ -23,7 +23,7 @@ import dev.zacsweers.metro.asContribution
 @GraphExtension(ActivityScope::class)
 @SingleIn(ActivityScope::class)
 public interface ActivityGraph : AppRootProvider {
-    public val traktAuthManager: TraktAuthManager
+    public val authManagers: Set<AuthManager>
     override val rootPresenter: RootPresenter
     public val navigator: Navigator
     override val screenContents: Set<ScreenContent>

--- a/data/account-manager/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/api/AccountAuthRepository.kt
+++ b/data/account-manager/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/api/AccountAuthRepository.kt
@@ -21,5 +21,11 @@ public interface AccountAuthRepository : ProviderScoped {
 
     public suspend fun refreshTokens(): TokenRefreshResult
 
+    public suspend fun saveTokens(
+        accessToken: String,
+        refreshToken: String,
+        expiresAtSeconds: Long,
+    )
+
     public suspend fun setAuthError(error: AuthError?)
 }

--- a/data/account-manager/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/api/AuthClientConfig.kt
+++ b/data/account-manager/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/api/AuthClientConfig.kt
@@ -1,0 +1,10 @@
+package com.thomaskioko.tvmaniac.accountmanager.api
+
+public interface AuthClientConfig : ProviderScoped {
+    public val clientId: String
+    public val clientSecret: String
+    public val redirectUri: String
+    public val authorizationEndpoint: String
+    public val tokenEndpoint: String
+    public val scopes: List<String>
+}

--- a/data/account-manager/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/api/AuthManager.kt
+++ b/data/account-manager/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/api/AuthManager.kt
@@ -1,9 +1,14 @@
 package com.thomaskioko.tvmaniac.accountmanager.api
 
 /**
- * Launches the sign-in web flow for a single [AccountProvider]. Each backend contributes one
- * implementation into a multibound set; consumers launch the entry for the provider being connected.
+ * Drives the sign-in web flow for a single [AccountProvider]: launching it, registering the platform
+ * result handler, and wiring the platform completion callback. Each backend contributes one
+ * implementation into a multibound set; the composition root iterates the set to wire every provider.
  */
 public interface AuthManager : ProviderScoped {
     public fun launchWebView()
+
+    public fun registerResult()
+
+    public fun setAuthCallback(callback: () -> Unit)
 }

--- a/data/account-manager/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/implementation/di/AuthManagerMultibindings.kt
+++ b/data/account-manager/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/implementation/di/AuthManagerMultibindings.kt
@@ -1,17 +1,17 @@
 package com.thomaskioko.tvmaniac.accountmanager.implementation.di
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AuthClientConfig
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthManager
 import com.thomaskioko.tvmaniac.core.base.ActivityScope
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Multibinds
 
-/**
- * Declares the [AuthManager] multibinding each provider contributes into. Contributed at
- * [ActivityScope] because the web flow needs the host Activity. Allowed empty so test graphs that
- * never exercise sign-in resolve the set without a provider adapter.
- */
 @ContributesTo(ActivityScope::class)
 public interface AuthManagerMultibindings {
+
     @Multibinds(allowEmpty = true)
     public fun authManagers(): Set<AuthManager>
+
+    @Multibinds(allowEmpty = true)
+    public fun authClientConfigs(): Set<AuthClientConfig>
 }

--- a/data/account-manager/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/testing/FakeAccountAuthRepository.kt
+++ b/data/account-manager/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/testing/FakeAccountAuthRepository.kt
@@ -22,6 +22,9 @@ public class FakeAccountAuthRepository(
     private val _loginEvents = MutableSharedFlow<Unit>(replay = 1, extraBufferCapacity = 1)
     private var refreshOutcome: TokenRefreshResult = TokenRefreshResult.NotLoggedIn
 
+    public var lastSavedAccessToken: String? = null
+        private set
+
     public fun setState(state: AccountAuthState) {
         _state.value = state
     }
@@ -54,6 +57,14 @@ public class FakeAccountAuthRepository(
     }
 
     override suspend fun refreshTokens(): TokenRefreshResult = refreshOutcome
+
+    override suspend fun saveTokens(
+        accessToken: String,
+        refreshToken: String,
+        expiresAtSeconds: Long,
+    ) {
+        lastSavedAccessToken = accessToken
+    }
 
     override suspend fun setAuthError(error: AuthError?) {
         _authError.value = error

--- a/data/account-manager/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/testing/FakeAuthManager.kt
+++ b/data/account-manager/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/testing/FakeAuthManager.kt
@@ -16,4 +16,10 @@ public class FakeAuthManager(
     override fun launchWebView() {
         onLaunchWebView()
     }
+
+    override fun registerResult() {
+    }
+
+    override fun setAuthCallback(callback: () -> Unit) {
+    }
 }

--- a/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TraktAccountAuthManager.kt
+++ b/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TraktAccountAuthManager.kt
@@ -18,4 +18,12 @@ public class TraktAccountAuthManager(
     override fun launchWebView() {
         traktAuthManager.launchWebView()
     }
+
+    override fun registerResult() {
+        traktAuthManager.registerResult()
+    }
+
+    override fun setAuthCallback(callback: () -> Unit) {
+        traktAuthManager.setAuthCallback(callback)
+    }
 }

--- a/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TraktAccountAuthRepository.kt
+++ b/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TraktAccountAuthRepository.kt
@@ -37,6 +37,14 @@ public class TraktAccountAuthRepository(
 
     override suspend fun refreshTokens(): TokenRefreshResult = traktAuthRepository.refreshTokens()
 
+    override suspend fun saveTokens(
+        accessToken: String,
+        refreshToken: String,
+        expiresAtSeconds: Long,
+    ) {
+        traktAuthRepository.saveTokens(accessToken, refreshToken, expiresAtSeconds)
+    }
+
     override suspend fun setAuthError(error: AuthError?) {
         traktAuthRepository.setAuthError(error)
     }

--- a/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TraktAuthClientConfig.kt
+++ b/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TraktAuthClientConfig.kt
@@ -1,0 +1,23 @@
+package com.thomaskioko.tvmaniac.traktauth.implementation
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.accountmanager.api.AuthClientConfig
+import com.thomaskioko.tvmaniac.trakt.api.TraktConfig
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.SingleIn
+
+@SingleIn(AppScope::class)
+@ContributesIntoSet(AppScope::class)
+public class TraktAuthClientConfig(
+    traktConfig: TraktConfig,
+) : AuthClientConfig {
+
+    override val provider: AccountProvider = AccountProvider.TRAKT
+    override val clientId: String = traktConfig.clientId
+    override val clientSecret: String = traktConfig.clientSecret
+    override val redirectUri: String = traktConfig.redirectUri
+    override val authorizationEndpoint: String = "https://trakt.tv/oauth/authorize"
+    override val tokenEndpoint: String = "https://api.trakt.tv/oauth/token"
+    override val scopes: List<String> = emptyList()
+}

--- a/ios-framework/src/iosMain/kotlin/com.thomaskioko.tvmaniac.iosframework/IosApplicationGraph.kt
+++ b/ios-framework/src/iosMain/kotlin/com.thomaskioko.tvmaniac.iosframework/IosApplicationGraph.kt
@@ -1,5 +1,7 @@
 package com.thomaskioko.tvmaniac.iosframework
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountAuthRepository
+import com.thomaskioko.tvmaniac.accountmanager.api.AuthClientConfig
 import com.thomaskioko.tvmaniac.appconfig.AppMetadata
 import com.thomaskioko.tvmaniac.appconfig.DebugConfig
 import com.thomaskioko.tvmaniac.core.base.AppInitializers
@@ -7,9 +9,6 @@ import com.thomaskioko.tvmaniac.core.base.IsDebugBuild
 import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.core.tasks.api.BackgroundTaskScheduler
 import com.thomaskioko.tvmaniac.featureflags.RemoteConfigBridge
-import com.thomaskioko.tvmaniac.trakt.api.TraktConfig
-import com.thomaskioko.tvmaniac.traktauth.api.TraktAuthManager
-import com.thomaskioko.tvmaniac.traktauth.api.TraktAuthRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
@@ -18,9 +17,8 @@ import dev.zacsweers.metro.Provides
 public interface IosApplicationGraph {
     public val initializers: AppInitializers
     public val viewPresenterGraphFactory: IosViewPresenterGraph.Factory
-    public val traktAuthRepository: TraktAuthRepository
-    public val traktAuthManager: TraktAuthManager
-    public val traktConfig: TraktConfig
+    public val accountAuthRepositories: Set<AccountAuthRepository>
+    public val authClientConfigs: Set<AuthClientConfig>
     public val backgroundTaskScheduler: BackgroundTaskScheduler
     public val appMetadata: AppMetadata
     public val debugConfig: DebugConfig

--- a/ios-framework/src/iosMain/kotlin/com.thomaskioko.tvmaniac.iosframework/IosViewPresenterGraph.kt
+++ b/ios-framework/src/iosMain/kotlin/com.thomaskioko.tvmaniac.iosframework/IosViewPresenterGraph.kt
@@ -1,6 +1,7 @@
 package com.thomaskioko.tvmaniac.iosframework
 
 import com.arkivanov.decompose.ComponentContext
+import com.thomaskioko.tvmaniac.accountmanager.api.AuthManager
 import com.thomaskioko.tvmaniac.core.base.ActivityScope
 import com.thomaskioko.tvmaniac.navigation.Navigator
 import com.thomaskioko.tvmaniac.presenter.root.RootPresenter
@@ -15,6 +16,7 @@ import dev.zacsweers.metro.SingleIn
 public interface IosViewPresenterGraph {
     public val rootPresenter: RootPresenter
     public val navigator: Navigator
+    public val authManagers: Set<AuthManager>
 
     @ContributesTo(AppScope::class)
     @GraphExtension.Factory

--- a/ios/Packages/TraktAuthKit/Sources/TraktAuthKit/AppAuthCoordinator.swift
+++ b/ios/Packages/TraktAuthKit/Sources/TraktAuthKit/AppAuthCoordinator.swift
@@ -3,16 +3,16 @@ import Foundation
 
 @MainActor
 final class AppAuthCoordinator {
-    private let configuration: TraktAuthConfiguration
+    private let configuration: OAuthConfiguration
     private var currentAuthorizationFlow: OIDExternalUserAgentSession?
 
-    init(configuration: TraktAuthConfiguration) {
+    init(configuration: OAuthConfiguration) {
         self.configuration = configuration
     }
 
     func performAuthorizationFlow(
         presentingViewController: UIViewController
-    ) async throws -> TraktCredential {
+    ) async throws -> OAuthCredential {
         let serviceConfig = OIDServiceConfiguration(
             authorizationEndpoint: configuration.authorizationEndpoint,
             tokenEndpoint: configuration.tokenEndpoint
@@ -38,14 +38,14 @@ final class AppAuthCoordinator {
             ) { authState, error in
                 if let error {
                     if (error as NSError).code == OIDErrorCode.userCanceledAuthorizationFlow.rawValue {
-                        continuation.resume(throwing: TraktAuthError.userCancelled)
+                        continuation.resume(throwing: OAuthError.userCancelled)
                     } else {
-                        continuation.resume(throwing: TraktAuthError.authorizationFailed(error))
+                        continuation.resume(throwing: OAuthError.authorizationFailed(error))
                     }
                 } else if let authState {
                     continuation.resume(returning: authState)
                 } else {
-                    continuation.resume(throwing: TraktAuthError.invalidTokenResponse)
+                    continuation.resume(throwing: OAuthError.invalidTokenResponse)
                 }
             }
         }
@@ -53,10 +53,10 @@ final class AppAuthCoordinator {
         guard let accessToken = authState.lastTokenResponse?.accessToken,
               let refreshToken = authState.lastTokenResponse?.refreshToken
         else {
-            throw TraktAuthError.invalidTokenResponse
+            throw OAuthError.invalidTokenResponse
         }
 
-        return TraktCredential(
+        return OAuthCredential(
             accessToken: accessToken,
             refreshToken: refreshToken,
             tokenType: authState.lastTokenResponse?.tokenType ?? "Bearer",

--- a/ios/Packages/TraktAuthKit/Sources/TraktAuthKit/OAuthClient.swift
+++ b/ios/Packages/TraktAuthKit/Sources/TraktAuthKit/OAuthClient.swift
@@ -2,18 +2,18 @@ import AppAuth
 import Foundation
 import UIKit
 
-public final class TraktOAuthClient {
-    private let configuration: TraktAuthConfiguration
+public final class OAuthClient {
+    private let configuration: OAuthConfiguration
     private var currentAuthorizationFlow: OIDExternalUserAgentSession?
 
-    public init(configuration: TraktAuthConfiguration) {
+    public init(configuration: OAuthConfiguration) {
         self.configuration = configuration
     }
 
     @MainActor
     public func authorize(
         presentingViewController: UIViewController
-    ) async throws -> TraktCredential {
+    ) async throws -> OAuthCredential {
         let coordinator = AppAuthCoordinator(configuration: configuration)
         return try await coordinator.performAuthorizationFlow(
             presentingViewController: presentingViewController

--- a/ios/Packages/TraktAuthKit/Sources/TraktAuthKit/OAuthConfiguration.swift
+++ b/ios/Packages/TraktAuthKit/Sources/TraktAuthKit/OAuthConfiguration.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct TraktAuthConfiguration {
+public struct OAuthConfiguration {
     public let authorizationEndpoint: URL
     public let tokenEndpoint: URL
     public let redirectURL: URL
@@ -22,20 +22,5 @@ public struct TraktAuthConfiguration {
         self.clientId = clientId
         self.clientSecret = clientSecret
         self.scopes = scopes
-    }
-
-    public static func trakt(
-        clientId: String,
-        clientSecret: String,
-        redirectURL: URL
-    ) -> Self {
-        Self(
-            authorizationEndpoint: URL(string: "https://trakt.tv/oauth/authorize")!,
-            tokenEndpoint: URL(string: "https://api.trakt.tv/oauth/token")!,
-            redirectURL: redirectURL,
-            clientId: clientId,
-            clientSecret: clientSecret,
-            scopes: []
-        )
     }
 }

--- a/ios/Packages/TraktAuthKit/Sources/TraktAuthKit/OAuthCredential.swift
+++ b/ios/Packages/TraktAuthKit/Sources/TraktAuthKit/OAuthCredential.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct TraktCredential {
+public struct OAuthCredential {
     public let accessToken: String
     public let refreshToken: String
     public let tokenType: String

--- a/ios/Packages/TraktAuthKit/Sources/TraktAuthKit/OAuthError.swift
+++ b/ios/Packages/TraktAuthKit/Sources/TraktAuthKit/OAuthError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum TraktAuthError: Error {
+public enum OAuthError: Error {
     case authorizationFailed(Error)
     case tokenExchangeFailed(Error)
     case userCancelled
@@ -9,7 +9,7 @@ public enum TraktAuthError: Error {
     case unknown(Error)
 }
 
-extension TraktAuthError: LocalizedError {
+extension OAuthError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case let .authorizationFailed(error):

--- a/ios/Packages/TvManiacKit/Sources/TvManiacKit/AppDelegate.swift
+++ b/ios/Packages/TvManiacKit/Sources/TvManiacKit/AppDelegate.swift
@@ -13,10 +13,7 @@ public class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
         remoteConfigBridge: Self.makeRemoteConfigBridge()
     )
 
-    public lazy var traktAuthRepository = appGraph.traktAuthRepository
-    public lazy var traktConfig = appGraph.traktConfig
     public lazy var logger = appGraph.logger
-    public lazy var traktAuthManager = appGraph.traktAuthManager
 
     public private(set) var notificationDelegate: NotificationDelegate?
 
@@ -59,10 +56,6 @@ public class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
         MemoryMonitor.shared.setDiagnosticLogger(DefaultDiagnosticLogger.shared)
         MemoryMonitor.shared.setDebugEnabled(appGraph.debugConfig.isDebug)
         MemoryMonitor.shared.logMemoryState(event: "AppDelegate.init")
-    }
-
-    public func setupAuthBridge(authCallback: @escaping () -> Void) {
-        traktAuthManager.setAuthCallback(callback: authCallback)
     }
 
     private func setupNotificationDelegate() {

--- a/ios/Packages/TvManiacKit/Sources/TvManiacKit/AuthCoordinator.swift
+++ b/ios/Packages/TvManiacKit/Sources/TvManiacKit/AuthCoordinator.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Provider-neutral entry point for launching a sign-in OAuth flow. Each provider ships a coordinator
+/// configured per provider, that the composition root wires to the matching `AuthManager`.
+public protocol AuthCoordinator: AnyObject {
+    @MainActor func initiateAuthorization()
+}

--- a/ios/Packages/TvManiacKit/Sources/TvManiacKit/AuthCoordinatorFactory.swift
+++ b/ios/Packages/TvManiacKit/Sources/TvManiacKit/AuthCoordinatorFactory.swift
@@ -1,27 +1,37 @@
 import Foundation
+import TraktAuthKit
 
 public enum AuthCoordinatorFactory {
     public static func create(
-        authRepository: TraktAuthRepository,
-        traktConfig: TraktConfig,
+        authRepository: AccountAuthRepository,
+        config: AuthClientConfig,
         logger: Logger
-    ) -> TraktAuthCoordinator {
-        let redirectURL = URL(string: traktConfig.redirectUri)
-            ?? URL(string: "about:blank")!
+    ) -> OAuthCoordinator {
+        let fallback = URL(string: "about:blank")!
+        let authorizationEndpoint = URL(string: config.authorizationEndpoint) ?? fallback
+        let tokenEndpoint = URL(string: config.tokenEndpoint) ?? fallback
+        let redirectURL = URL(string: config.redirectUri) ?? fallback
 
-        if redirectURL.absoluteString == "about:blank" {
+        if authorizationEndpoint == fallback || tokenEndpoint == fallback || redirectURL == fallback {
             logger.error(
-                tag: "TraktAuthCoordinator",
-                message: "Invalid Trakt redirect URI in TraktConfig"
+                tag: "OAuthCoordinator",
+                message: "Invalid OAuth endpoint or redirect URI for provider \(config.provider.name)"
             )
         }
 
-        return TraktAuthCoordinator(
+        let configuration = OAuthConfiguration(
+            authorizationEndpoint: authorizationEndpoint,
+            tokenEndpoint: tokenEndpoint,
+            redirectURL: redirectURL,
+            clientId: config.clientId,
+            clientSecret: config.clientSecret,
+            scopes: config.scopes
+        )
+
+        return OAuthCoordinator(
             authRepository: authRepository,
             logger: logger,
-            clientId: traktConfig.clientId,
-            clientSecret: traktConfig.clientSecret,
-            redirectURL: redirectURL
+            configuration: configuration
         )
     }
 }

--- a/ios/Packages/TvManiacKit/Sources/TvManiacKit/AuthCoordinatorRegistry.swift
+++ b/ios/Packages/TvManiacKit/Sources/TvManiacKit/AuthCoordinatorRegistry.swift
@@ -1,0 +1,36 @@
+import Foundation
+import TvManiac
+
+/// Builds and retains a sign-in coordinator per connected provider, pointing each provider's
+/// `AuthManager` at the coordinator built from its matching `AuthClientConfig`. Keeps the app entry point
+/// free of provider-auth setup — a new provider is picked up from the graph with no change here.
+@MainActor
+public final class AuthCoordinatorRegistry {
+    private var coordinators: [AuthCoordinator] = []
+
+    public init() {}
+
+    public func register(presenterGraph: IosViewPresenterGraph, appGraph: IosApplicationGraph) {
+        guard coordinators.isEmpty else { return }
+        let configs = appGraph.authClientConfigs.compactMap { $0 as? AuthClientConfig }
+        let repositories = appGraph.accountAuthRepositories.compactMap { $0 as? AccountAuthRepository }
+
+        coordinators = presenterGraph.authManagers.compactMap { element in
+            guard let manager = element as? AuthManager,
+                  let config = configs.first(where: { $0.provider == manager.provider }),
+                  let repository = repositories.first(where: { $0.provider == manager.provider })
+            else {
+                return nil
+            }
+            let coordinator = AuthCoordinatorFactory.create(
+                authRepository: repository,
+                config: config,
+                logger: appGraph.logger
+            )
+            manager.setAuthCallback(callback: { [weak coordinator] in
+                coordinator?.initiateAuthorization()
+            })
+            return coordinator
+        }
+    }
+}

--- a/ios/Packages/TvManiacKit/Sources/TvManiacKit/OAuthCoordinator.swift
+++ b/ios/Packages/TvManiacKit/Sources/TvManiacKit/OAuthCoordinator.swift
@@ -4,29 +4,19 @@ import TraktAuthKit
 import TvManiac
 import UIKit
 
-public class TraktAuthCoordinator: NSObject {
-    private let oauthClient: TraktOAuthClient
-    private let authRepository: TraktAuthRepository
+public class OAuthCoordinator: NSObject, AuthCoordinator {
+    private let oauthClient: OAuthClient
+    private let authRepository: AccountAuthRepository
     private let logger: Logger
 
     public init(
-        authRepository: TraktAuthRepository,
+        authRepository: AccountAuthRepository,
         logger: Logger,
-        clientId: String,
-        clientSecret: String,
-        redirectURL: URL
+        configuration: OAuthConfiguration
     ) {
         self.authRepository = authRepository
         self.logger = logger
-
-        let oauthConfig = TraktAuthConfiguration.trakt(
-            clientId: clientId,
-            clientSecret: clientSecret,
-            redirectURL: redirectURL
-        )
-
-        oauthClient = TraktOAuthClient(configuration: oauthConfig)
-
+        oauthClient = OAuthClient(configuration: configuration)
         super.init()
     }
 
@@ -47,7 +37,7 @@ public class TraktAuthCoordinator: NSObject {
                 )
 
                 guard let expiresAt = credential.expiresAt else {
-                    logger.error(tag: "TraktAuthCoordinator", message: "Token response missing expiration time")
+                    logger.error(tag: "OAuthCoordinator", message: "Token response missing expiration time")
                     await handleAuthError(AuthError.TokenExchangeFailed())
                     return
                 }
@@ -58,16 +48,16 @@ public class TraktAuthCoordinator: NSObject {
                     expiresAtSeconds: Int64(expiresAt.timeIntervalSince1970)
                 )
 
-            } catch let error as TraktAuthError {
+            } catch let error as OAuthError {
                 logger.error(
-                    tag: "TraktAuthCoordinator",
+                    tag: "OAuthCoordinator",
                     message: "OAuth authorization failed: \(String(describing: error))"
                 )
                 await handleAuthError(mapToKMPError(error))
 
             } catch {
                 logger.error(
-                    tag: "TraktAuthCoordinator",
+                    tag: "OAuthCoordinator",
                     message: "Authorization or token save failed: \(error.localizedDescription)"
                 )
                 await handleAuthError(AuthError.Unknown())
@@ -80,13 +70,13 @@ public class TraktAuthCoordinator: NSObject {
             try await authRepository.setAuthError(error: error)
         } catch {
             logger.error(
-                tag: "TraktAuthCoordinator",
+                tag: "OAuthCoordinator",
                 message: "Failed to persist auth error state: \(error.localizedDescription)"
             )
         }
     }
 
-    private func mapToKMPError(_ error: TraktAuthError) -> AuthError {
+    private func mapToKMPError(_ error: OAuthError) -> AuthError {
         switch error {
         case .authorizationFailed, .tokenExchangeFailed, .invalidTokenResponse:
             AuthError.TokenExchangeFailed()

--- a/ios/ios/App/iOSApp.swift
+++ b/ios/ios/App/iOSApp.swift
@@ -14,7 +14,7 @@ struct iOSApp: App {
     var scenePhase: ScenePhase
 
     @State private var componentHolder: ComponentHolder<IosViewPresenterGraph>?
-    @State private var authCoordinator: TraktAuthCoordinator?
+    @State private var authRegistry = AuthCoordinatorRegistry()
     @State private var toastManager = ToastManager()
     private let screenRegistry = ScreenRegistryBootstrap.makeRegistry()
 
@@ -85,7 +85,7 @@ struct iOSApp: App {
                 .animation(.spring(), value: toastManager.toast)
                 .provideWidthSizeClass()
                 .onAppear {
-                    setupAuthCoordinator()
+                    authRegistry.register(presenterGraph: holder.component, appGraph: appDelegate.appGraph)
                     appDelegate.configureNotificationDelegate(rootPresenter: holder.component.rootPresenter)
                 }
                 .onChange(of: scenePhase) { _, newPhase in
@@ -100,19 +100,6 @@ struct iOSApp: App {
                     }
                 }
             }
-        }
-    }
-
-    private func setupAuthCoordinator() {
-        if authCoordinator == nil {
-            authCoordinator = AuthCoordinatorFactory.create(
-                authRepository: appDelegate.traktAuthRepository,
-                traktConfig: appDelegate.traktConfig,
-                logger: appDelegate.logger
-            )
-        }
-        appDelegate.setupAuthBridge { [weak authCoordinator] in
-            authCoordinator?.initiateAuthorization()
         }
     }
 


### PR DESCRIPTION
## Description
This PR refactors the authentication system to support multiple providers by generalizing the core authentication interfaces and components. It transitions away from a Trakt-specific implementation towards a more flexible registry-based architecture on both Android and iOS. #727 

## Changes
- Generalized authentication types and interfaces across the `data` and `api` layers.
- Introduced `AuthClientConfig` with support for multibindings to allow multiple authentication providers.
- Implemented `AuthCoordinatorRegistry` on iOS to manage different authentication flows dynamically.
- Refactored iOS `TraktAuthKit` to `OAuthClient` and related generic components.
- Simplified `MainActivity` and `iOSApp` by offloading authentication coordination to specialized registries and factories.