### PR TITLE
chore: Use Multibindings for AccountProviders

### DIFF
--- a/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklProviderFeatures.kt
+++ b/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklProviderFeatures.kt
@@ -1,0 +1,24 @@
+package com.thomaskioko.tvmaniac.simkl.implementation
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProviderKey
+import com.thomaskioko.tvmaniac.accountmanager.api.ProviderFeatures
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoMap
+import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.binding
+
+@SingleIn(AppScope::class)
+@ContributesIntoMap(
+    scope = AppScope::class,
+    binding = binding<
+        @AccountProviderKey(AccountProvider.SIMKL)
+        ProviderFeatures,
+        >(),
+)
+public class SimklProviderFeatures : ProviderFeatures {
+    override val supportsContinueWatchingFetch: Boolean = false
+    override val supportsFavorites: Boolean = false
+    override val supportsLists: Boolean = false
+    override val supportsCalendar: Boolean = false
+}

--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/TraktProviderFeatures.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/TraktProviderFeatures.kt
@@ -1,0 +1,24 @@
+package com.thomaskioko.trakt.service.implementation
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProviderKey
+import com.thomaskioko.tvmaniac.accountmanager.api.ProviderFeatures
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoMap
+import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.binding
+
+@SingleIn(AppScope::class)
+@ContributesIntoMap(
+    scope = AppScope::class,
+    binding = binding<
+        @AccountProviderKey(AccountProvider.TRAKT)
+        ProviderFeatures,
+        >(),
+)
+public class TraktProviderFeatures : ProviderFeatures {
+    override val supportsContinueWatchingFetch: Boolean = true
+    override val supportsFavorites: Boolean = true
+    override val supportsLists: Boolean = true
+    override val supportsCalendar: Boolean = true
+}

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
@@ -61,7 +61,6 @@ internal class Scenarios(
         simkl.stubProfileEndpoints()
         simkl.stubWatchedHistoryEndpoints()
         simkl.stubActivities()
-        stubBackgroundSyncChainEmpty()
     }
 
     fun stubAuthenticatedSimklStartWatching() {
@@ -69,19 +68,6 @@ internal class Scenarios(
         simkl.stubProfileEndpoints()
         simkl.stubPlanToWatchWatchlist()
         simkl.stubActivities()
-        stubBackgroundSyncChainEmpty()
-    }
-
-    /**
-     * Stubs the Trakt endpoints the login-driven Continue Watching sync chain hits (activity +
-     * progress) with empty responses so it runs to completion instead of aborting on the
-     * MockEngine's "no stub" throw before the Simkl watched-history step fills `watched_episodes`.
-     */
-    private fun stubBackgroundSyncChainEmpty() {
-        mockHandler.stubEndpoint(Endpoints.Trakt.SyncLastActivities)
-        mockHandler.stubFixture(path = Endpoints.Trakt.SyncWatchedShows.path, fixturePath = EMPTY_ARRAY_FIXTURE)
-        mockHandler.stubFixture(path = Endpoints.Trakt.SyncPlaybackEpisodes.path, fixturePath = EMPTY_ARRAY_FIXTURE)
-        mockHandler.stubFixture(path = Endpoints.Trakt.UsersHiddenProgressWatched.path, fixturePath = EMPTY_ARRAY_FIXTURE)
     }
 
     fun stubAuthenticatedSync() {

--- a/core/integration/infra/src/jvmMain/kotlin/com/thomaskioko/tvmaniac/testing/di/TestGraph.kt
+++ b/core/integration/infra/src/jvmMain/kotlin/com/thomaskioko/tvmaniac/testing/di/TestGraph.kt
@@ -1,7 +1,6 @@
 package com.thomaskioko.tvmaniac.testing.di
 
 import com.thomaskioko.tvmaniac.core.tasks.api.WorkerFactory
-import com.thomaskioko.tvmaniac.data.user.api.UserRemoteDataSource
 import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
 import com.thomaskioko.tvmaniac.featureflags.FeatureFlag
 import com.thomaskioko.tvmaniac.navigation.NavDestination
@@ -24,7 +23,6 @@ public interface TestGraph {
     public val syncObserver: SyncObserver
     public val workerFactory: WorkerFactory
     public val featureFlags: Set<FeatureFlag<Boolean>>
-    public val userRemoteDataSources: Set<UserRemoteDataSource>
 
     @DependencyGraph.Factory
     public fun interface Factory {

--- a/data/account-manager/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/api/ProviderFeatures.kt
+++ b/data/account-manager/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/api/ProviderFeatures.kt
@@ -1,0 +1,15 @@
+package com.thomaskioko.tvmaniac.accountmanager.api
+
+public interface ProviderFeatures {
+    public val supportsContinueWatchingFetch: Boolean
+    public val supportsFavorites: Boolean
+    public val supportsLists: Boolean
+    public val supportsCalendar: Boolean
+}
+
+public object NoProviderFeatures : ProviderFeatures {
+    override val supportsContinueWatchingFetch: Boolean = false
+    override val supportsFavorites: Boolean = false
+    override val supportsLists: Boolean = false
+    override val supportsCalendar: Boolean = false
+}

--- a/data/account-manager/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/api/ProviderScoped.kt
+++ b/data/account-manager/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/api/ProviderScoped.kt
@@ -1,18 +1,5 @@
 package com.thomaskioko.tvmaniac.accountmanager.api
 
-/**
- * Remote data source bound to a single [AccountProvider].
- *
- * Each backend contributes an implementation into a multibound set; consumers pick the one serving the
- * active account with [getActiveProvider].
- */
 public interface ProviderScoped {
     public val provider: AccountProvider
 }
-
-/**
- * Returns the source serving the active account, or null when no provider is connected or none serves it.
- */
-public fun <T : ProviderScoped> Set<T>.getActiveProvider(
-    accountManager: AccountManager,
-): T? = firstOrNull { it.provider == accountManager.getActiveProvider() }

--- a/data/account-manager/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/implementation/di/ProviderFeaturesMultibindings.kt
+++ b/data/account-manager/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/implementation/di/ProviderFeaturesMultibindings.kt
@@ -1,0 +1,30 @@
+package com.thomaskioko.tvmaniac.accountmanager.implementation.di
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.accountmanager.api.NoProviderFeatures
+import com.thomaskioko.tvmaniac.accountmanager.api.ProviderFeatures
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Multibinds
+import dev.zacsweers.metro.Provides
+
+@ContributesTo(AppScope::class)
+public interface ProviderFeaturesMultibindings {
+
+    @Multibinds(allowEmpty = true)
+    public fun providerFeatures(): Map<AccountProvider, ProviderFeatures>
+}
+
+@BindingContainer
+@ContributesTo(AppScope::class)
+public interface ActiveProviderFeaturesBindingContainer {
+    public companion object {
+        @Provides
+        public fun activeProviderFeatures(
+            features: Map<AccountProvider, ProviderFeatures>,
+            accountManager: AccountManager,
+        ): ProviderFeatures = accountManager.getActiveProvider()?.let { features[it] } ?: NoProviderFeatures
+    }
+}

--- a/data/account-manager/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/implementation/di/ProviderFeaturesMultibindings.kt
+++ b/data/account-manager/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/implementation/di/ProviderFeaturesMultibindings.kt
@@ -19,12 +19,10 @@ public interface ProviderFeaturesMultibindings {
 
 @BindingContainer
 @ContributesTo(AppScope::class)
-public interface ActiveProviderFeaturesBindingContainer {
-    public companion object {
-        @Provides
-        public fun activeProviderFeatures(
-            features: Map<AccountProvider, ProviderFeatures>,
-            accountManager: AccountManager,
-        ): ProviderFeatures = accountManager.getActiveProvider()?.let { features[it] } ?: NoProviderFeatures
-    }
+public object ActiveProviderFeaturesBindingContainer {
+    @Provides
+    public fun activeProviderFeatures(
+        features: Map<AccountProvider, ProviderFeatures>,
+        accountManager: AccountManager,
+    ): ProviderFeatures = accountManager.getActiveProvider()?.let { features[it] } ?: NoProviderFeatures
 }

--- a/data/account-manager/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/accountmanager/implementation/ActiveProviderFeaturesProviderTest.kt
+++ b/data/account-manager/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/accountmanager/implementation/ActiveProviderFeaturesProviderTest.kt
@@ -1,0 +1,84 @@
+package com.thomaskioko.tvmaniac.accountmanager.implementation
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.accountmanager.api.NoProviderFeatures
+import com.thomaskioko.tvmaniac.accountmanager.implementation.di.ActiveProviderFeaturesBindingContainer
+import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
+import com.thomaskioko.tvmaniac.accountmanager.testing.FakeProviderFeatures
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class ActiveProviderFeaturesProviderTest {
+
+    private val traktFeatures = FakeProviderFeatures(
+        supportsContinueWatchingFetch = true,
+        supportsFavorites = true,
+        supportsLists = true,
+        supportsCalendar = true,
+    )
+    private val simklFeatures = FakeProviderFeatures(
+        supportsContinueWatchingFetch = false,
+        supportsFavorites = false,
+        supportsLists = false,
+        supportsCalendar = false,
+    )
+    private val featuresMap = mapOf(
+        AccountProvider.TRAKT to traktFeatures,
+        AccountProvider.SIMKL to simklFeatures,
+    )
+    private val accountManager = FakeAccountManager()
+
+    @Test
+    fun `should return trakt features given trakt is the active provider`() {
+        accountManager.setActiveProvider(AccountProvider.TRAKT)
+
+        val result = ActiveProviderFeaturesBindingContainer.activeProviderFeatures(
+            features = featuresMap,
+            accountManager = accountManager,
+        )
+
+        result.supportsContinueWatchingFetch shouldBe true
+        result.supportsFavorites shouldBe true
+        result.supportsLists shouldBe true
+        result.supportsCalendar shouldBe true
+    }
+
+    @Test
+    fun `should return simkl features given simkl is the active provider`() {
+        accountManager.setActiveProvider(AccountProvider.SIMKL)
+
+        val result = ActiveProviderFeaturesBindingContainer.activeProviderFeatures(
+            features = featuresMap,
+            accountManager = accountManager,
+        )
+
+        result.supportsContinueWatchingFetch shouldBe false
+        result.supportsFavorites shouldBe false
+        result.supportsLists shouldBe false
+        result.supportsCalendar shouldBe false
+    }
+
+    @Test
+    fun `should return NoProviderFeatures given no active provider`() {
+        accountManager.setActiveProvider(null)
+
+        val result = ActiveProviderFeaturesBindingContainer.activeProviderFeatures(
+            features = featuresMap,
+            accountManager = accountManager,
+        )
+
+        result shouldBe NoProviderFeatures
+    }
+
+    @Test
+    fun `should return NoProviderFeatures given active provider not in features map`() {
+        accountManager.setActiveProvider(AccountProvider.TRAKT)
+
+        val result = ActiveProviderFeaturesBindingContainer.activeProviderFeatures(
+            features = emptyMap(),
+            accountManager = accountManager,
+        )
+
+        result shouldBe NoProviderFeatures
+    }
+}

--- a/data/account-manager/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/testing/FakeProviderFeatures.kt
+++ b/data/account-manager/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/testing/FakeProviderFeatures.kt
@@ -1,0 +1,10 @@
+package com.thomaskioko.tvmaniac.accountmanager.testing
+
+import com.thomaskioko.tvmaniac.accountmanager.api.ProviderFeatures
+
+public class FakeProviderFeatures(
+    override val supportsContinueWatchingFetch: Boolean = false,
+    override val supportsFavorites: Boolean = false,
+    override val supportsLists: Boolean = false,
+    override val supportsCalendar: Boolean = false,
+) : ProviderFeatures

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepository.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepository.kt
@@ -1,7 +1,6 @@
 package com.thomaskioko.tvmaniac.episodes.implementation
 
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
-import com.thomaskioko.tvmaniac.accountmanager.api.getActiveProvider
 import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
 import com.thomaskioko.tvmaniac.episodes.api.EpisodeWatchesDataSource
@@ -31,7 +30,7 @@ import kotlin.time.Instant.Companion.fromEpochMilliseconds
 public class DefaultWatchedEpisodeSyncRepository(
     private val dao: WatchedEpisodeDao,
     private val episodesDao: EpisodesDao,
-    private val sources: Set<EpisodeWatchesDataSource>,
+    private val activeSource: () -> EpisodeWatchesDataSource?,
     private val accountManager: AccountManager,
     private val datastoreRepository: DatastoreRepository,
     private val lastRequestStore: EpisodeWatchesLastRequestStore,
@@ -42,9 +41,6 @@ public class DefaultWatchedEpisodeSyncRepository(
 ) : WatchedEpisodeSyncRepository {
 
     private val syncMutex = Mutex()
-
-    private fun activeSource(): EpisodeWatchesDataSource? =
-        sources.getActiveProvider(accountManager)
 
     override suspend fun syncPendingEpisodes() {
         if (accountManager.getActiveProvider() == null) return

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/di/EpisodeWatchesMultibindings.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/di/EpisodeWatchesMultibindings.kt
@@ -1,0 +1,28 @@
+package com.thomaskioko.tvmaniac.episodes.implementation.di
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
+import com.thomaskioko.tvmaniac.episodes.api.EpisodeWatchesDataSource
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Multibinds
+import dev.zacsweers.metro.Provides
+
+@ContributesTo(AppScope::class)
+public interface EpisodeWatchesMultibindings {
+
+    @Multibinds(allowEmpty = true)
+    public fun episodeWatchesDataSources(): Set<EpisodeWatchesDataSource>
+}
+
+@BindingContainer
+@ContributesTo(AppScope::class)
+public interface ActiveEpisodeWatchesDataSourceBindingContainer {
+    public companion object {
+        @Provides
+        public fun activeEpisodeWatchesDataSource(
+            sources: Set<EpisodeWatchesDataSource>,
+            accountManager: AccountManager,
+        ): EpisodeWatchesDataSource? = sources.firstOrNull { it.provider == accountManager.getActiveProvider() }
+    }
+}

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/di/EpisodeWatchesMultibindings.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/di/EpisodeWatchesMultibindings.kt
@@ -17,12 +17,10 @@ public interface EpisodeWatchesMultibindings {
 
 @BindingContainer
 @ContributesTo(AppScope::class)
-public interface ActiveEpisodeWatchesDataSourceBindingContainer {
-    public companion object {
-        @Provides
-        public fun activeEpisodeWatchesDataSource(
-            sources: Set<EpisodeWatchesDataSource>,
-            accountManager: AccountManager,
-        ): EpisodeWatchesDataSource? = sources.firstOrNull { it.provider == accountManager.getActiveProvider() }
-    }
+public object ActiveEpisodeWatchesDataSourceBindingContainer {
+    @Provides
+    public fun activeEpisodeWatchesDataSource(
+        sources: Set<EpisodeWatchesDataSource>,
+        accountManager: AccountManager,
+    ): EpisodeWatchesDataSource? = sources.firstOrNull { it.provider == accountManager.getActiveProvider() }
 }

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepositoryTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepositoryTest.kt
@@ -71,7 +71,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
         defaultWatchedEpisodeSyncRepository = DefaultWatchedEpisodeSyncRepository(
             dao = dao,
             episodesDao = DefaultEpisodesDao(database, showIdResolver, dispatchers, fakeDateTimeProvider),
-            sources = setOf(recordingDataSource),
+            activeSource = { recordingDataSource.takeIf { it.provider == accountManager.getActiveProvider() } },
             accountManager = accountManager,
             datastoreRepository = datastoreRepository,
             lastRequestStore = EpisodeWatchesLastRequestStore(requestManagerRepository),
@@ -323,7 +323,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
         val simklRepository = DefaultWatchedEpisodeSyncRepository(
             dao = dao,
             episodesDao = DefaultEpisodesDao(database, showIdResolver, dispatchers, fakeDateTimeProvider),
-            sources = setOf(simklSource),
+            activeSource = { simklSource.takeIf { it.provider == accountManager.getActiveProvider() } },
             accountManager = accountManager,
             datastoreRepository = datastoreRepository,
             lastRequestStore = EpisodeWatchesLastRequestStore(requestManagerRepository),

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepositoryTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepositoryTest.kt
@@ -71,7 +71,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
         defaultWatchedEpisodeSyncRepository = DefaultWatchedEpisodeSyncRepository(
             dao = dao,
             episodesDao = DefaultEpisodesDao(database, showIdResolver, dispatchers, fakeDateTimeProvider),
-            activeSource = { recordingDataSource.takeIf { it.provider == accountManager.getActiveProvider() } },
+            activeSource = { recordingDataSource },
             accountManager = accountManager,
             datastoreRepository = datastoreRepository,
             lastRequestStore = EpisodeWatchesLastRequestStore(requestManagerRepository),
@@ -323,7 +323,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
         val simklRepository = DefaultWatchedEpisodeSyncRepository(
             dao = dao,
             episodesDao = DefaultEpisodesDao(database, showIdResolver, dispatchers, fakeDateTimeProvider),
-            activeSource = { simklSource.takeIf { it.provider == accountManager.getActiveProvider() } },
+            activeSource = { simklSource },
             accountManager = accountManager,
             datastoreRepository = datastoreRepository,
             lastRequestStore = EpisodeWatchesLastRequestStore(requestManagerRepository),

--- a/data/favorites/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/favorites/implementation/DefaultFavoritesRepository.kt
+++ b/data/favorites/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/favorites/implementation/DefaultFavoritesRepository.kt
@@ -1,7 +1,6 @@
 package com.thomaskioko.tvmaniac.favorites.implementation
 
-import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
-import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.accountmanager.api.ProviderFeatures
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.fresh
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.get
 import com.thomaskioko.tvmaniac.favorites.api.FavoriteShow
@@ -17,14 +16,13 @@ import kotlinx.coroutines.flow.Flow
 public class DefaultFavoritesRepository(
     private val dao: FavoritesDao,
     private val favoritesStore: FavoritesStore,
-    private val accountManager: AccountManager,
+    private val activeProviderFeatures: () -> ProviderFeatures,
 ) : FavoritesRepository {
 
     override fun observeFavorites(): Flow<List<FavoriteShow>> = dao.observeFavoriteShows()
 
     override suspend fun syncFavorites(forceRefresh: Boolean) {
-        // TODO:: Remove hardcoded provider
-        if (accountManager.getActiveProvider() != AccountProvider.TRAKT) return
+        if (!activeProviderFeatures().supportsFavorites) return
 
         when {
             forceRefresh -> favoritesStore.fresh(Unit)

--- a/data/favorites/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/favorites/implementation/DefaultFavoritesRepositoryGuardTest.kt
+++ b/data/favorites/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/favorites/implementation/DefaultFavoritesRepositoryGuardTest.kt
@@ -1,7 +1,6 @@
 package com.thomaskioko.tvmaniac.favorites.implementation
 
-import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
-import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
+import com.thomaskioko.tvmaniac.accountmanager.testing.FakeProviderFeatures
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.database.test.BaseDatabaseTest
@@ -47,7 +46,6 @@ internal class DefaultFavoritesRepositoryGuardTest : BaseDatabaseTest() {
         databaseWrite = testDispatcher,
         databaseRead = testDispatcher,
     )
-    private val accountManager = FakeAccountManager()
     private val requestManager = FakeRequestManagerRepository(initialRequestValid = false)
     private val trackingTraktSource = TrackingTraktSource()
 
@@ -56,6 +54,9 @@ internal class DefaultFavoritesRepositoryGuardTest : BaseDatabaseTest() {
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+    }
+
+    private fun buildRepository(activeProviderFeatures: () -> FakeProviderFeatures): DefaultFavoritesRepository {
         val favoritesStore = FavoritesStore(
             traktUserDataSource = trackingTraktSource,
             tmdbDataSource = NoOpTmdbDataSource,
@@ -66,10 +67,10 @@ internal class DefaultFavoritesRepositoryGuardTest : BaseDatabaseTest() {
             formatterUtil = FakeFormatterUtil(),
             dispatchers = dispatchers,
         )
-        repository = DefaultFavoritesRepository(
+        return DefaultFavoritesRepository(
             dao = NoOpFavDao,
             favoritesStore = favoritesStore,
-            accountManager = accountManager,
+            activeProviderFeatures = activeProviderFeatures,
         )
     }
 
@@ -81,7 +82,7 @@ internal class DefaultFavoritesRepositoryGuardTest : BaseDatabaseTest() {
 
     @Test
     fun `should skip network fetch given no provider is active`() = runTest(testDispatcher) {
-        accountManager.setActiveProvider(null)
+        repository = buildRepository { FakeProviderFeatures(supportsFavorites = false) }
 
         repository.syncFavorites(forceRefresh = false)
 
@@ -90,7 +91,7 @@ internal class DefaultFavoritesRepositoryGuardTest : BaseDatabaseTest() {
 
     @Test
     fun `should skip network fetch given simkl provider is active`() = runTest(testDispatcher) {
-        accountManager.setActiveProvider(AccountProvider.SIMKL)
+        repository = buildRepository { FakeProviderFeatures(supportsFavorites = false) }
 
         repository.syncFavorites(forceRefresh = false)
 

--- a/data/library/implementation/build.gradle.kts
+++ b/data/library/implementation/build.gradle.kts
@@ -38,7 +38,6 @@ kotlin {
                 implementation(projects.api.tmdb.testing)
                 implementation(projects.core.logger.testing)
                 implementation(projects.core.util.testing)
-                implementation(projects.data.accountManager.testing)
                 implementation(projects.data.database.testing)
                 implementation(projects.data.followedshows.implementation)
                 implementation(projects.data.requestManager.testing)

--- a/data/library/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/DefaultLibraryRepository.kt
+++ b/data/library/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/DefaultLibraryRepository.kt
@@ -1,7 +1,6 @@
 package com.thomaskioko.tvmaniac.data.library.implementation
 
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
-import com.thomaskioko.tvmaniac.accountmanager.api.getActiveProvider
 import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.fresh
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.get
@@ -50,7 +49,7 @@ public class DefaultLibraryRepository(
     private val libraryStore: LibraryStore,
     private val datastoreRepository: DatastoreRepository,
     private val followedShowsDao: FollowedShowsDao,
-    private val sources: Set<LibraryRemoteDataSource>,
+    private val activeSource: () -> LibraryRemoteDataSource?,
     private val accountManager: AccountManager,
     private val requestManagerRepository: RequestManagerRepository,
     private val transactionRunner: DatabaseTransactionRunner,
@@ -183,9 +182,6 @@ public class DefaultLibraryRepository(
             requestType = LIBRARY_SYNC.name,
             threshold = expiry,
         )
-
-    private fun activeSource(): LibraryRemoteDataSource? =
-        sources.getActiveProvider(accountManager)
 
     private suspend fun processPendingUploadActions(): PendingActionOutcome {
         val pendingUploads = followedShowsDao.entriesWithUploadPendingAction()

--- a/data/library/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/LibraryStore.kt
+++ b/data/library/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/LibraryStore.kt
@@ -1,7 +1,5 @@
 package com.thomaskioko.tvmaniac.data.library.implementation
 
-import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
-import com.thomaskioko.tvmaniac.accountmanager.api.getActiveProvider
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.storeBuilder
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.usingDispatchers
@@ -42,8 +40,7 @@ import org.mobilenativefoundation.store.store5.Validator
 @Inject
 @SingleIn(AppScope::class)
 public class LibraryStore(
-    private val sources: Set<LibraryRemoteDataSource>,
-    private val accountManager: AccountManager,
+    private val activeSource: () -> LibraryRemoteDataSource?,
     private val tmdbDataSource: TmdbShowDetailsNetworkDataSource,
     private val followedShowsDao: FollowedShowsDao,
     private val tvShowsDao: TvShowsDao,
@@ -56,7 +53,7 @@ public class LibraryStore(
 ) : Store<LibrarySortOption, List<FollowedShowEntry>> by storeBuilder(
     fetcher = Fetcher.of { _: LibrarySortOption ->
         coroutineScope {
-            val source = sources.getActiveProvider(accountManager)
+            val source = activeSource()
                 ?: throw AuthenticationException("No active sync provider")
             source.getWatchlist()
                 .getOrThrow()

--- a/data/library/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/di/LibraryMultibindings.kt
+++ b/data/library/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/di/LibraryMultibindings.kt
@@ -1,13 +1,28 @@
 package com.thomaskioko.tvmaniac.data.library.implementation.di
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
 import com.thomaskioko.tvmaniac.data.library.LibraryRemoteDataSource
 import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Multibinds
+import dev.zacsweers.metro.Provides
 
 @ContributesTo(AppScope::class)
 public interface LibraryMultibindings {
 
     @Multibinds(allowEmpty = true)
     public fun libraryRemoteDataSources(): Set<LibraryRemoteDataSource>
+}
+
+@BindingContainer
+@ContributesTo(AppScope::class)
+public interface ActiveLibraryRemoteDataSourceBindingContainer {
+    public companion object {
+        @Provides
+        public fun activeLibraryRemoteDataSource(
+            sources: Set<LibraryRemoteDataSource>,
+            accountManager: AccountManager,
+        ): LibraryRemoteDataSource? = sources.firstOrNull { it.provider == accountManager.getActiveProvider() }
+    }
 }

--- a/data/library/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/di/LibraryMultibindings.kt
+++ b/data/library/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/di/LibraryMultibindings.kt
@@ -17,12 +17,10 @@ public interface LibraryMultibindings {
 
 @BindingContainer
 @ContributesTo(AppScope::class)
-public interface ActiveLibraryRemoteDataSourceBindingContainer {
-    public companion object {
-        @Provides
-        public fun activeLibraryRemoteDataSource(
-            sources: Set<LibraryRemoteDataSource>,
-            accountManager: AccountManager,
-        ): LibraryRemoteDataSource? = sources.firstOrNull { it.provider == accountManager.getActiveProvider() }
-    }
+public object ActiveLibraryRemoteDataSourceBindingContainer {
+    @Provides
+    public fun activeLibraryRemoteDataSource(
+        sources: Set<LibraryRemoteDataSource>,
+        accountManager: AccountManager,
+    ): LibraryRemoteDataSource? = sources.firstOrNull { it.provider == accountManager.getActiveProvider() }
 }

--- a/data/library/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/LibraryStoreTest.kt
+++ b/data/library/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/LibraryStoreTest.kt
@@ -2,10 +2,10 @@ package com.thomaskioko.tvmaniac.data.library.implementation
 
 import app.cash.turbine.test
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
-import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.logger.fixture.FakeLogger
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.data.library.LibraryRemoteDataSource
 import com.thomaskioko.tvmaniac.data.library.model.LibrarySortOption
 import com.thomaskioko.tvmaniac.data.library.model.RemoteFollowedShow
 import com.thomaskioko.tvmaniac.database.test.BaseDatabaseTest
@@ -54,7 +54,6 @@ internal class LibraryStoreTest : BaseDatabaseTest() {
         databaseRead = testDispatcher,
     )
 
-    private val accountManager = FakeAccountManager()
     private val fakeRequestManager = FakeRequestManagerRepository(initialRequestValid = false)
     private val fakeActivitySync = FakeActivitySyncRepository()
     private val fakeTmdbDetailsSource = FakeTmdbShowDetailsNetworkDataSource()
@@ -68,8 +67,6 @@ internal class LibraryStoreTest : BaseDatabaseTest() {
     private val traktSource = FakeLibrarySource(provider = AccountProvider.TRAKT)
     private val simklSource = FakeLibrarySource(provider = AccountProvider.SIMKL)
     private val transactionRunner = ImmediateTransactionRunner()
-
-    private lateinit var store: LibraryStore
 
     @BeforeTest
     fun setUp() {
@@ -85,19 +82,20 @@ internal class LibraryStoreTest : BaseDatabaseTest() {
             database = database,
             logger = FakeLogger(),
         )
-        store = LibraryStore(
-            activeSource = { setOf(traktSource, simklSource).firstOrNull { it.provider == accountManager.getActiveProvider() } },
-            tmdbDataSource = fakeTmdbDetailsSource,
-            followedShowsDao = followedShowsDao,
-            tvShowsDao = tvShowsDao,
-            requestManagerRepository = fakeRequestManager,
-            syncRepository = fakeActivitySync,
-            transactionRunner = transactionRunner,
-            showReconciler = showReconciler,
-            formatterUtil = fakeFormatterUtil,
-            dispatchers = dispatchers,
-        )
     }
+
+    private fun buildStore(activeSource: () -> LibraryRemoteDataSource?): LibraryStore = LibraryStore(
+        activeSource = activeSource,
+        tmdbDataSource = fakeTmdbDetailsSource,
+        followedShowsDao = followedShowsDao,
+        tvShowsDao = tvShowsDao,
+        requestManagerRepository = fakeRequestManager,
+        syncRepository = fakeActivitySync,
+        transactionRunner = transactionRunner,
+        showReconciler = showReconciler,
+        formatterUtil = fakeFormatterUtil,
+        dispatchers = dispatchers,
+    )
 
     @AfterTest
     fun tearDown() {
@@ -107,7 +105,7 @@ internal class LibraryStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should write followed shows and trakt external id given trakt watchlist show with tmdb id`() = runTest(testDispatcher) {
-        accountManager.setActiveProvider(AccountProvider.TRAKT)
+        val store = buildStore { traktSource }
         traktSource.setWatchlist(
             listOf(
                 RemoteFollowedShow(
@@ -156,7 +154,7 @@ internal class LibraryStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should write followed shows and simkl external id given simkl show resolved via imdb id`() = runTest(testDispatcher) {
-        accountManager.setActiveProvider(AccountProvider.SIMKL)
+        val store = buildStore { simklSource }
         fakeTmdbShowsSource.setFindShowByExternalId(ApiResponse.Success(TMDB_ID))
         simklSource.setWatchlist(
             listOf(
@@ -211,7 +209,7 @@ internal class LibraryStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should skip show given no tmdb id and imdb lookup returns null`() = runTest(testDispatcher) {
-        accountManager.setActiveProvider(AccountProvider.SIMKL)
+        val store = buildStore { simklSource }
         fakeTmdbShowsSource.setFindShowByExternalId(ApiResponse.Success(null))
         simklSource.setWatchlist(
             listOf(
@@ -242,7 +240,7 @@ internal class LibraryStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should not attach trakt external id given simkl show resolved via tmdb id`() = runTest(testDispatcher) {
-        accountManager.setActiveProvider(AccountProvider.SIMKL)
+        val store = buildStore { simklSource }
         simklSource.setWatchlist(
             listOf(
                 RemoteFollowedShow(
@@ -305,7 +303,7 @@ private class ImmediateTransactionRunner : DatabaseTransactionRunner {
 
 private class FakeLibrarySource(
     override val provider: AccountProvider,
-) : com.thomaskioko.tvmaniac.data.library.LibraryRemoteDataSource {
+) : LibraryRemoteDataSource {
 
     private var watchlistShows: List<RemoteFollowedShow> = emptyList()
 

--- a/data/library/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/LibraryStoreTest.kt
+++ b/data/library/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/LibraryStoreTest.kt
@@ -86,8 +86,7 @@ internal class LibraryStoreTest : BaseDatabaseTest() {
             logger = FakeLogger(),
         )
         store = LibraryStore(
-            sources = setOf(traktSource, simklSource),
-            accountManager = accountManager,
+            activeSource = { setOf(traktSource, simklSource).firstOrNull { it.provider == accountManager.getActiveProvider() } },
             tmdbDataSource = fakeTmdbDetailsSource,
             followedShowsDao = followedShowsDao,
             tvShowsDao = tvShowsDao,

--- a/data/sync-activity/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/syncactivity/implementation/TraktActivityStore.kt
+++ b/data/sync-activity/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/syncactivity/implementation/TraktActivityStore.kt
@@ -1,7 +1,5 @@
 package com.thomaskioko.tvmaniac.syncactivity.implementation
 
-import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
-import com.thomaskioko.tvmaniac.accountmanager.api.getActiveProvider
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.apiFetcher
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.storeBuilder
@@ -26,16 +24,14 @@ import kotlin.time.Instant
 @Inject
 @SingleIn(AppScope::class)
 public class TraktActivityStore(
-    private val sources: Set<RemoteActivitySource>,
-    private val accountManager: AccountManager,
+    private val activeSource: () -> RemoteActivitySource?,
     private val activityDao: TraktActivityDao,
     private val requestManagerRepository: RequestManagerRepository,
     private val dispatchers: AppCoroutineDispatchers,
     private val dateTimeProvider: DateTimeProvider,
 ) : Store<Unit, List<TraktLastActivity>> by storeBuilder(
     fetcher = apiFetcher {
-        val source = sources.getActiveProvider(accountManager)
-        source?.getLastActivities() ?: ApiResponse.Unauthenticated
+        activeSource()?.getLastActivities() ?: ApiResponse.Unauthenticated
     },
     sourceOfTruth = SourceOfTruth.of(
         reader = { _: Unit -> activityDao.observeAll() },

--- a/data/sync-activity/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/syncactivity/implementation/di/SyncActivityMultibindings.kt
+++ b/data/sync-activity/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/syncactivity/implementation/di/SyncActivityMultibindings.kt
@@ -1,13 +1,28 @@
 package com.thomaskioko.tvmaniac.syncactivity.implementation.di
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
 import com.thomaskioko.tvmaniac.syncactivity.api.RemoteActivitySource
 import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Multibinds
+import dev.zacsweers.metro.Provides
 
 @ContributesTo(AppScope::class)
 public interface SyncActivityMultibindings {
 
     @Multibinds(allowEmpty = true)
     public fun remoteActivitySources(): Set<RemoteActivitySource>
+}
+
+@BindingContainer
+@ContributesTo(AppScope::class)
+public interface ActiveRemoteActivitySourceBindingContainer {
+    public companion object {
+        @Provides
+        public fun activeRemoteActivitySource(
+            sources: Set<RemoteActivitySource>,
+            accountManager: AccountManager,
+        ): RemoteActivitySource? = sources.firstOrNull { it.provider == accountManager.getActiveProvider() }
+    }
 }

--- a/data/sync-activity/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/syncactivity/implementation/di/SyncActivityMultibindings.kt
+++ b/data/sync-activity/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/syncactivity/implementation/di/SyncActivityMultibindings.kt
@@ -17,12 +17,10 @@ public interface SyncActivityMultibindings {
 
 @BindingContainer
 @ContributesTo(AppScope::class)
-public interface ActiveRemoteActivitySourceBindingContainer {
-    public companion object {
-        @Provides
-        public fun activeRemoteActivitySource(
-            sources: Set<RemoteActivitySource>,
-            accountManager: AccountManager,
-        ): RemoteActivitySource? = sources.firstOrNull { it.provider == accountManager.getActiveProvider() }
-    }
+public object ActiveRemoteActivitySourceBindingContainer {
+    @Provides
+    public fun activeRemoteActivitySource(
+        sources: Set<RemoteActivitySource>,
+        accountManager: AccountManager,
+    ): RemoteActivitySource? = sources.firstOrNull { it.provider == accountManager.getActiveProvider() }
 }

--- a/data/user/implementation/build.gradle.kts
+++ b/data/user/implementation/build.gradle.kts
@@ -28,7 +28,6 @@ kotlin {
             dependencies {
                 implementation(libs.bundles.unittest)
                 implementation(projects.core.util.testing)
-                implementation(projects.data.accountManager.testing)
                 implementation(projects.data.database.testing)
                 implementation(projects.data.requestManager.testing)
             }

--- a/data/user/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/UserStatsStore.kt
+++ b/data/user/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/UserStatsStore.kt
@@ -1,7 +1,5 @@
 package com.thomaskioko.tvmaniac.data.user.implementation
 
-import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
-import com.thomaskioko.tvmaniac.accountmanager.api.getActiveProvider
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.storeBuilder
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.usingDispatchers
@@ -25,14 +23,13 @@ import org.mobilenativefoundation.store.store5.Validator
 
 @Inject
 public class UserStatsStore(
-    private val sources: Set<UserRemoteDataSource>,
-    private val accountManager: AccountManager,
+    private val activeSource: () -> UserRemoteDataSource?,
     private val userStatsDao: UserStatsDao,
     private val requestManagerRepository: RequestManagerRepository,
     private val dispatchers: AppCoroutineDispatchers,
 ) : Store<String, UserProfileStats> by storeBuilder(
     fetcher = Fetcher.ofResult { slug: String ->
-        when (val response = sources.getActiveProvider(accountManager)?.getUserStats(slug) ?: ApiResponse.Unauthenticated) {
+        when (val response = activeSource()?.getUserStats(slug) ?: ApiResponse.Unauthenticated) {
             is ApiResponse.Success -> when (val body = response.body) {
                 null -> FetcherResult.Error.Exception(AuthenticationException("Provider does not support user stats"))
                 else -> FetcherResult.Data(body)

--- a/data/user/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/UserStore.kt
+++ b/data/user/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/UserStore.kt
@@ -1,7 +1,5 @@
 package com.thomaskioko.tvmaniac.data.user.implementation
 
-import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
-import com.thomaskioko.tvmaniac.accountmanager.api.getActiveProvider
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.apiFetcher
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.storeBuilder
@@ -21,14 +19,13 @@ import org.mobilenativefoundation.store.store5.Validator
 
 @Inject
 public class UserStore(
-    private val sources: Set<UserRemoteDataSource>,
-    private val accountManager: AccountManager,
+    private val activeSource: () -> UserRemoteDataSource?,
     private val userDao: UserDao,
     private val requestManagerRepository: RequestManagerRepository,
     private val dispatchers: AppCoroutineDispatchers,
 ) : Store<String, User> by storeBuilder(
     fetcher = apiFetcher { slug ->
-        sources.getActiveProvider(accountManager)?.getUserProfile(slug)
+        activeSource()?.getUserProfile(slug)
             ?: ApiResponse.Unauthenticated
     },
     sourceOfTruth = SourceOfTruth.of<String, RemoteUserProfile, User>(

--- a/data/user/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/di/UserMultibindings.kt
+++ b/data/user/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/di/UserMultibindings.kt
@@ -1,0 +1,28 @@
+package com.thomaskioko.tvmaniac.data.user.implementation.di
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
+import com.thomaskioko.tvmaniac.data.user.api.UserRemoteDataSource
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Multibinds
+import dev.zacsweers.metro.Provides
+
+@ContributesTo(AppScope::class)
+public interface UserMultibindings {
+
+    @Multibinds(allowEmpty = true)
+    public fun userRemoteDataSources(): Set<UserRemoteDataSource>
+}
+
+@BindingContainer
+@ContributesTo(AppScope::class)
+public interface ActiveUserRemoteDataSourceBindingContainer {
+    public companion object {
+        @Provides
+        public fun activeUserRemoteDataSource(
+            sources: Set<UserRemoteDataSource>,
+            accountManager: AccountManager,
+        ): UserRemoteDataSource? = sources.firstOrNull { it.provider == accountManager.getActiveProvider() }
+    }
+}

--- a/data/user/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/di/UserMultibindings.kt
+++ b/data/user/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/di/UserMultibindings.kt
@@ -17,12 +17,10 @@ public interface UserMultibindings {
 
 @BindingContainer
 @ContributesTo(AppScope::class)
-public interface ActiveUserRemoteDataSourceBindingContainer {
-    public companion object {
-        @Provides
-        public fun activeUserRemoteDataSource(
-            sources: Set<UserRemoteDataSource>,
-            accountManager: AccountManager,
-        ): UserRemoteDataSource? = sources.firstOrNull { it.provider == accountManager.getActiveProvider() }
-    }
+public object ActiveUserRemoteDataSourceBindingContainer {
+    @Provides
+    public fun activeUserRemoteDataSource(
+        sources: Set<UserRemoteDataSource>,
+        accountManager: AccountManager,
+    ): UserRemoteDataSource? = sources.firstOrNull { it.provider == accountManager.getActiveProvider() }
 }

--- a/data/user/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/UserStatsStoreTest.kt
+++ b/data/user/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/UserStatsStoreTest.kt
@@ -2,7 +2,6 @@ package com.thomaskioko.tvmaniac.data.user.implementation
 
 import app.cash.turbine.test
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
-import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.data.user.api.UserRemoteDataSource
@@ -38,15 +37,12 @@ internal class UserStatsStoreTest : BaseDatabaseTest() {
     )
 
     private lateinit var userStatsDao: DefaultUserStatsDao
-    private lateinit var accountManager: FakeAccountManager
     private lateinit var requestManager: FakeRequestManagerRepository
     private lateinit var traktSource: FakeStatsSource
-    private lateinit var store: UserStatsStore
 
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
-        accountManager = FakeAccountManager()
         requestManager = FakeRequestManagerRepository(initialRequestValid = false)
         userStatsDao = DefaultUserStatsDao(
             database = database,
@@ -54,10 +50,6 @@ internal class UserStatsStoreTest : BaseDatabaseTest() {
             dispatchers = dispatchers,
         )
         traktSource = FakeStatsSource(provider = AccountProvider.TRAKT)
-        store = buildStore(
-            sources = setOf(traktSource),
-            accountManager = accountManager,
-        )
     }
 
     @AfterTest
@@ -68,7 +60,7 @@ internal class UserStatsStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should persist stats given active provider returns non-null stats`() = runTest(testDispatcher) {
-        accountManager.setActiveProvider(AccountProvider.TRAKT)
+        val store = buildStore { traktSource }
         traktSource.statsResponse = ApiResponse.Success(
             RemoteUserStats(
                 showsWatched = 42L,
@@ -94,7 +86,7 @@ internal class UserStatsStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should not write to dao given provider returns null stats`() = runTest(testDispatcher) {
-        accountManager.setActiveProvider(AccountProvider.TRAKT)
+        val store = buildStore { traktSource }
         traktSource.statsResponse = ApiResponse.Success(null)
 
         store.stream(StoreReadRequest.fresh("test-user")).test {
@@ -110,7 +102,7 @@ internal class UserStatsStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should not write to dao given no active provider`() = runTest(testDispatcher) {
-        accountManager.setActiveProvider(null)
+        val store = buildStore { null }
 
         store.stream(StoreReadRequest.fresh("test-user")).test {
             awaitItem()
@@ -133,11 +125,7 @@ internal class UserStatsStoreTest : BaseDatabaseTest() {
                 minutesWatched = 3000L,
             ),
         )
-        val multiStore = buildStore(
-            sources = setOf(traktSource, simklSource),
-            accountManager = accountManager,
-        )
-        accountManager.setActiveProvider(AccountProvider.SIMKL)
+        val multiStore = buildStore { simklSource }
 
         multiStore.stream(StoreReadRequest.fresh("test-user")).test {
             awaitItem()
@@ -157,11 +145,7 @@ internal class UserStatsStoreTest : BaseDatabaseTest() {
     fun `should not write stats given simkl source returns null stats`() = runTest(testDispatcher) {
         val simklSource = FakeStatsSource(provider = AccountProvider.SIMKL)
         simklSource.statsResponse = ApiResponse.Success(null)
-        val multiStore = buildStore(
-            sources = setOf(traktSource, simklSource),
-            accountManager = accountManager,
-        )
-        accountManager.setActiveProvider(AccountProvider.SIMKL)
+        val multiStore = buildStore { simklSource }
 
         multiStore.stream(StoreReadRequest.fresh("test-user")).test {
             awaitItem()
@@ -174,11 +158,8 @@ internal class UserStatsStoreTest : BaseDatabaseTest() {
         }
     }
 
-    private fun buildStore(
-        sources: Set<UserRemoteDataSource>,
-        accountManager: FakeAccountManager,
-    ): UserStatsStore = UserStatsStore(
-        activeSource = { sources.firstOrNull { it.provider == accountManager.getActiveProvider() } },
+    private fun buildStore(activeSource: () -> UserRemoteDataSource?): UserStatsStore = UserStatsStore(
+        activeSource = activeSource,
         userStatsDao = userStatsDao,
         requestManagerRepository = requestManager,
         dispatchers = dispatchers,

--- a/data/user/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/UserStatsStoreTest.kt
+++ b/data/user/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/UserStatsStoreTest.kt
@@ -54,7 +54,10 @@ internal class UserStatsStoreTest : BaseDatabaseTest() {
             dispatchers = dispatchers,
         )
         traktSource = FakeStatsSource(provider = AccountProvider.TRAKT)
-        store = buildStore(setOf(traktSource))
+        store = buildStore(
+            sources = setOf(traktSource),
+            accountManager = accountManager,
+        )
     }
 
     @AfterTest
@@ -130,7 +133,10 @@ internal class UserStatsStoreTest : BaseDatabaseTest() {
                 minutesWatched = 3000L,
             ),
         )
-        val multiStore = buildStore(setOf(traktSource, simklSource))
+        val multiStore = buildStore(
+            sources = setOf(traktSource, simklSource),
+            accountManager = accountManager,
+        )
         accountManager.setActiveProvider(AccountProvider.SIMKL)
 
         multiStore.stream(StoreReadRequest.fresh("test-user")).test {
@@ -151,7 +157,10 @@ internal class UserStatsStoreTest : BaseDatabaseTest() {
     fun `should not write stats given simkl source returns null stats`() = runTest(testDispatcher) {
         val simklSource = FakeStatsSource(provider = AccountProvider.SIMKL)
         simklSource.statsResponse = ApiResponse.Success(null)
-        val multiStore = buildStore(setOf(traktSource, simklSource))
+        val multiStore = buildStore(
+            sources = setOf(traktSource, simklSource),
+            accountManager = accountManager,
+        )
         accountManager.setActiveProvider(AccountProvider.SIMKL)
 
         multiStore.stream(StoreReadRequest.fresh("test-user")).test {
@@ -165,9 +174,11 @@ internal class UserStatsStoreTest : BaseDatabaseTest() {
         }
     }
 
-    private fun buildStore(sources: Set<UserRemoteDataSource>): UserStatsStore = UserStatsStore(
-        sources = sources,
-        accountManager = accountManager,
+    private fun buildStore(
+        sources: Set<UserRemoteDataSource>,
+        accountManager: FakeAccountManager,
+    ): UserStatsStore = UserStatsStore(
+        activeSource = { sources.firstOrNull { it.provider == accountManager.getActiveProvider() } },
         userStatsDao = userStatsDao,
         requestManagerRepository = requestManager,
         dispatchers = dispatchers,

--- a/data/user/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/UserStoreTest.kt
+++ b/data/user/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/UserStoreTest.kt
@@ -2,7 +2,6 @@ package com.thomaskioko.tvmaniac.data.user.implementation
 
 import app.cash.turbine.test
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
-import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.data.user.api.UserRemoteDataSource
@@ -39,15 +38,12 @@ internal class UserStoreTest : BaseDatabaseTest() {
 
     private lateinit var userDao: DefaultUserDao
     private lateinit var userStatsDao: DefaultUserStatsDao
-    private lateinit var accountManager: FakeAccountManager
     private lateinit var requestManager: FakeRequestManagerRepository
     private lateinit var traktSource: FakeUserSource
-    private lateinit var store: UserStore
 
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
-        accountManager = FakeAccountManager()
         requestManager = FakeRequestManagerRepository(initialRequestValid = false)
         userStatsDao = DefaultUserStatsDao(
             database = database,
@@ -60,10 +56,6 @@ internal class UserStoreTest : BaseDatabaseTest() {
             dispatchers = dispatchers,
         )
         traktSource = FakeUserSource(provider = AccountProvider.TRAKT)
-        store = buildStore(
-            sources = setOf(traktSource),
-            accountManager = accountManager,
-        )
     }
 
     @AfterTest
@@ -74,7 +66,7 @@ internal class UserStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should persist profile given active provider returns success`() = runTest(testDispatcher) {
-        accountManager.setActiveProvider(AccountProvider.TRAKT)
+        val store = buildStore { traktSource }
         traktSource.profileResponse = ApiResponse.Success(
             RemoteUserProfile(
                 slug = "john-doe",
@@ -104,7 +96,7 @@ internal class UserStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should not write to dao given no active provider`() = runTest(testDispatcher) {
-        accountManager.setActiveProvider(null)
+        val store = buildStore { null }
 
         store.stream(StoreReadRequest.fresh("me")).test {
             awaitItem()
@@ -129,11 +121,7 @@ internal class UserStoreTest : BaseDatabaseTest() {
                 backgroundUrl = null,
             ),
         )
-        val multiStore = buildStore(
-            sources = setOf(traktSource, simklSource),
-            accountManager = accountManager,
-        )
-        accountManager.setActiveProvider(AccountProvider.SIMKL)
+        val multiStore = buildStore { simklSource }
 
         multiStore.stream(StoreReadRequest.fresh("me")).test {
             awaitItem()
@@ -170,11 +158,7 @@ internal class UserStoreTest : BaseDatabaseTest() {
                 backgroundUrl = null,
             ),
         )
-        val multiStore = buildStore(
-            sources = setOf(traktSource, simklSource),
-            accountManager = accountManager,
-        )
-        accountManager.setActiveProvider(AccountProvider.SIMKL)
+        val multiStore = buildStore { simklSource }
 
         multiStore.stream(StoreReadRequest.fresh("me")).test {
             awaitItem()
@@ -190,11 +174,8 @@ internal class UserStoreTest : BaseDatabaseTest() {
         }
     }
 
-    private fun buildStore(
-        sources: Set<UserRemoteDataSource>,
-        accountManager: FakeAccountManager,
-    ): UserStore = UserStore(
-        activeSource = { sources.firstOrNull { it.provider == accountManager.getActiveProvider() } },
+    private fun buildStore(activeSource: () -> UserRemoteDataSource?): UserStore = UserStore(
+        activeSource = activeSource,
         userDao = userDao,
         requestManagerRepository = requestManager,
         dispatchers = dispatchers,

--- a/data/user/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/UserStoreTest.kt
+++ b/data/user/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/UserStoreTest.kt
@@ -60,7 +60,10 @@ internal class UserStoreTest : BaseDatabaseTest() {
             dispatchers = dispatchers,
         )
         traktSource = FakeUserSource(provider = AccountProvider.TRAKT)
-        store = buildStore(setOf(traktSource))
+        store = buildStore(
+            sources = setOf(traktSource),
+            accountManager = accountManager,
+        )
     }
 
     @AfterTest
@@ -126,7 +129,10 @@ internal class UserStoreTest : BaseDatabaseTest() {
                 backgroundUrl = null,
             ),
         )
-        val multiStore = buildStore(setOf(traktSource, simklSource))
+        val multiStore = buildStore(
+            sources = setOf(traktSource, simklSource),
+            accountManager = accountManager,
+        )
         accountManager.setActiveProvider(AccountProvider.SIMKL)
 
         multiStore.stream(StoreReadRequest.fresh("me")).test {
@@ -164,7 +170,10 @@ internal class UserStoreTest : BaseDatabaseTest() {
                 backgroundUrl = null,
             ),
         )
-        val multiStore = buildStore(setOf(traktSource, simklSource))
+        val multiStore = buildStore(
+            sources = setOf(traktSource, simklSource),
+            accountManager = accountManager,
+        )
         accountManager.setActiveProvider(AccountProvider.SIMKL)
 
         multiStore.stream(StoreReadRequest.fresh("me")).test {
@@ -181,9 +190,11 @@ internal class UserStoreTest : BaseDatabaseTest() {
         }
     }
 
-    private fun buildStore(sources: Set<UserRemoteDataSource>): UserStore = UserStore(
-        sources = sources,
-        accountManager = accountManager,
+    private fun buildStore(
+        sources: Set<UserRemoteDataSource>,
+        accountManager: FakeAccountManager,
+    ): UserStore = UserStore(
+        activeSource = { sources.firstOrNull { it.provider == accountManager.getActiveProvider() } },
         userDao = userDao,
         requestManagerRepository = requestManager,
         dispatchers = dispatchers,

--- a/domain/continue-watching/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/SyncContinueWatchingInteractor.kt
+++ b/domain/continue-watching/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/SyncContinueWatchingInteractor.kt
@@ -1,7 +1,5 @@
 package com.thomaskioko.tvmaniac.domain.continuewatching
 
-import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
-import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.accountmanager.api.ProviderFeatures
 import com.thomaskioko.tvmaniac.continuewatching.api.ContinueWatchingRepository
 import com.thomaskioko.tvmaniac.core.base.interactor.Interactor
@@ -34,7 +32,6 @@ public class SyncContinueWatchingInteractor(
     private val continueWatchingRepository: ContinueWatchingRepository,
     private val syncShowMetadataInteractor: SyncShowMetadataInteractor,
     private val watchedEpisodeSyncRepository: WatchedEpisodeSyncRepository,
-    private val accountManager: AccountManager,
     private val activeProviderFeatures: () -> ProviderFeatures,
     private val requestManagerRepository: RequestManagerRepository,
     private val dispatchers: AppCoroutineDispatchers,
@@ -71,7 +68,7 @@ public class SyncContinueWatchingInteractor(
 
                 watchedEpisodeSyncRepository.syncAllWatchedEpisodes(params.forceRefresh)
 
-                if (accountManager.getActiveProvider() == AccountProvider.SIMKL) {
+                if (!features.supportsContinueWatchingFetch) {
                     continueWatchingRepository.deriveMembershipFromWatchedEpisodes()
                 }
 

--- a/domain/continue-watching/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/SyncContinueWatchingInteractor.kt
+++ b/domain/continue-watching/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/SyncContinueWatchingInteractor.kt
@@ -2,6 +2,7 @@ package com.thomaskioko.tvmaniac.domain.continuewatching
 
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.accountmanager.api.ProviderFeatures
 import com.thomaskioko.tvmaniac.continuewatching.api.ContinueWatchingRepository
 import com.thomaskioko.tvmaniac.core.base.interactor.Interactor
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
@@ -34,6 +35,7 @@ public class SyncContinueWatchingInteractor(
     private val syncShowMetadataInteractor: SyncShowMetadataInteractor,
     private val watchedEpisodeSyncRepository: WatchedEpisodeSyncRepository,
     private val accountManager: AccountManager,
+    private val activeProviderFeatures: () -> ProviderFeatures,
     private val requestManagerRepository: RequestManagerRepository,
     private val dispatchers: AppCoroutineDispatchers,
     private val logger: Logger,
@@ -54,14 +56,18 @@ public class SyncContinueWatchingInteractor(
             }
 
             withContext(dispatchers.io) {
+                val features = activeProviderFeatures()
+
                 syncActivityInteractor.executeSync(
                     SyncActivityInteractor.Param(forceRefresh = params.forceRefresh),
                 )
 
-                continueWatchingRepository.sync(
-                    forceRefresh = params.forceRefresh,
-                    useNitro = params.useNitro,
-                )
+                if (features.supportsContinueWatchingFetch) {
+                    continueWatchingRepository.sync(
+                        forceRefresh = params.forceRefresh,
+                        useNitro = params.useNitro,
+                    )
+                }
 
                 watchedEpisodeSyncRepository.syncAllWatchedEpisodes(params.forceRefresh)
 

--- a/domain/continue-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/SyncContinueWatchingInteractorTest.kt
+++ b/domain/continue-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/SyncContinueWatchingInteractorTest.kt
@@ -2,6 +2,7 @@ package com.thomaskioko.tvmaniac.domain.continuewatching
 
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
+import com.thomaskioko.tvmaniac.accountmanager.testing.FakeProviderFeatures
 import com.thomaskioko.tvmaniac.continuewatching.api.ContinueWatchingEntry
 import com.thomaskioko.tvmaniac.continuewatching.testing.FakeContinueWatchingRepository
 import com.thomaskioko.tvmaniac.continuewatching.testing.FakeContinueWatchingRepository.SyncInvocation
@@ -41,7 +42,7 @@ class SyncContinueWatchingInteractorTest {
     private val watchedEpisodeSyncRepository = FakeWatchedEpisodeSyncRepository()
     private val watchProviderRepository = FakeWatchProviderRepository()
     private val requestManagerRepository = FakeRequestManagerRepository(initialRequestValid = false)
-    private val accountManager = FakeAccountManager()
+    private val accountManager = FakeAccountManager().also { it.setActiveProvider(AccountProvider.TRAKT) }
 
     private val syncActivityInteractor = SyncActivityInteractor(
         traktActivityRepository = activityRepository,
@@ -61,6 +62,12 @@ class SyncContinueWatchingInteractorTest {
         syncShowMetadataInteractor = syncShowMetadataInteractor,
         watchedEpisodeSyncRepository = watchedEpisodeSyncRepository,
         accountManager = accountManager,
+        activeProviderFeatures = {
+            when (accountManager.getActiveProvider()) {
+                AccountProvider.TRAKT -> FakeProviderFeatures(supportsContinueWatchingFetch = true)
+                else -> FakeProviderFeatures(supportsContinueWatchingFetch = false)
+            }
+        },
         requestManagerRepository = requestManagerRepository,
         dispatchers = dispatchers,
         logger = FakeLogger(),
@@ -163,6 +170,30 @@ class SyncContinueWatchingInteractorTest {
 
         interactor.executeSync(SyncContinueWatchingInteractor.Param(forceRefresh = false))
 
+        continueWatchingRepository.deriveMembershipInvocationCount() shouldBe 0
+    }
+
+    @Test
+    fun `should skip continue watching sync given simkl is the active provider`() = runTest(testDispatcher) {
+        accountManager.setActiveProvider(AccountProvider.SIMKL)
+
+        interactor.executeSync(SyncContinueWatchingInteractor.Param(forceRefresh = false))
+
+        continueWatchingRepository.syncInvocations().shouldBeEmpty()
+        watchedEpisodeSyncRepository.syncAllInvocations() shouldBe listOf(false)
+        continueWatchingRepository.deriveMembershipInvocationCount() shouldBe 1
+    }
+
+    @Test
+    fun `should invoke continue watching sync given trakt is the active provider`() = runTest(testDispatcher) {
+        accountManager.setActiveProvider(AccountProvider.TRAKT)
+
+        interactor.executeSync(SyncContinueWatchingInteractor.Param(forceRefresh = false))
+
+        continueWatchingRepository.syncInvocations() shouldBe listOf(
+            SyncInvocation(forceRefresh = false, useNitro = false),
+        )
+        watchedEpisodeSyncRepository.syncAllInvocations() shouldBe listOf(false)
         continueWatchingRepository.deriveMembershipInvocationCount() shouldBe 0
     }
 

--- a/domain/continue-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/SyncContinueWatchingInteractorTest.kt
+++ b/domain/continue-watching/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/continuewatching/SyncContinueWatchingInteractorTest.kt
@@ -1,7 +1,5 @@
 package com.thomaskioko.tvmaniac.domain.continuewatching
 
-import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
-import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
 import com.thomaskioko.tvmaniac.accountmanager.testing.FakeProviderFeatures
 import com.thomaskioko.tvmaniac.continuewatching.api.ContinueWatchingEntry
 import com.thomaskioko.tvmaniac.continuewatching.testing.FakeContinueWatchingRepository
@@ -42,7 +40,6 @@ class SyncContinueWatchingInteractorTest {
     private val watchedEpisodeSyncRepository = FakeWatchedEpisodeSyncRepository()
     private val watchProviderRepository = FakeWatchProviderRepository()
     private val requestManagerRepository = FakeRequestManagerRepository(initialRequestValid = false)
-    private val accountManager = FakeAccountManager().also { it.setActiveProvider(AccountProvider.TRAKT) }
 
     private val syncActivityInteractor = SyncActivityInteractor(
         traktActivityRepository = activityRepository,
@@ -56,22 +53,18 @@ class SyncContinueWatchingInteractorTest {
         dispatchers = dispatchers,
     )
 
-    private val interactor = SyncContinueWatchingInteractor(
+    private fun buildInteractor(supportsContinueWatchingFetch: Boolean = true) = SyncContinueWatchingInteractor(
         syncActivityInteractor = syncActivityInteractor,
         continueWatchingRepository = continueWatchingRepository,
         syncShowMetadataInteractor = syncShowMetadataInteractor,
         watchedEpisodeSyncRepository = watchedEpisodeSyncRepository,
-        accountManager = accountManager,
-        activeProviderFeatures = {
-            when (accountManager.getActiveProvider()) {
-                AccountProvider.TRAKT -> FakeProviderFeatures(supportsContinueWatchingFetch = true)
-                else -> FakeProviderFeatures(supportsContinueWatchingFetch = false)
-            }
-        },
+        activeProviderFeatures = { FakeProviderFeatures(supportsContinueWatchingFetch = supportsContinueWatchingFetch) },
         requestManagerRepository = requestManagerRepository,
         dispatchers = dispatchers,
         logger = FakeLogger(),
     )
+
+    private val interactor = buildInteractor()
 
     @Test
     fun `should skip when ttl valid and not force refresh`() = runTest(testDispatcher) {
@@ -156,28 +149,24 @@ class SyncContinueWatchingInteractorTest {
     }
 
     @Test
-    fun `should derive continue watching membership when active provider is simkl`() = runTest(testDispatcher) {
-        accountManager.setActiveProvider(AccountProvider.SIMKL)
-
-        interactor.executeSync(SyncContinueWatchingInteractor.Param(forceRefresh = false))
+    fun `should derive continue watching membership given continue watching fetch is unsupported`() = runTest(testDispatcher) {
+        buildInteractor(supportsContinueWatchingFetch = false)
+            .executeSync(SyncContinueWatchingInteractor.Param(forceRefresh = false))
 
         continueWatchingRepository.deriveMembershipInvocationCount() shouldBe 1
     }
 
     @Test
-    fun `should not derive continue watching membership when active provider is trakt`() = runTest(testDispatcher) {
-        accountManager.setActiveProvider(AccountProvider.TRAKT)
-
+    fun `should not derive continue watching membership given continue watching fetch is supported`() = runTest(testDispatcher) {
         interactor.executeSync(SyncContinueWatchingInteractor.Param(forceRefresh = false))
 
         continueWatchingRepository.deriveMembershipInvocationCount() shouldBe 0
     }
 
     @Test
-    fun `should skip continue watching sync given simkl is the active provider`() = runTest(testDispatcher) {
-        accountManager.setActiveProvider(AccountProvider.SIMKL)
-
-        interactor.executeSync(SyncContinueWatchingInteractor.Param(forceRefresh = false))
+    fun `should skip continue watching sync given continue watching fetch is unsupported`() = runTest(testDispatcher) {
+        buildInteractor(supportsContinueWatchingFetch = false)
+            .executeSync(SyncContinueWatchingInteractor.Param(forceRefresh = false))
 
         continueWatchingRepository.syncInvocations().shouldBeEmpty()
         watchedEpisodeSyncRepository.syncAllInvocations() shouldBe listOf(false)
@@ -185,9 +174,7 @@ class SyncContinueWatchingInteractorTest {
     }
 
     @Test
-    fun `should invoke continue watching sync given trakt is the active provider`() = runTest(testDispatcher) {
-        accountManager.setActiveProvider(AccountProvider.TRAKT)
-
+    fun `should invoke continue watching sync given continue watching fetch is supported`() = runTest(testDispatcher) {
         interactor.executeSync(SyncContinueWatchingInteractor.Param(forceRefresh = false))
 
         continueWatchingRepository.syncInvocations() shouldBe listOf(

--- a/domain/notifications/build.gradle.kts
+++ b/domain/notifications/build.gradle.kts
@@ -45,6 +45,7 @@ kotlin {
                 implementation(projects.core.notifications.testing)
                 implementation(projects.core.util.testing)
                 implementation(projects.core.view)
+                implementation(projects.data.accountManager.testing)
                 implementation(projects.data.datastore.testing)
                 implementation(projects.data.episode.testing)
                 implementation(projects.i18n.generator)

--- a/domain/notifications/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/notifications/interactor/SyncTraktCalendarInteractor.kt
+++ b/domain/notifications/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/notifications/interactor/SyncTraktCalendarInteractor.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.domain.notifications.interactor
 
+import com.thomaskioko.tvmaniac.accountmanager.api.ProviderFeatures
 import com.thomaskioko.tvmaniac.core.base.interactor.Interactor
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.logger.Logger
@@ -15,11 +16,14 @@ import kotlinx.coroutines.withContext
 public class SyncTraktCalendarInteractor(
     private val episodeRepository: EpisodeRepository,
     private val dateTimeProvider: DateTimeProvider,
+    private val activeProviderFeatures: () -> ProviderFeatures,
     private val logger: Logger,
     private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<SyncTraktCalendarInteractor.Params>() {
 
     override suspend fun doWork(params: Params) {
+        if (!activeProviderFeatures().supportsCalendar) return
+
         logger.debug(TAG, "Starting Trakt calendar sync")
         withContext(dispatchers.io) {
             episodeRepository.syncUpcomingEpisodesFromTrakt(

--- a/domain/notifications/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/notifications/interactor/SyncTraktCalendarInteractorTest.kt
+++ b/domain/notifications/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/notifications/interactor/SyncTraktCalendarInteractorTest.kt
@@ -1,0 +1,96 @@
+package com.thomaskioko.tvmaniac.domain.notifications.interactor
+
+import com.thomaskioko.tvmaniac.accountmanager.testing.FakeProviderFeatures
+import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
+import com.thomaskioko.tvmaniac.core.logger.fixture.FakeLogger
+import com.thomaskioko.tvmaniac.db.EpisodeById
+import com.thomaskioko.tvmaniac.episodes.api.EpisodeRepository
+import com.thomaskioko.tvmaniac.episodes.api.model.RecentlyWatchedEpisode
+import com.thomaskioko.tvmaniac.episodes.api.model.SeasonWatchProgress
+import com.thomaskioko.tvmaniac.episodes.api.model.ShowWatchProgress
+import com.thomaskioko.tvmaniac.episodes.api.model.UpcomingEpisode
+import com.thomaskioko.tvmaniac.util.testing.FakeDateTimeProvider
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.time.Duration
+
+class SyncTraktCalendarInteractorTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val dispatchers = AppCoroutineDispatchers(
+        main = testDispatcher,
+        io = testDispatcher,
+        computation = testDispatcher,
+        databaseWrite = testDispatcher,
+        databaseRead = testDispatcher,
+    )
+    private val dateTimeProvider = FakeDateTimeProvider()
+
+    private fun buildInteractor(
+        episodeRepository: EpisodeRepository,
+        supportsCalendar: Boolean,
+    ) = SyncTraktCalendarInteractor(
+        episodeRepository = episodeRepository,
+        dateTimeProvider = dateTimeProvider,
+        activeProviderFeatures = { FakeProviderFeatures(supportsCalendar = supportsCalendar) },
+        logger = FakeLogger(),
+        dispatchers = dispatchers,
+    )
+
+    @Test
+    fun `should skip calendar sync given simkl is the active provider`() = runTest(testDispatcher) {
+        val episodeRepository = CountingEpisodeRepository()
+
+        buildInteractor(episodeRepository = episodeRepository, supportsCalendar = false)
+            .executeSync(SyncTraktCalendarInteractor.Params())
+
+        episodeRepository.syncUpcomingCount shouldBe 0
+    }
+
+    @Test
+    fun `should run calendar sync given trakt is the active provider`() = runTest(testDispatcher) {
+        val episodeRepository = CountingEpisodeRepository()
+
+        buildInteractor(episodeRepository = episodeRepository, supportsCalendar = true)
+            .executeSync(SyncTraktCalendarInteractor.Params())
+
+        episodeRepository.syncUpcomingCount shouldBe 1
+    }
+
+    @Test
+    fun `should skip calendar sync given no active provider`() = runTest(testDispatcher) {
+        val episodeRepository = CountingEpisodeRepository()
+
+        buildInteractor(episodeRepository = episodeRepository, supportsCalendar = false)
+            .executeSync(SyncTraktCalendarInteractor.Params())
+
+        episodeRepository.syncUpcomingCount shouldBe 0
+    }
+}
+
+private class CountingEpisodeRepository : EpisodeRepository {
+    var syncUpcomingCount: Int = 0
+
+    override fun observeEpisodeById(episodeId: Long): Flow<EpisodeById?> = flowOf(null)
+    override fun observeRecentlyWatched(limit: Long): Flow<List<RecentlyWatchedEpisode>> = flowOf(emptyList())
+    override suspend fun markEpisodeAsWatched(showId: Long, episodeId: Long, seasonNumber: Long, episodeNumber: Long) {}
+    override suspend fun markEpisodeAndPreviousEpisodesWatched(showId: Long, episodeId: Long, seasonNumber: Long, episodeNumber: Long) {}
+    override suspend fun markEpisodeAsUnwatched(showId: Long, episodeId: Long) {}
+    override fun observeSeasonWatchProgress(showId: Long, seasonNumber: Long): Flow<SeasonWatchProgress> =
+        flowOf(SeasonWatchProgress(0, 0, 0, 0))
+    override fun observeShowWatchProgress(showId: Long): Flow<ShowWatchProgress> =
+        flowOf(ShowWatchProgress(0, 0, 0))
+    override fun observeAllSeasonsWatchProgress(showId: Long): Flow<List<SeasonWatchProgress>> = flowOf(emptyList())
+    override suspend fun markSeasonWatched(showId: Long, seasonNumber: Long) {}
+    override suspend fun markSeasonAndPreviousSeasonsWatched(showId: Long, seasonNumber: Long) {}
+    override suspend fun markSeasonUnwatched(showId: Long, seasonNumber: Long) {}
+    override fun observeUnwatchedCountInPreviousSeasons(showId: Long, seasonNumber: Long): Flow<Long> = flowOf(0L)
+    override suspend fun getUpcomingEpisodesFromFollowedShows(limit: Duration): List<UpcomingEpisode> = emptyList()
+    override suspend fun syncUpcomingEpisodesFromTrakt(startDate: String, days: Int, forceRefresh: Boolean) {
+        syncUpcomingCount++
+    }
+}

--- a/domain/user/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/user/UpdateUserProfileData.kt
+++ b/domain/user/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/user/UpdateUserProfileData.kt
@@ -1,7 +1,6 @@
 package com.thomaskioko.tvmaniac.domain.user
 
-import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
-import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.accountmanager.api.ProviderFeatures
 import com.thomaskioko.tvmaniac.core.base.interactor.Interactor
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.data.user.api.UserRepository
@@ -13,7 +12,7 @@ import kotlinx.coroutines.withContext
 public class UpdateUserProfileData(
     private val userRepository: UserRepository,
     private val traktListRepository: TraktListRepository,
-    private val accountManager: AccountManager,
+    private val activeProviderFeatures: () -> ProviderFeatures,
     private val dispatchers: AppCoroutineDispatchers,
 ) : Interactor<UpdateUserProfileData.Params>() {
 
@@ -31,9 +30,11 @@ public class UpdateUserProfileData(
                 forceRefresh = params.forceRefresh,
             )
 
-            // TODO:: Remote hardCoded provider
-            if (accountManager.getActiveProvider() == AccountProvider.TRAKT) {
-                traktListRepository.fetchUserLists(slug = slug, forceRefresh = params.forceRefresh)
+            if (activeProviderFeatures().supportsLists) {
+                traktListRepository.fetchUserLists(
+                    slug = slug,
+                    forceRefresh = params.forceRefresh,
+                )
             }
         }
     }

--- a/domain/user/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/user/UpdateUserProfileDataTest.kt
+++ b/domain/user/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/user/UpdateUserProfileDataTest.kt
@@ -1,14 +1,12 @@
 package com.thomaskioko.tvmaniac.domain.user
 
-import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
-import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
+import com.thomaskioko.tvmaniac.accountmanager.testing.FakeProviderFeatures
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.data.user.testing.FakeUserRepository
 import com.thomaskioko.tvmaniac.traktlists.testing.FakeTraktListRepository
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 
 internal class UpdateUserProfileDataTest {
@@ -22,27 +20,21 @@ internal class UpdateUserProfileDataTest {
         databaseRead = testDispatcher,
     )
 
-    private lateinit var accountManager: FakeAccountManager
-    private lateinit var userRepository: FakeUserRepository
     private lateinit var traktListRepository: FakeTraktListRepository
-    private lateinit var interactor: UpdateUserProfileData
 
-    @BeforeTest
-    fun setUp() {
-        accountManager = FakeAccountManager()
-        userRepository = FakeUserRepository()
+    private fun buildInteractor(supportsLists: Boolean): UpdateUserProfileData {
         traktListRepository = FakeTraktListRepository()
-        interactor = UpdateUserProfileData(
-            userRepository = userRepository,
+        return UpdateUserProfileData(
+            userRepository = FakeUserRepository(),
             traktListRepository = traktListRepository,
-            accountManager = accountManager,
+            activeProviderFeatures = { FakeProviderFeatures(supportsLists = supportsLists) },
             dispatchers = dispatchers,
         )
     }
 
     @Test
     fun `should fetch user lists given trakt provider is active`() = runTest(testDispatcher) {
-        accountManager.setActiveProvider(AccountProvider.TRAKT)
+        val interactor = buildInteractor(supportsLists = true)
 
         interactor.executeSync(UpdateUserProfileData.Params(username = "me", forceRefresh = false))
 
@@ -51,7 +43,7 @@ internal class UpdateUserProfileDataTest {
 
     @Test
     fun `should skip user lists given simkl provider is active`() = runTest(testDispatcher) {
-        accountManager.setActiveProvider(AccountProvider.SIMKL)
+        val interactor = buildInteractor(supportsLists = false)
 
         interactor.executeSync(UpdateUserProfileData.Params(username = "me", forceRefresh = false))
 
@@ -60,7 +52,7 @@ internal class UpdateUserProfileDataTest {
 
     @Test
     fun `should skip user lists given no provider is active`() = runTest(testDispatcher) {
-        accountManager.setActiveProvider(null)
+        val interactor = buildInteractor(supportsLists = false)
 
         interactor.executeSync(UpdateUserProfileData.Params(username = "me", forceRefresh = false))
 

--- a/features/continue-watching/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/FakeContinueWatchingPresenterBuilder.kt
+++ b/features/continue-watching/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/FakeContinueWatchingPresenterBuilder.kt
@@ -2,6 +2,7 @@ package com.thomaskioko.tvmaniac.continuewatching.presenter
 
 import com.arkivanov.decompose.ComponentContext
 import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
+import com.thomaskioko.tvmaniac.accountmanager.testing.FakeProviderFeatures
 import com.thomaskioko.tvmaniac.continuewatching.testing.FakeContinueWatchingRepository
 import com.thomaskioko.tvmaniac.core.base.coroutines.FakeAppScopeLauncher
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
@@ -103,6 +104,7 @@ class FakeContinueWatchingPresenterBuilder {
         syncShowMetadataInteractor = syncShowMetadataInteractor,
         watchedEpisodeSyncRepository = watchedEpisodeSyncRepository,
         accountManager = fakeAccountManager,
+        activeProviderFeatures = { FakeProviderFeatures(supportsContinueWatchingFetch = true) },
         requestManagerRepository = requestManagerRepository,
         dispatchers = coroutineDispatcher,
         logger = fakeLogger,

--- a/features/continue-watching/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/FakeContinueWatchingPresenterBuilder.kt
+++ b/features/continue-watching/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/FakeContinueWatchingPresenterBuilder.kt
@@ -103,7 +103,6 @@ class FakeContinueWatchingPresenterBuilder {
         continueWatchingRepository = continueWatchingRepository,
         syncShowMetadataInteractor = syncShowMetadataInteractor,
         watchedEpisodeSyncRepository = watchedEpisodeSyncRepository,
-        accountManager = fakeAccountManager,
         activeProviderFeatures = { FakeProviderFeatures(supportsContinueWatchingFetch = true) },
         requestManagerRepository = requestManagerRepository,
         dispatchers = coroutineDispatcher,

--- a/features/debug/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/debug/presenter/DebugPresenterTest.kt
+++ b/features/debug/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/debug/presenter/DebugPresenterTest.kt
@@ -311,7 +311,6 @@ class DebugPresenterTest {
                     dispatchers = dispatchers,
                 ),
                 watchedEpisodeSyncRepository = FakeWatchedEpisodeSyncRepository(),
-                accountManager = FakeAccountManager(),
                 activeProviderFeatures = { FakeProviderFeatures(supportsContinueWatchingFetch = true) },
                 requestManagerRepository = FakeRequestManagerRepository(),
                 dispatchers = dispatchers,

--- a/features/debug/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/debug/presenter/DebugPresenterTest.kt
+++ b/features/debug/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/debug/presenter/DebugPresenterTest.kt
@@ -6,6 +6,7 @@ import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthState
 import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
+import com.thomaskioko.tvmaniac.accountmanager.testing.FakeProviderFeatures
 import com.thomaskioko.tvmaniac.continuewatching.testing.FakeContinueWatchingRepository
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.logger.fixture.FakeLogger
@@ -311,6 +312,7 @@ class DebugPresenterTest {
                 ),
                 watchedEpisodeSyncRepository = FakeWatchedEpisodeSyncRepository(),
                 accountManager = FakeAccountManager(),
+                activeProviderFeatures = { FakeProviderFeatures(supportsContinueWatchingFetch = true) },
                 requestManagerRepository = FakeRequestManagerRepository(),
                 dispatchers = dispatchers,
                 logger = logger,

--- a/features/profile/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/profile/ProfilePresenterTest.kt
+++ b/features/profile/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/profile/ProfilePresenterTest.kt
@@ -7,6 +7,7 @@ import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthError
 import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
 import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAuthManager
+import com.thomaskioko.tvmaniac.accountmanager.testing.FakeProviderFeatures
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.logger.fixture.FakeLogger
 import com.thomaskioko.tvmaniac.data.library.model.LibraryItem
@@ -112,7 +113,7 @@ internal class ProfilePresenterTest {
     private val updateUserProfileData = UpdateUserProfileData(
         userRepository = userRepository,
         traktListRepository = traktListRepository,
-        accountManager = accountManager,
+        activeProviderFeatures = { FakeProviderFeatures(supportsLists = true) },
         dispatchers = testDispatchers,
     )
 

--- a/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/ShowDetailsPresenterTest.kt
+++ b/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/ShowDetailsPresenterTest.kt
@@ -5,6 +5,7 @@ import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.thomaskioko.root.nav.NotificationRationale
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
+import com.thomaskioko.tvmaniac.accountmanager.testing.FakeProviderFeatures
 import com.thomaskioko.tvmaniac.core.base.coroutines.FakeAppScopeLauncher
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.logger.fixture.FakeLogger
@@ -768,6 +769,7 @@ class ShowDetailsPresenterTest {
             syncTraktCalendarInteractor = SyncTraktCalendarInteractor(
                 episodeRepository = episodeRepository,
                 dateTimeProvider = fakeDateTimeProvider,
+                activeProviderFeatures = { FakeProviderFeatures(supportsCalendar = true) },
                 logger = FakeLogger(),
                 dispatchers = coroutineDispatcher,
             ),

--- a/features/upnext/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextPresenter.kt
+++ b/features/upnext/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextPresenter.kt
@@ -143,7 +143,7 @@ public class UpNextPresenter(
 
     private fun markEpisodeWatched(action: MarkWatched) {
         if (action.episodeId in updatingEpisodeIdsState.value) return
-        updatingEpisodeIdsState.update { it.add(action.episodeId) }
+        updatingEpisodeIdsState.update { it.adding(action.episodeId) }
         coroutineScope.launch {
             val marker = TimeSource.Monotonic.markNow()
             try {
@@ -160,7 +160,7 @@ public class UpNextPresenter(
                 if (elapsed < INDICATOR_FLOOR) {
                     delay(INDICATOR_FLOOR - elapsed)
                 }
-                updatingEpisodeIdsState.update { it.remove(action.episodeId) }
+                updatingEpisodeIdsState.update { it.removing(action.episodeId) }
             }
         }
     }

--- a/features/upnext/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextPresenterTest.kt
+++ b/features/upnext/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextPresenterTest.kt
@@ -474,7 +474,6 @@ internal class UpNextPresenterTest {
                 dispatchers = dispatchers,
             ),
             watchedEpisodeSyncRepository = FakeWatchedEpisodeSyncRepository(),
-            accountManager = FakeAccountManager(),
             activeProviderFeatures = { FakeProviderFeatures(supportsContinueWatchingFetch = true) },
             requestManagerRepository = FakeRequestManagerRepository(initialRequestValid = false),
             dispatchers = dispatchers,

--- a/features/upnext/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextPresenterTest.kt
+++ b/features/upnext/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextPresenterTest.kt
@@ -5,6 +5,7 @@ import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
+import com.thomaskioko.tvmaniac.accountmanager.testing.FakeProviderFeatures
 import com.thomaskioko.tvmaniac.continuewatching.testing.FakeContinueWatchingRepository
 import com.thomaskioko.tvmaniac.core.base.coroutines.FakeAppScopeLauncher
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
@@ -474,6 +475,7 @@ internal class UpNextPresenterTest {
             ),
             watchedEpisodeSyncRepository = FakeWatchedEpisodeSyncRepository(),
             accountManager = FakeAccountManager(),
+            activeProviderFeatures = { FakeProviderFeatures(supportsContinueWatchingFetch = true) },
             requestManagerRepository = FakeRequestManagerRepository(initialRequestValid = false),
             dispatchers = dispatchers,
             logger = logger,


### PR DESCRIPTION
## Description
This PR refactors the dependency injection layer using Metro multibindings to streamline provider-specific logic (Trakt and Simkl). It introduces a feature-gating mechanism that allows domain interactors to conditionally execute tasks based on the active provider's capabilities, improving maintainability and scalability for multi-provider support.

## Changes
- Implemented **Metro DI multibindings** to centralize and simplify the resolution of active account provider dependencies (e.g., library, activity, and user data sources).
- Introduced the **`ProviderFeatures` interface** and provider-specific implementations (Trakt/Simkl) to define capabilities like calendar synchronization and list support.
- Decoupled repositories and domain interactors from hardcoded provider checks, utilizing the new feature-gating system for cleaner architecture.
- Refactored synchronization logic in `SyncContinueWatchingInteractor` and `SyncTraktCalendarInteractor` to conditionally execute based on provider-specific feature flags.
- Streamlined the data layer by removing redundant data sources and centralizing remote source resolution logic.
