### PR TITLE
feat: Add Presenter multi-account provider support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ obtain them. Create `local.properties` in the project root:
 TMDB_API_KEY=your_tmdb_api_key
 TRAKT_CLIENT_ID=your_trakt_client_id
 TRAKT_CLIENT_SECRET=your_trakt_client_secret
-TRAKT_REDIRECT_URI=tvmaniac://callback
+TRAKT_REDIRECT_URI=tvmaniac://auth/trakt
 ```
 
 This file is gitignored. Do not commit it.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Create `local.properties` in the project root:
 TMDB_API_KEY=your_tmdb_api_key
 TRAKT_CLIENT_ID=your_trakt_client_id
 TRAKT_CLIENT_SECRET=your_trakt_client_secret
-TRAKT_REDIRECT_URI=tvmaniac://callback
+TRAKT_REDIRECT_URI=tvmaniac://auth/trakt
 ```
 
 ### Setup & Build

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,7 +41,6 @@ dependencies {
     implementation(projects.androidDesignsystem)
     implementation(projects.features.root.ui)
     implementation(projects.features.root.nav)
-    implementation(projects.features.root.presenter)
     implementation(projects.api.tmdb.implementation)
     implementation(projects.api.trakt.implementation)
     implementation(projects.core.appconfig.api)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,8 +52,13 @@
         <category android:name="android.intent.category.BROWSABLE" />
 
         <data
-          android:host="callback"
-          android:scheme="tvmaniac" />
+          android:scheme="tvmaniac"
+          android:host="auth"
+          android:path="/trakt" />
+        <data
+          android:scheme="tvmaniac"
+          android:host="auth"
+          android:path="/simkl" />
 
       </intent-filter>
     </activity>

--- a/app/src/main/kotlin/com/thomaskioko/tvmaniac/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/thomaskioko/tvmaniac/app/MainActivity.kt
@@ -39,7 +39,7 @@ public class MainActivity : ComponentActivity() {
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
-        graph.authManagers.forEach { it.registerResult() }
+        graph.authManagers.values.forEach { it.registerResult() }
 
         enableEdgeToEdge()
 

--- a/app/src/main/kotlin/com/thomaskioko/tvmaniac/app/di/ActivityGraph.kt
+++ b/app/src/main/kotlin/com/thomaskioko/tvmaniac/app/di/ActivityGraph.kt
@@ -3,6 +3,7 @@ package com.thomaskioko.tvmaniac.app.di
 import androidx.activity.ComponentActivity
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.defaultComponentContext
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthManager
 import com.thomaskioko.tvmaniac.app.TvManicApplication
 import com.thomaskioko.tvmaniac.app.ui.di.AppRootProvider
@@ -23,7 +24,7 @@ import dev.zacsweers.metro.asContribution
 @GraphExtension(ActivityScope::class)
 @SingleIn(ActivityScope::class)
 public interface ActivityGraph : AppRootProvider {
-    public val authManagers: Set<AuthManager>
+    public val authManagers: Map<AccountProvider, AuthManager>
     override val rootPresenter: RootPresenter
     public val navigator: Navigator
     override val screenContents: Set<ScreenContent>

--- a/core/integration/infra/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testing/di/FakeAppConfigBindingContainer.kt
+++ b/core/integration/infra/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testing/di/FakeAppConfigBindingContainer.kt
@@ -34,7 +34,7 @@ public object FakeAppConfigBindingContainer {
     public fun provideTraktConfig(): TraktConfig = object : TraktConfig {
         override val clientId: String = "fake-trakt-client-id"
         override val clientSecret: String = "fake-trakt-client-secret"
-        override val redirectUri: String = "tvmaniac://auth"
+        override val redirectUri: String = "tvmaniac://auth/trakt"
     }
 
     @Provides
@@ -42,6 +42,6 @@ public object FakeAppConfigBindingContainer {
     public fun provideSimklConfig(): SimklConfig = object : SimklConfig {
         override val clientId: String = "fake-simkl-client-id"
         override val clientSecret: String = "fake-simkl-client-secret"
-        override val redirectUri: String = "tvmaniac://auth"
+        override val redirectUri: String = "tvmaniac://auth/simkl"
     }
 }

--- a/data/account-manager/api/build.gradle.kts
+++ b/data/account-manager/api/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
     alias(libs.plugins.app.kmp)
 }
 
+scaffold {
+    useMetro()
+}
+
 kotlin {
     sourceSets {
         commonMain {

--- a/data/account-manager/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/api/AccountProviderKey.kt
+++ b/data/account-manager/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/api/AccountProviderKey.kt
@@ -1,0 +1,6 @@
+package com.thomaskioko.tvmaniac.accountmanager.api
+
+import dev.zacsweers.metro.MapKey
+
+@MapKey
+public annotation class AccountProviderKey(val value: AccountProvider)

--- a/data/account-manager/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/api/AccountProviderKey.kt
+++ b/data/account-manager/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/api/AccountProviderKey.kt
@@ -3,4 +3,5 @@ package com.thomaskioko.tvmaniac.accountmanager.api
 import dev.zacsweers.metro.MapKey
 
 @MapKey
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.TYPE)
 public annotation class AccountProviderKey(val value: AccountProvider)

--- a/data/account-manager/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/implementation/DefaultAccountManager.kt
+++ b/data/account-manager/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/implementation/DefaultAccountManager.kt
@@ -24,17 +24,16 @@ import kotlinx.coroutines.flow.merge
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 public class DefaultAccountManager(
-    authRepositories: Set<AccountAuthRepository>,
+    private val repositories: Map<AccountProvider, AccountAuthRepository>,
 ) : AccountManager {
 
-    private val repositories: List<AccountAuthRepository> = authRepositories.toList()
     private val selectedProvider = MutableStateFlow<AccountProvider?>(null)
 
     private val providerStates: Flow<List<Pair<AccountProvider, AccountAuthState>>> =
         if (repositories.isEmpty()) {
             flowOf(emptyList())
         } else {
-            combine(repositories.map { repo -> repo.state.map { repo.provider to it } }) { it.toList() }
+            combine(repositories.values.map { repo -> repo.state.map { repo.provider to it } }) { it.toList() }
         }
 
     override val activeProvider: Flow<AccountProvider?> =
@@ -44,7 +43,7 @@ public class DefaultAccountManager(
     override val isConnected: Flow<Boolean> = activeProvider.map { it != null }
 
     override val connectionEvents: Flow<AccountProvider> =
-        repositories.map { repo -> repo.loginEvents.map { repo.provider } }.merge()
+        repositories.values.map { repo -> repo.loginEvents.map { repo.provider } }.merge()
 
     override val accounts: Flow<List<ConnectedAccount>> =
         combine(providerStates, selectedProvider) { states, selected ->
@@ -62,7 +61,7 @@ public class DefaultAccountManager(
         accounts.map { list -> list.firstOrNull { it.isActive } }.distinctUntilChanged()
 
     override val authError: Flow<AuthError?> =
-        if (repositories.isEmpty()) flowOf(null) else repositories.map { it.authError }.merge()
+        if (repositories.isEmpty()) flowOf(null) else repositories.values.map { it.authError }.merge()
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override val activeAuthState: Flow<AuthState?> =
@@ -70,20 +69,20 @@ public class DefaultAccountManager(
             flowOf(null)
         } else {
             activeProvider.flatMapLatest { provider ->
-                repositories.firstOrNull { it.provider == provider }?.authState ?: flowOf(null)
+                provider?.let { repositories[it]?.authState } ?: flowOf(null)
             }
         }
 
     override fun getActiveProvider(): AccountProvider? {
         val selected = selectedProvider.value
-        if (selected != null && repositories.any { it.provider == selected && it.isLoggedIn() }) {
+        if (selected != null && repositories[selected]?.isLoggedIn() == true) {
             return selected
         }
-        return repositories.firstOrNull { it.isLoggedIn() }?.provider
+        return repositories.values.firstOrNull { it.isLoggedIn() }?.provider
     }
 
     override suspend fun logout(provider: AccountProvider) {
-        repositories.firstOrNull { it.provider == provider }?.logout()
+        repositories[provider]?.logout()
         if (selectedProvider.value == provider) {
             selectedProvider.value = null
         }
@@ -94,14 +93,14 @@ public class DefaultAccountManager(
     }
 
     override suspend fun setAuthError(error: AuthError?) {
-        repositories.forEach { it.setAuthError(error) }
+        repositories.values.forEach { it.setAuthError(error) }
     }
 
     override suspend fun refreshActiveTokens(): TokenRefreshResult =
         activeRepository()?.refreshTokens() ?: TokenRefreshResult.NotLoggedIn
 
     private fun activeRepository(): AccountAuthRepository? =
-        getActiveProvider()?.let { provider -> repositories.firstOrNull { it.provider == provider } }
+        getActiveProvider()?.let { provider -> repositories[provider] }
 
     private fun resolveActive(
         states: List<Pair<AccountProvider, AccountAuthState>>,

--- a/data/account-manager/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/implementation/di/AuthClientConfigMultibindings.kt
+++ b/data/account-manager/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/implementation/di/AuthClientConfigMultibindings.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.accountmanager.implementation.di
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthClientConfig
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
@@ -9,5 +10,5 @@ import dev.zacsweers.metro.Multibinds
 public interface AuthClientConfigMultibindings {
 
     @Multibinds(allowEmpty = true)
-    public fun authClientConfigs(): Set<AuthClientConfig>
+    public fun authClientConfigs(): Map<AccountProvider, AuthClientConfig>
 }

--- a/data/account-manager/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/implementation/di/AuthManagerMultibindings.kt
+++ b/data/account-manager/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/implementation/di/AuthManagerMultibindings.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.accountmanager.implementation.di
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthManager
 import com.thomaskioko.tvmaniac.core.base.ActivityScope
 import dev.zacsweers.metro.ContributesTo
@@ -9,5 +10,5 @@ import dev.zacsweers.metro.Multibinds
 public interface AuthManagerMultibindings {
 
     @Multibinds(allowEmpty = true)
-    public fun authManagers(): Set<AuthManager>
+    public fun authManagers(): Map<AccountProvider, AuthManager>
 }

--- a/data/account-manager/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/accountmanager/implementation/DefaultAccountManagerTest.kt
+++ b/data/account-manager/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/accountmanager/implementation/DefaultAccountManagerTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.Test
 class DefaultAccountManagerTest {
 
     private val traktRepository = FakeAccountAuthRepository(AccountProvider.TRAKT)
-    private val accountManager = DefaultAccountManager(authRepositories = setOf(traktRepository))
+    private val accountManager = DefaultAccountManager(repositories = mapOf(AccountProvider.TRAKT to traktRepository))
 
     @Test
     fun `should expose TRAKT as the active provider when logged in`() = runTest {

--- a/data/oauth/implementation/src/androidMain/kotlin/com/thomaskioko/tvmaniac/oauth/implementation/AndroidOAuthLauncher.kt
+++ b/data/oauth/implementation/src/androidMain/kotlin/com/thomaskioko/tvmaniac/oauth/implementation/AndroidOAuthLauncher.kt
@@ -30,6 +30,7 @@ import kotlin.coroutines.suspendCoroutine
 public class AndroidOAuthLauncher(
     private val activity: ComponentActivity,
     private val authStateHolder: AuthStateHolder,
+    private val authClientConfigs: Map<AccountProvider, AuthClientConfig>,
     private val logger: Logger,
     @IoCoroutineScope private val coroutineScope: CoroutineScope,
 ) : OAuthLauncher {
@@ -38,7 +39,7 @@ public class AndroidOAuthLauncher(
     private lateinit var launcher: ActivityResultLauncher<AuthorizationRequest>
 
     @Volatile
-    private var pendingConfig: AuthClientConfig? = null
+    private var pendingProvider: AccountProvider? = null
 
     override fun register() {
         if (::launcher.isInitialized) return
@@ -53,7 +54,7 @@ public class AndroidOAuthLauncher(
         check(::launcher.isInitialized) {
             "register() must be called before launch(). Call it in the Activity's onCreate()/onStart()."
         }
-        pendingConfig = config
+        pendingProvider = config.provider
         try {
             launcher.launch(buildRequest(config))
         } catch (e: ActivityNotFoundException) {
@@ -85,17 +86,27 @@ public class AndroidOAuthLauncher(
     }
 
     private suspend fun onResult(result: OAuthActivityResultContract.Result) {
-        val config = pendingConfig ?: return
         val (response, error) = result
         when {
-            response != null -> exchangeAuthorizationCode(response.createTokenExchangeRequest(), config)
+            response != null -> {
+                val config = requireNotNull(
+                    authClientConfigs.values.firstOrNull { it.clientId == response.request.clientId }
+                        ?: pendingProvider?.let { authClientConfigs[it] },
+                ) { "No AuthClientConfig matched the OAuth response (clientId=${response.request.clientId})." }
+                exchangeAuthorizationCode(response.createTokenExchangeRequest(), config)
+            }
             error != null -> {
                 logger.error(LOG_TAG, error)
+                val provider = pendingProvider
+                if (provider == null) {
+                    logger.warning(LOG_TAG, "OAuth error after process recreation; no pending provider to route it to.")
+                    return
+                }
                 val authError = when (error.type) {
                     TYPE_USER_CANCELED -> AuthError.OAuthCancelled
                     else -> AuthError.OAuthFailed(error.error ?: "Unknown OAuth error")
                 }
-                authStateHolder.setAuthError(config.provider, authError)
+                authStateHolder.setAuthError(provider, authError)
             }
         }
     }

--- a/data/simklauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simklauth/implementation/SimklAccountAuthManager.kt
+++ b/data/simklauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simklauth/implementation/SimklAccountAuthManager.kt
@@ -1,23 +1,28 @@
 package com.thomaskioko.tvmaniac.simklauth.implementation
 
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProviderKey
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthClientConfig
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthManager
 import com.thomaskioko.tvmaniac.core.base.ActivityScope
 import com.thomaskioko.tvmaniac.oauth.api.OAuthLauncher
-import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.binding
 
 @SingleIn(ActivityScope::class)
-@ContributesIntoSet(ActivityScope::class)
+@ContributesIntoMap(
+    scope = ActivityScope::class,
+    binding = binding<@AccountProviderKey(AccountProvider.SIMKL) AuthManager>(),
+)
 public class SimklAccountAuthManager(
     private val launcher: OAuthLauncher,
-    authClientConfigs: Set<AuthClientConfig>,
+    authClientConfigs: Map<AccountProvider, AuthClientConfig>,
 ) : AuthManager {
 
     override val provider: AccountProvider = AccountProvider.SIMKL
 
-    private val config: AuthClientConfig = authClientConfigs.first { it.provider == AccountProvider.SIMKL }
+    private val config: AuthClientConfig = authClientConfigs.getValue(AccountProvider.SIMKL)
 
     override fun launchWebView() {
         launcher.launch(config)

--- a/data/simklauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simklauth/implementation/SimklAccountAuthManager.kt
+++ b/data/simklauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simklauth/implementation/SimklAccountAuthManager.kt
@@ -13,7 +13,10 @@ import dev.zacsweers.metro.binding
 @SingleIn(ActivityScope::class)
 @ContributesIntoMap(
     scope = ActivityScope::class,
-    binding = binding<@AccountProviderKey(AccountProvider.SIMKL) AuthManager>(),
+    binding = binding<
+        @AccountProviderKey(AccountProvider.SIMKL)
+        AuthManager,
+        >(),
 )
 public class SimklAccountAuthManager(
     private val launcher: OAuthLauncher,

--- a/data/simklauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simklauth/implementation/SimklAccountAuthRepository.kt
+++ b/data/simklauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simklauth/implementation/SimklAccountAuthRepository.kt
@@ -3,18 +3,23 @@ package com.thomaskioko.tvmaniac.simklauth.implementation
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountAuthRepository
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountAuthState
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProviderKey
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthError
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthState
 import com.thomaskioko.tvmaniac.accountmanager.api.TokenRefreshResult
 import com.thomaskioko.tvmaniac.oauth.api.AuthStateHolder
 import dev.zacsweers.metro.AppScope
-import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.binding
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 
 @SingleIn(AppScope::class)
-@ContributesIntoSet(AppScope::class)
+@ContributesIntoMap(
+    scope = AppScope::class,
+    binding = binding<@AccountProviderKey(AccountProvider.SIMKL) AccountAuthRepository>(),
+)
 public class SimklAccountAuthRepository(
     private val authStateHolder: AuthStateHolder,
 ) : AccountAuthRepository {

--- a/data/simklauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simklauth/implementation/SimklAccountAuthRepository.kt
+++ b/data/simklauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simklauth/implementation/SimklAccountAuthRepository.kt
@@ -18,7 +18,10 @@ import kotlinx.coroutines.flow.SharedFlow
 @SingleIn(AppScope::class)
 @ContributesIntoMap(
     scope = AppScope::class,
-    binding = binding<@AccountProviderKey(AccountProvider.SIMKL) AccountAuthRepository>(),
+    binding = binding<
+        @AccountProviderKey(AccountProvider.SIMKL)
+        AccountAuthRepository,
+        >(),
 )
 public class SimklAccountAuthRepository(
     private val authStateHolder: AuthStateHolder,

--- a/data/simklauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simklauth/implementation/SimklAuthClientConfig.kt
+++ b/data/simklauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simklauth/implementation/SimklAuthClientConfig.kt
@@ -12,7 +12,10 @@ import dev.zacsweers.metro.binding
 @SingleIn(AppScope::class)
 @ContributesIntoMap(
     scope = AppScope::class,
-    binding = binding<@AccountProviderKey(AccountProvider.SIMKL) AuthClientConfig>(),
+    binding = binding<
+        @AccountProviderKey(AccountProvider.SIMKL)
+        AuthClientConfig,
+        >(),
 )
 public class SimklAuthClientConfig(
     simklConfig: SimklConfig,

--- a/data/simklauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simklauth/implementation/SimklAuthClientConfig.kt
+++ b/data/simklauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simklauth/implementation/SimklAuthClientConfig.kt
@@ -1,14 +1,19 @@
 package com.thomaskioko.tvmaniac.simklauth.implementation
 
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProviderKey
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthClientConfig
 import com.thomaskioko.tvmaniac.appconfig.SimklConfig
 import dev.zacsweers.metro.AppScope
-import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.binding
 
 @SingleIn(AppScope::class)
-@ContributesIntoSet(AppScope::class)
+@ContributesIntoMap(
+    scope = AppScope::class,
+    binding = binding<@AccountProviderKey(AccountProvider.SIMKL) AuthClientConfig>(),
+)
 public class SimklAuthClientConfig(
     simklConfig: SimklConfig,
 ) : AuthClientConfig {

--- a/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TraktAccountAuthManager.kt
+++ b/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TraktAccountAuthManager.kt
@@ -13,7 +13,10 @@ import dev.zacsweers.metro.binding
 @SingleIn(ActivityScope::class)
 @ContributesIntoMap(
     scope = ActivityScope::class,
-    binding = binding<@AccountProviderKey(AccountProvider.TRAKT) AuthManager>(),
+    binding = binding<
+        @AccountProviderKey(AccountProvider.TRAKT)
+        AuthManager,
+        >(),
 )
 public class TraktAccountAuthManager(
     private val launcher: OAuthLauncher,

--- a/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TraktAccountAuthManager.kt
+++ b/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TraktAccountAuthManager.kt
@@ -1,23 +1,28 @@
 package com.thomaskioko.tvmaniac.traktauth.implementation
 
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProviderKey
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthClientConfig
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthManager
 import com.thomaskioko.tvmaniac.core.base.ActivityScope
 import com.thomaskioko.tvmaniac.oauth.api.OAuthLauncher
-import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.binding
 
 @SingleIn(ActivityScope::class)
-@ContributesIntoSet(ActivityScope::class)
+@ContributesIntoMap(
+    scope = ActivityScope::class,
+    binding = binding<@AccountProviderKey(AccountProvider.TRAKT) AuthManager>(),
+)
 public class TraktAccountAuthManager(
     private val launcher: OAuthLauncher,
-    authClientConfigs: Set<AuthClientConfig>,
+    authClientConfigs: Map<AccountProvider, AuthClientConfig>,
 ) : AuthManager {
 
     override val provider: AccountProvider = AccountProvider.TRAKT
 
-    private val config: AuthClientConfig = authClientConfigs.first { it.provider == AccountProvider.TRAKT }
+    private val config: AuthClientConfig = authClientConfigs.getValue(AccountProvider.TRAKT)
 
     override fun launchWebView() {
         launcher.launch(config)

--- a/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TraktAccountAuthRepository.kt
+++ b/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TraktAccountAuthRepository.kt
@@ -18,7 +18,10 @@ import kotlinx.coroutines.flow.SharedFlow
 @SingleIn(AppScope::class)
 @ContributesIntoMap(
     scope = AppScope::class,
-    binding = binding<@AccountProviderKey(AccountProvider.TRAKT) AccountAuthRepository>(),
+    binding = binding<
+        @AccountProviderKey(AccountProvider.TRAKT)
+        AccountAuthRepository,
+        >(),
 )
 public class TraktAccountAuthRepository(
     private val traktAuthRepository: OAuthRepository,

--- a/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TraktAccountAuthRepository.kt
+++ b/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TraktAccountAuthRepository.kt
@@ -3,18 +3,23 @@ package com.thomaskioko.tvmaniac.traktauth.implementation
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountAuthRepository
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountAuthState
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProviderKey
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthError
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthState
 import com.thomaskioko.tvmaniac.accountmanager.api.TokenRefreshResult
 import com.thomaskioko.tvmaniac.oauth.api.OAuthRepository
 import dev.zacsweers.metro.AppScope
-import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.binding
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 
 @SingleIn(AppScope::class)
-@ContributesIntoSet(AppScope::class)
+@ContributesIntoMap(
+    scope = AppScope::class,
+    binding = binding<@AccountProviderKey(AccountProvider.TRAKT) AccountAuthRepository>(),
+)
 public class TraktAccountAuthRepository(
     private val traktAuthRepository: OAuthRepository,
 ) : AccountAuthRepository {

--- a/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TraktAuthClientConfig.kt
+++ b/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TraktAuthClientConfig.kt
@@ -12,7 +12,10 @@ import dev.zacsweers.metro.binding
 @SingleIn(AppScope::class)
 @ContributesIntoMap(
     scope = AppScope::class,
-    binding = binding<@AccountProviderKey(AccountProvider.TRAKT) AuthClientConfig>(),
+    binding = binding<
+        @AccountProviderKey(AccountProvider.TRAKT)
+        AuthClientConfig,
+        >(),
 )
 public class TraktAuthClientConfig(
     traktConfig: TraktConfig,

--- a/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TraktAuthClientConfig.kt
+++ b/data/traktauth/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/implementation/TraktAuthClientConfig.kt
@@ -1,14 +1,19 @@
 package com.thomaskioko.tvmaniac.traktauth.implementation
 
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProviderKey
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthClientConfig
 import com.thomaskioko.tvmaniac.trakt.api.TraktConfig
 import dev.zacsweers.metro.AppScope
-import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.binding
 
 @SingleIn(AppScope::class)
-@ContributesIntoSet(AppScope::class)
+@ContributesIntoMap(
+    scope = AppScope::class,
+    binding = binding<@AccountProviderKey(AccountProvider.TRAKT) AuthClientConfig>(),
+)
 public class TraktAuthClientConfig(
     traktConfig: TraktConfig,
 ) : AuthClientConfig {

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -7,7 +7,7 @@ TMDB and Trakt API credentials are required.
 
 ## 2. Trakt OAuth Credentials
 [Create a Trakt app](https://trakt.tv/oauth/applications/new).
-- **Redirect URI**: `tvmaniac://callback`
+- **Redirect URI**: `tvmaniac://auth/trakt`
 - Note the **Client ID** and **Client Secret**.
 
 ## 3. Local Configuration
@@ -17,7 +17,7 @@ Create `local.properties` in project root:
 TMDB_API_KEY=your_tmdb_api_key
 TRAKT_CLIENT_ID=your_trakt_client_id
 TRAKT_CLIENT_SECRET=your_trakt_client_secret
-TRAKT_REDIRECT_URI=tvmaniac://callback
+TRAKT_REDIRECT_URI=tvmaniac://auth/trakt
 ```
 
 **CI/CD**: Use identical environment variable names.

--- a/features/profile/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/profile/presenter/ProfileAction.kt
+++ b/features/profile/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/profile/presenter/ProfileAction.kt
@@ -1,7 +1,9 @@
 package com.thomaskioko.tvmaniac.profile.presenter
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+
 public sealed interface ProfileAction {
-    public data object LoginClicked : ProfileAction
+    public data class LoginClicked(val provider: AccountProvider) : ProfileAction
 
     public data object SettingsClicked : ProfileAction
 

--- a/features/profile/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/profile/presenter/ProfilePresenter.kt
+++ b/features/profile/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/profile/presenter/ProfilePresenter.kt
@@ -81,7 +81,7 @@ public class ProfilePresenter(
     componentContext: ComponentContext,
     private val navigator: Navigator,
     private val localizer: Localizer,
-    private val authManagers: Set<AuthManager>,
+    private val authManagers: Map<AccountProvider, AuthManager>,
     private val accountManager: AccountManager,
     private val updateUserProfileData: UpdateUserProfileData,
     private val errorToStringMapper: ErrorToStringMapper,
@@ -187,9 +187,9 @@ public class ProfilePresenter(
 
     public fun dispatch(action: ProfileAction) {
         when (action) {
-            LoginClicked -> {
+            is LoginClicked -> {
                 coroutineScope.launch {
-                    authManagers.firstOrNull { it.provider == AccountProvider.TRAKT }?.launchWebView()
+                    authManagers[action.provider]?.launchWebView()
                 }
             }
             SettingsClicked -> navigator.navigateTo(SettingsRoute)

--- a/features/profile/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/profile/presenter/ProfilePresenter.kt
+++ b/features/profile/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/profile/presenter/ProfilePresenter.kt
@@ -153,12 +153,12 @@ public class ProfilePresenter(
     public val state: StateFlow<ProfileState> = combine(
         observeUserProfileInteractor.flow,
         accountManager.isConnected,
+        accountManager.activeProvider,
         accountManager.authError,
         profileLoadingState.observable,
         uiMessageManager.message,
         sectionsFlow,
-    ) { userProfile, isConnected, authError, isLoading, uiMessage, sections ->
-        val authenticated = isConnected
+    ) { userProfile, isConnected, activeProvider, authError, isLoading, uiMessage, sections ->
         val errorMessage = authError?.toUiMessage(localizer) ?: uiMessage
         val profile = userProfile?.toPresentation()
         val displayName = profile?.fullName ?: profile?.username ?: ""
@@ -167,7 +167,8 @@ public class ProfilePresenter(
             userProfile = profile,
             isLoading = isLoading,
             errorMessage = errorMessage,
-            authenticated = authenticated,
+            authenticated = isConnected,
+            activeProvider = activeProvider,
             userLists = sections.userLists,
             inProgress = sections.inProgress,
             completed = sections.completed,

--- a/features/profile/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/profile/presenter/model/ProfileState.kt
+++ b/features/profile/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/profile/presenter/model/ProfileState.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.profile.presenter.model
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.core.view.UiMessage
 
 public data class ProfileState(
@@ -7,6 +8,7 @@ public data class ProfileState(
     val userProfile: ProfileInfo?,
     val errorMessage: UiMessage? = null,
     val authenticated: Boolean,
+    val activeProvider: AccountProvider? = null,
     val userLists: SectionState<ProfileListItem> = SectionState.Loading,
     val inProgress: SectionState<ProfileShowItem> = SectionState.Loading,
     val completed: SectionState<ProfileShowItem> = SectionState.Loading,

--- a/features/profile/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/profile/ProfilePresenterTest.kt
+++ b/features/profile/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/profile/ProfilePresenterTest.kt
@@ -528,7 +528,7 @@ internal class ProfilePresenterTest {
             componentContext = DefaultComponentContext(lifecycle = lifecycle),
             navigator = navigator,
             localizer = FakeLocalizer(),
-            authManagers = setOf(authManager),
+            authManagers = mapOf(AccountProvider.TRAKT to authManager),
             accountManager = accountManager,
             updateUserProfileData = updateUserProfileData,
             errorToStringMapper = { it.message ?: "Test error" },

--- a/features/profile/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/profile/ProfilePresenterTest.kt
+++ b/features/profile/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/profile/ProfilePresenterTest.kt
@@ -73,6 +73,7 @@ internal class ProfilePresenterTest {
     private val userRepository = FakeUserRepository()
     private val accountManager = FakeAccountManager()
     private val authManager = FakeAuthManager()
+    private val simklAuthManager = FakeAuthManager(AccountProvider.SIMKL)
     private val traktListRepository = FakeTraktListRepository()
     private val upNextRepository = FakeUpNextRepository()
     private val episodeRepository = FakeEpisodeRepository()
@@ -144,6 +145,7 @@ internal class ProfilePresenterTest {
             val loadedState = awaitItem()
             loadedState.userProfile shouldBe createExpectedProfileInfo(testProfile)
             loadedState.authenticated shouldBe true
+            loadedState.activeProvider shouldBe AccountProvider.TRAKT
             loadedState.isLoading shouldBe false
         }
     }
@@ -230,6 +232,7 @@ internal class ProfilePresenterTest {
 
             loggedOutState.userProfile shouldBe null
             loggedOutState.authenticated shouldBe false
+            loggedOutState.activeProvider shouldBe null
             loggedOutState.showLoading shouldBe false
         }
     }
@@ -434,6 +437,20 @@ internal class ProfilePresenterTest {
             listOf(FakeFavoritesRepository.SyncInvocation(forceRefresh = true))
     }
 
+    @Test
+    fun `should launch the chosen provider given a non default provider`() = runTest {
+        var traktLaunches = 0
+        var simklLaunches = 0
+        authManager.setOnLaunchWebView { traktLaunches += 1 }
+        simklAuthManager.setOnLaunchWebView { simklLaunches += 1 }
+
+        presenter.dispatch(ProfileAction.LoginClicked(AccountProvider.SIMKL))
+        advanceUntilIdle()
+
+        simklLaunches shouldBe 1
+        traktLaunches shouldBe 0
+    }
+
     private fun createExpectedProfileInfo(profile: UserProfile): ProfileInfo {
         return ProfileInfo(
             slug = profile.slug,
@@ -528,7 +545,10 @@ internal class ProfilePresenterTest {
             componentContext = DefaultComponentContext(lifecycle = lifecycle),
             navigator = navigator,
             localizer = FakeLocalizer(),
-            authManagers = mapOf(AccountProvider.TRAKT to authManager),
+            authManagers = mapOf(
+                AccountProvider.TRAKT to authManager,
+                AccountProvider.SIMKL to simklAuthManager,
+            ),
             accountManager = accountManager,
             updateUserProfileData = updateUserProfileData,
             errorToStringMapper = { it.message ?: "Test error" },

--- a/features/profile/ui/build.gradle.kts
+++ b/features/profile/ui/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
 
     api(libs.androidx.compose.foundation)
     api(libs.androidx.compose.runtime)
+    implementation(projects.data.accountManager.api)
     implementation(projects.androidDesignsystem)
     implementation(projects.features.home.nav)
     implementation(projects.core.testTags)

--- a/features/profile/ui/src/main/kotlin/com/thomaskioko/tvmaniac/profile/ui/ProfileScreen.kt
+++ b/features/profile/ui/src/main/kotlin/com/thomaskioko/tvmaniac/profile/ui/ProfileScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.compose.components.AvatarComponent
 import com.thomaskioko.tvmaniac.compose.components.OutlinedVerticalIconButton
 import com.thomaskioko.tvmaniac.compose.components.PosterCard
@@ -119,7 +120,7 @@ internal fun ProfileScreen(
                     completed = state.completed,
                     recentlyWatched = state.recentlyWatched,
                     favorites = state.favorites,
-                    onLoginClicked = { onAction(LoginClicked) },
+                    onLoginClicked = { onAction(LoginClicked(AccountProvider.TRAKT)) },
                     onViewLists = { onAction(ProfileAction.ViewListsClicked) },
                     onListClick = {},
                     onShowClick = { onAction(ProfileAction.ShowClicked(it)) },

--- a/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsActions.kt
+++ b/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsActions.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.settings.presenter
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.domain.theme.ImageQuality
 
 public sealed interface SettingsActions
@@ -20,7 +21,7 @@ public data object DismissTraktDialog : SettingsActions
 
 public data object TraktLogoutClicked : SettingsActions
 
-public data object TraktLoginClicked : SettingsActions
+public data class TraktLoginClicked(val provider: AccountProvider) : SettingsActions
 
 public data class ImageQualitySelected(
     val quality: ImageQuality,

--- a/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsPresenter.kt
+++ b/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsPresenter.kt
@@ -57,7 +57,7 @@ public class SettingsPresenter(
     private val errorToStringMapper: ErrorToStringMapper,
     private val localizer: Localizer,
     private val logger: Logger,
-    private val authManagers: Set<AuthManager>,
+    private val authManagers: Map<AccountProvider, AuthManager>,
     observeSettingsPreferencesInteractor: ObserveSettingsPreferencesInteractor,
     accountManager: AccountManager,
 ) : ComponentContext by componentContext {
@@ -134,11 +134,11 @@ public class SettingsPresenter(
                 updateTrackDialogState()
             }
 
-            TraktLoginClicked -> {
+            is TraktLoginClicked -> {
                 coroutineScope.launch {
                     traktAuthState.addLoader()
                     try {
-                        authManagers.firstOrNull { it.provider == AccountProvider.TRAKT }?.launchWebView()
+                        authManagers[action.provider]?.launchWebView()
                     } finally {
                         traktAuthState.removeLoader()
                     }

--- a/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsPresenter.kt
+++ b/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsPresenter.kt
@@ -80,9 +80,10 @@ public class SettingsPresenter(
         notificationToggleState.observable,
         observeSettingsPreferencesInteractor.flow,
         accountManager.isConnected,
+        accountManager.activeProvider,
         uiMessageManager.message,
         userRepository.observeCurrentUser().onStart { emit(null) },
-    ) { currentState, isProcessingTraktAuth, isTogglingNotifications, preferences, isLoggedIn, message, userProfile ->
+    ) { currentState, isProcessingTraktAuth, isTogglingNotifications, preferences, isLoggedIn, activeProvider, message, userProfile ->
         val username = userProfile?.let { it.fullName ?: it.username }
         currentState.copy(
             isLoading = false,
@@ -93,6 +94,7 @@ public class SettingsPresenter(
             openTrailersInYoutube = preferences.openTrailersInYoutube,
             includeSpecials = preferences.includeSpecials,
             isAuthenticated = isLoggedIn,
+            activeProvider = activeProvider,
             backgroundSyncEnabled = preferences.backgroundSyncEnabled,
             lastSyncDate = preferences.lastSyncDate,
             showLastSyncDate = preferences.showLastSyncDate,

--- a/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsState.kt
+++ b/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsState.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.settings.presenter
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.core.view.UiMessage
 import com.thomaskioko.tvmaniac.domain.theme.ImageQuality
 import kotlinx.collections.immutable.ImmutableList
@@ -7,6 +8,7 @@ import kotlinx.collections.immutable.persistentListOf
 
 public data class SettingsState(
     val isAuthenticated: Boolean,
+    val activeProvider: AccountProvider? = null,
     val theme: ThemeModel,
     val imageQuality: ImageQuality,
     val currentPage: SettingsPage = SettingsPage.ROOT,

--- a/features/settings/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/settings/SettingsPresenterTest.kt
+++ b/features/settings/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/settings/SettingsPresenterTest.kt
@@ -28,6 +28,7 @@ import com.thomaskioko.tvmaniac.settings.presenter.ShowTraktDialog
 import com.thomaskioko.tvmaniac.settings.presenter.ThemeModel
 import com.thomaskioko.tvmaniac.settings.presenter.ThemeSelected
 import com.thomaskioko.tvmaniac.settings.presenter.TraktLoginClicked
+import com.thomaskioko.tvmaniac.settings.presenter.TraktLogoutClicked
 import com.thomaskioko.tvmaniac.syncactivity.testing.FakeActivitySyncRepository
 import com.thomaskioko.tvmaniac.syncactivity.testing.FakeTraktActivityRepository
 import com.thomaskioko.tvmaniac.util.testing.FakeAppMetadata
@@ -56,6 +57,7 @@ class SettingsPresenterTest {
     private val fakeLogger = FakeLogger()
     private val localizer = FakeLocalizer()
     private val authManager = FakeAuthManager()
+    private val simklAuthManager = FakeAuthManager(AccountProvider.SIMKL)
     private lateinit var presenter: SettingsPresenter
 
     @BeforeTest
@@ -70,7 +72,10 @@ class SettingsPresenterTest {
             errorToStringMapper = ErrorToStringMapper { it.message ?: "Test error" },
             localizer = localizer,
             logger = fakeLogger,
-            authManagers = mapOf(AccountProvider.TRAKT to authManager),
+            authManagers = mapOf(
+                AccountProvider.TRAKT to authManager,
+                AccountProvider.SIMKL to simklAuthManager,
+            ),
             logoutInteractor = LogoutInteractor(
                 accountManager = accountManager,
                 userRepository = userRepository,
@@ -192,6 +197,7 @@ class SettingsPresenterTest {
             }
 
             state.isAuthenticated shouldBe false
+            state.activeProvider shouldBe null
             state.labels.traktConnected shouldBe localizer.getString(StringResourceKey.LabelSettingsTraktConnect)
             state.labels.traktConnectedDescription shouldBe
                 localizer.getString(StringResourceKey.SettingsTraktDetailDescription)
@@ -212,6 +218,7 @@ class SettingsPresenterTest {
                 state = awaitItem()
             }
 
+            state.activeProvider shouldBe AccountProvider.TRAKT
             state.labels.traktConnected shouldBe
                 localizer.getString(StringResourceKey.LabelSettingsTraktConnectedAs, "Test User")
             state.labels.traktConnectedDescription shouldBe
@@ -231,5 +238,29 @@ class SettingsPresenterTest {
         testScheduler.advanceUntilIdle()
 
         launched shouldBe true
+    }
+
+    @Test
+    fun `should launch the chosen provider given a non default provider`() = runTest {
+        var traktLaunched = false
+        var simklLaunched = false
+        authManager.setOnLaunchWebView { traktLaunched = true }
+        simklAuthManager.setOnLaunchWebView { simklLaunched = true }
+
+        presenter.dispatch(TraktLoginClicked(AccountProvider.SIMKL))
+        testScheduler.advanceUntilIdle()
+
+        simklLaunched shouldBe true
+        traktLaunched shouldBe false
+    }
+
+    @Test
+    fun `should log out the active provider given logout is clicked`() = runTest {
+        accountManager.setActiveProvider(AccountProvider.SIMKL)
+
+        presenter.dispatch(TraktLogoutClicked)
+        testScheduler.advanceUntilIdle()
+
+        accountManager.lastLogoutProvider shouldBe AccountProvider.SIMKL
     }
 }

--- a/features/settings/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/settings/SettingsPresenterTest.kt
+++ b/features/settings/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/settings/SettingsPresenterTest.kt
@@ -70,7 +70,7 @@ class SettingsPresenterTest {
             errorToStringMapper = ErrorToStringMapper { it.message ?: "Test error" },
             localizer = localizer,
             logger = fakeLogger,
-            authManagers = setOf(authManager),
+            authManagers = mapOf(AccountProvider.TRAKT to authManager),
             logoutInteractor = LogoutInteractor(
                 accountManager = accountManager,
                 userRepository = userRepository,
@@ -227,7 +227,7 @@ class SettingsPresenterTest {
         var launched = false
         authManager.setOnLaunchWebView { launched = true }
 
-        presenter.dispatch(TraktLoginClicked)
+        presenter.dispatch(TraktLoginClicked(AccountProvider.TRAKT))
         testScheduler.advanceUntilIdle()
 
         launched shouldBe true

--- a/features/settings/ui/build.gradle.kts
+++ b/features/settings/ui/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 
     api(libs.androidx.compose.foundation)
     api(libs.androidx.compose.runtime)
+    implementation(projects.data.accountManager.api)
     implementation(projects.androidDesignsystem)
     implementation(projects.core.testTags)
     implementation(projects.core.view)

--- a/features/settings/ui/src/main/kotlin/com/thomaskioko/tvmaniac/settings/ui/components/TraktPage.kt
+++ b/features/settings/ui/src/main/kotlin/com/thomaskioko/tvmaniac/settings/ui/components/TraktPage.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.android.feature.settings.R
 import com.thomaskioko.tvmaniac.compose.components.ThemePreviews
 import com.thomaskioko.tvmaniac.compose.components.TvManiacAlertDialog
@@ -118,7 +119,7 @@ internal fun TraktPage(
                         modifier = Modifier.testTag(SettingsTestTags.TRAKT_ACCOUNT_ROW_TEST_TAG),
                         enabled = !state.isProcessingTraktAuth,
                         onClick = {
-                            onAction(if (state.isAuthenticated) ShowTraktDialog else TraktLoginClicked)
+                            onAction(if (state.isAuthenticated) ShowTraktDialog else TraktLoginClicked(AccountProvider.TRAKT))
                         },
                         colors = ButtonDefaults.buttonColors(
                             containerColor = MaterialTheme.colorScheme.secondary,

--- a/features/show-list/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/showlist/ShowListAction.kt
+++ b/features/show-list/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/showlist/ShowListAction.kt
@@ -1,7 +1,9 @@
 package com.thomaskioko.tvmaniac.presentation.showlist
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+
 public sealed interface ShowListAction {
-    public data object Login : ShowListAction
+    public data class Login(val provider: AccountProvider) : ShowListAction
     public data object ShowCreateListField : ShowListAction
     public data object DismissCreateListField : ShowListAction
     public data class UpdateCreateListName(val name: String) : ShowListAction

--- a/features/show-list/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/showlist/ShowListPresenter.kt
+++ b/features/show-list/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/showlist/ShowListPresenter.kt
@@ -50,7 +50,7 @@ public class ShowListPresenter(
     observeTraktListsInteractor: ObserveTraktListsInteractor,
     private val navigator: Navigator,
     private val accountManager: AccountManager,
-    private val authManagers: Set<AuthManager>,
+    private val authManagers: Map<AccountProvider, AuthManager>,
     private val syncTraktListsInteractor: SyncTraktListsInteractor,
     private val createTraktListInteractor: CreateTraktListInteractor,
     private val toggleShowInListInteractor: ToggleShowInListInteractor,
@@ -103,7 +103,7 @@ public class ShowListPresenter(
 
     public fun dispatch(action: ShowListAction) {
         when (action) {
-            ShowListAction.Login -> authManagers.firstOrNull { it.provider == AccountProvider.TRAKT }?.launchWebView()
+            is ShowListAction.Login -> authManagers[action.provider]?.launchWebView()
             ShowListAction.ShowCreateListField -> createListState.update {
                 it.copy(showField = true, error = null)
             }

--- a/features/show-list/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/showlist/ShowListPresenterTest.kt
+++ b/features/show-list/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/showlist/ShowListPresenterTest.kt
@@ -42,6 +42,7 @@ internal class ShowListPresenterTest {
     private val traktListRepository = FakeTraktListRepository()
     private val accountManager = FakeAccountManager()
     private val authManager = FakeAuthManager()
+    private val simklAuthManager = FakeAuthManager(AccountProvider.SIMKL)
     private val userRepository = FakeUserRepository()
     private val localizer = FakeLocalizer()
     private val logger = FakeLogger()
@@ -199,9 +200,29 @@ internal class ShowListPresenterTest {
             testDispatcher.scheduler.advanceUntilIdle()
             expectMostRecentItem()
 
-            presenter.dispatch(ShowListAction.Login)
+            presenter.dispatch(ShowListAction.Login(AccountProvider.TRAKT))
 
             launchCount shouldBe 1
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `should launch the chosen provider given a non default provider`() = runTest {
+        var traktLaunches = 0
+        var simklLaunches = 0
+        authManager.setOnLaunchWebView { traktLaunches += 1 }
+        simklAuthManager.setOnLaunchWebView { simklLaunches += 1 }
+        val presenter = createPresenter()
+
+        presenter.state.test {
+            testDispatcher.scheduler.advanceUntilIdle()
+            expectMostRecentItem()
+
+            presenter.dispatch(ShowListAction.Login(AccountProvider.SIMKL))
+
+            simklLaunches shouldBe 1
+            traktLaunches shouldBe 0
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -465,7 +486,7 @@ internal class ShowListPresenterTest {
         observeTraktListsInteractor = ObserveTraktListsInteractor(traktListRepository),
         navigator = navigator,
         accountManager = accountManager,
-        authManagers = setOf(authManager),
+        authManagers = mapOf(AccountProvider.TRAKT to authManager, AccountProvider.SIMKL to simklAuthManager),
         syncTraktListsInteractor = SyncTraktListsInteractor(traktListRepository, userRepository),
         createTraktListInteractor = CreateTraktListInteractor(traktListRepository, userRepository),
         toggleShowInListInteractor = ToggleShowInListInteractor(traktListRepository, userRepository),

--- a/features/show-list/ui/build.gradle.kts
+++ b/features/show-list/ui/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     api(projects.navigation.ui)
 
     api(libs.androidx.compose.runtime)
+    implementation(projects.data.accountManager.api)
     implementation(projects.androidDesignsystem)
     implementation(projects.core.testTags)
     implementation(projects.core.view)

--- a/features/show-list/ui/src/main/kotlin/com/thomaskioko/tvmaniac/showlist/ui/ShowListSheetContent.kt
+++ b/features/show-list/ui/src/main/kotlin/com/thomaskioko/tvmaniac/showlist/ui/ShowListSheetContent.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.compose.components.FilledTextButton
 import com.thomaskioko.tvmaniac.compose.components.ThemePreviews
 import com.thomaskioko.tvmaniac.compose.components.TvManiacPreviewWrapperProvider
@@ -273,7 +274,7 @@ private fun LoginRequiredContent(
         Spacer(modifier = Modifier.height(16.dp))
 
         FilledTextButton(
-            onClick = { onAction(ShowListAction.Login) },
+            onClick = { onAction(ShowListAction.Login(AccountProvider.TRAKT)) },
             modifier = Modifier
                 .fillMaxWidth()
                 .testTag(ShowListTestTags.LOGIN_REQUIRED_CONFIRM_BUTTON_TEST_TAG),

--- a/ios-framework/src/iosMain/kotlin/com.thomaskioko.tvmaniac.iosframework/IosApplicationGraph.kt
+++ b/ios-framework/src/iosMain/kotlin/com.thomaskioko.tvmaniac.iosframework/IosApplicationGraph.kt
@@ -1,6 +1,7 @@
 package com.thomaskioko.tvmaniac.iosframework
 
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountAuthRepository
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthClientConfig
 import com.thomaskioko.tvmaniac.appconfig.AppMetadata
 import com.thomaskioko.tvmaniac.appconfig.DebugConfig
@@ -17,8 +18,8 @@ import dev.zacsweers.metro.Provides
 public interface IosApplicationGraph {
     public val initializers: AppInitializers
     public val viewPresenterGraphFactory: IosViewPresenterGraph.Factory
-    public val accountAuthRepositories: Set<AccountAuthRepository>
-    public val authClientConfigs: Set<AuthClientConfig>
+    public val accountAuthRepositories: Map<AccountProvider, AccountAuthRepository>
+    public val authClientConfigs: Map<AccountProvider, AuthClientConfig>
     public val backgroundTaskScheduler: BackgroundTaskScheduler
     public val appMetadata: AppMetadata
     public val debugConfig: DebugConfig

--- a/ios-framework/src/iosMain/kotlin/com.thomaskioko.tvmaniac.iosframework/IosViewPresenterGraph.kt
+++ b/ios-framework/src/iosMain/kotlin/com.thomaskioko.tvmaniac.iosframework/IosViewPresenterGraph.kt
@@ -1,6 +1,7 @@
 package com.thomaskioko.tvmaniac.iosframework
 
 import com.arkivanov.decompose.ComponentContext
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthManager
 import com.thomaskioko.tvmaniac.core.base.ActivityScope
 import com.thomaskioko.tvmaniac.navigation.Navigator
@@ -16,7 +17,7 @@ import dev.zacsweers.metro.SingleIn
 public interface IosViewPresenterGraph {
     public val rootPresenter: RootPresenter
     public val navigator: Navigator
-    public val authManagers: Set<AuthManager>
+    public val authManagers: Map<AccountProvider, AuthManager>
 
     @ContributesTo(AppScope::class)
     @GraphExtension.Factory

--- a/ios/Packages/Profile/Sources/Profile/ProfileTab.swift
+++ b/ios/Packages/Profile/Sources/Profile/ProfileTab.swift
@@ -19,7 +19,7 @@ public struct ProfileTab: View {
         ProfileScreen(
             state: uiState.toState(),
             onSettingsClicked: { presenter.dispatch(action: ProfileActionSettingsClicked()) },
-            onLoginClicked: { presenter.dispatch(action: ProfileActionLoginClicked()) },
+            onLoginClicked: { presenter.dispatch(action: ProfileActionLoginClicked(provider: .trakt)) },
             onViewListsClicked: { presenter.dispatch(action: ProfileActionViewListsClicked()) },
             onRetryLists: { presenter.dispatch(action: ProfileActionRefreshProfile()) },
             onShowClicked: { showId in presenter.dispatch(action: ProfileActionShowClicked(showId: showId)) },

--- a/ios/Packages/Settings/Sources/Settings/SettingsView.swift
+++ b/ios/Packages/Settings/Sources/Settings/SettingsView.swift
@@ -305,7 +305,7 @@ public struct SettingsView: View {
             logoutLabel: uiState.labels.logout,
             loginLabel: uiState.labels.login,
             onLogout: { showingLogoutAlert = true },
-            onLogin: { presenter.dispatch(action: TraktLoginClicked()) }
+            onLogin: { presenter.dispatch(action: TraktLoginClicked(provider: .trakt)) }
         )
     }
 

--- a/ios/Packages/ShowList/Sources/ShowList/ShowListSheetView.swift
+++ b/ios/Packages/ShowList/Sources/ShowList/ShowListSheetView.swift
@@ -200,7 +200,12 @@ public struct ShowListSheetView: View {
                 .textStyle(theme.typography.bodyMedium)
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.appOnSurfaceVariant)
-            Button(action: { presenter.dispatch(action: ShowListActionLogin()) }) {
+
+            Button(
+                action: {
+                    presenter.dispatch(action: ShowListActionLogin(provider: .trakt))
+                }
+            ) {
                 Text(state.labels.loginRequiredConfirmText)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 8)

--- a/ios/Packages/TvManiacKit/Sources/TvManiacKit/AuthCoordinatorRegistry.swift
+++ b/ios/Packages/TvManiacKit/Sources/TvManiacKit/AuthCoordinatorRegistry.swift
@@ -12,13 +12,13 @@ public final class AuthCoordinatorRegistry {
 
     public func register(presenterGraph: IosViewPresenterGraph, appGraph: IosApplicationGraph) {
         guard coordinators.isEmpty else { return }
-        let configs = appGraph.authClientConfigs.compactMap { $0 as? AuthClientConfig }
-        let repositories = appGraph.accountAuthRepositories.compactMap { $0 as? AccountAuthRepository }
+        let configs = appGraph.authClientConfigs
+        let repositories = appGraph.accountAuthRepositories
 
-        coordinators = presenterGraph.authManagers.compactMap { element in
-            guard let manager = element as? AuthManager,
-                  let config = configs.first(where: { $0.provider == manager.provider }),
-                  let repository = repositories.first(where: { $0.provider == manager.provider })
+        coordinators = presenterGraph.authManagers.compactMap { key, value in
+            guard let manager = value as? AuthManager,
+                  let config = configs[key] as? AuthClientConfig,
+                  let repository = repositories[key] as? AccountAuthRepository
             else {
                 return nil
             }


### PR DESCRIPTION
## Description
This PR introduces support for multiple authentication providers (Trakt and Simkl) across the application. It refactors the authentication logic and dependency injection to allow for extensibility and consistent multi-account management in Profile, Settings, and Show List features. #727 

## Changes
- Introduce multi-account provider support for Trakt and Simkl in the presenter layer.
- Refactor dependency injection to use Map multibindings for authentication managers and configurations.
- Update Profile, Settings, and Show List screens to support provider-specific actions.
- Enhance authentication coordination with keyed lookups for platform-specific launchers.
- Update OAuth redirect URIs and improve configuration resolution during the authentication flow.

## Bug Fixes
- Fix an issue where OAuth configuration was not correctly resolved during the AppAuth round-trip on Android.
- Resolve linting issues and update documentation links.