### PR TITLE
feat: Integrate Simkl for Calendar and "Plan to Watch" 

### DIFF
--- a/api/simkl/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/api/model/SimklCalendarResponse.kt
+++ b/api/simkl/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/api/model/SimklCalendarResponse.kt
@@ -7,16 +7,19 @@ import kotlinx.serialization.Serializable
 public data class SimklCalendarEntry(
     @SerialName("date") val date: String,
     @SerialName("title") val title: String? = null,
-    @SerialName("ep_title") val episodeTitle: String? = null,
+    @SerialName("ids") val ids: SimklCalendarIds? = null,
+    @SerialName("episode") val episode: SimklCalendarEpisode? = null,
+)
+
+@Serializable
+public data class SimklCalendarEpisode(
     @SerialName("season") val season: Int? = null,
     @SerialName("episode") val episode: Int? = null,
-    @SerialName("runtime") val runtime: Int? = null,
-    @SerialName("ids") val ids: SimklCalendarIds? = null,
 )
 
 @Serializable
 public data class SimklCalendarIds(
-    @SerialName("simkl") val simkl: Long? = null,
+    @SerialName("simkl_id") val simklId: Long? = null,
     @SerialName("tmdb") val tmdb: String? = null,
     @SerialName("imdb") val imdb: String? = null,
 )

--- a/api/simkl/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/api/model/SimklCalendarResponse.kt
+++ b/api/simkl/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/api/model/SimklCalendarResponse.kt
@@ -1,0 +1,22 @@
+package com.thomaskioko.tvmaniac.simkl.api.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class SimklCalendarEntry(
+    @SerialName("date") val date: String,
+    @SerialName("title") val title: String? = null,
+    @SerialName("ep_title") val episodeTitle: String? = null,
+    @SerialName("season") val season: Int? = null,
+    @SerialName("episode") val episode: Int? = null,
+    @SerialName("runtime") val runtime: Int? = null,
+    @SerialName("ids") val ids: SimklCalendarIds? = null,
+)
+
+@Serializable
+public data class SimklCalendarIds(
+    @SerialName("simkl") val simkl: Long? = null,
+    @SerialName("tmdb") val tmdb: String? = null,
+    @SerialName("imdb") val imdb: String? = null,
+)

--- a/api/simkl/implementation/build.gradle.kts
+++ b/api/simkl/implementation/build.gradle.kts
@@ -26,7 +26,10 @@ kotlin {
                 api(projects.data.accountManager.api)
                 api(projects.data.episode.api)
                 api(projects.data.followedshows.api)
+                api(projects.data.calendar.api)
+                api(projects.data.followedshows.api)
                 api(projects.data.library.api)
+                api(projects.data.startWatching.api)
                 api(projects.data.oauth.api)
                 api(projects.data.syncActivity.api)
                 api(projects.data.user.api)
@@ -47,7 +50,9 @@ kotlin {
                 implementation(projects.api.simkl.api)
                 implementation(projects.api.simkl.testing)
                 implementation(projects.core.networkUtil.api)
+                implementation(projects.data.calendar.api)
                 implementation(projects.data.episode.api)
+                implementation(projects.data.followedshows.testing)
             }
         }
 

--- a/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklBindingContainer.kt
+++ b/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklBindingContainer.kt
@@ -3,6 +3,7 @@ package com.thomaskioko.tvmaniac.simkl.implementation
 import com.thomaskioko.tvmaniac.appconfig.DebugConfig
 import com.thomaskioko.tvmaniac.appconfig.SimklConfig
 import com.thomaskioko.tvmaniac.core.base.SimklApi
+import com.thomaskioko.tvmaniac.core.base.SimklDataApi
 import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.oauth.api.AuthStateHolder
 import dev.zacsweers.metro.AppScope
@@ -40,5 +41,19 @@ public object SimklBindingContainer {
         httpClientEngine = httpClientEngine,
         kermitLogger = logger,
         authStateHolder = authStateHolder,
+    )
+
+    @Provides
+    @SingleIn(AppScope::class)
+    @SimklDataApi
+    public fun provideDataHttpClient(
+        @SimklApi httpClientEngine: HttpClientEngine,
+        debugConfig: DebugConfig,
+        logger: Logger,
+    ): HttpClient = simklDataHttpClient(
+        isDebug = debugConfig.isDebug,
+        json = json,
+        httpClientEngine = httpClientEngine,
+        kermitLogger = logger,
     )
 }

--- a/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklCalendarRemoteDataSource.kt
+++ b/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklCalendarRemoteDataSource.kt
@@ -80,6 +80,7 @@ private fun SimklCalendarEntry.toRemoteCalendarEntry(): RemoteCalendarEntry? {
     val episodeNumber = episode?.episode ?: return null
     return RemoteCalendarEntry(
         tmdbId = tmdbId,
+        episodeTraktId = null,
         showTitle = title ?: "",
         episodeTitle = null,
         seasonNumber = episode?.season ?: 1,

--- a/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklCalendarRemoteDataSource.kt
+++ b/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklCalendarRemoteDataSource.kt
@@ -1,0 +1,94 @@
+package com.thomaskioko.tvmaniac.simkl.implementation
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.core.base.SimklDataApi
+import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.safeRequest
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.data.calendar.CalendarRemoteDataSource
+import com.thomaskioko.tvmaniac.data.calendar.RemoteCalendarEntry
+import com.thomaskioko.tvmaniac.followedshows.api.FollowedShowsDao
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklCalendarEntry
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.SingleIn
+import io.ktor.client.HttpClient
+import io.ktor.http.HttpMethod
+import io.ktor.http.path
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+
+@SingleIn(AppScope::class)
+@ContributesIntoSet(AppScope::class)
+public class SimklCalendarRemoteDataSource(
+    @SimklDataApi private val httpClient: HttpClient,
+    private val followedShowsDao: FollowedShowsDao,
+) : CalendarRemoteDataSource {
+
+    override val provider: AccountProvider = AccountProvider.SIMKL
+
+    override suspend fun getCalendarEntries(
+        startDate: String,
+        days: Int,
+    ): ApiResponse<List<RemoteCalendarEntry>> {
+        val trackedTmdbIds = followedShowsDao.entries()
+            .mapNotNull { it.tmdbId }
+            .toSet()
+
+        if (trackedTmdbIds.isEmpty()) return ApiResponse.Success(emptyList())
+
+        return coroutineScope {
+            val tvDeferred = async { fetchCalendarFeed("calendar/tv.json") }
+            val animeDeferred = async { fetchCalendarFeed("calendar/anime.json") }
+
+            mergeFeedResults(
+                tvResult = tvDeferred.await(),
+                animeResult = animeDeferred.await(),
+                trackedTmdbIds = trackedTmdbIds,
+            )
+        }
+    }
+
+    private fun mergeFeedResults(
+        tvResult: ApiResponse<List<SimklCalendarEntry>>,
+        animeResult: ApiResponse<List<SimklCalendarEntry>>,
+        trackedTmdbIds: Set<Long>,
+    ): ApiResponse<List<RemoteCalendarEntry>> {
+        if (tvResult is ApiResponse.Unauthenticated) return ApiResponse.Unauthenticated
+        if (animeResult is ApiResponse.Unauthenticated) return ApiResponse.Unauthenticated
+        if (tvResult !is ApiResponse.Success) return ApiResponse.Success(emptyList())
+        if (animeResult !is ApiResponse.Success) return ApiResponse.Success(emptyList())
+
+        val merged = (tvResult.body + animeResult.body)
+            .filter { entry ->
+                val tmdbId = entry.ids?.tmdb?.toLongOrNull()
+                tmdbId != null && tmdbId in trackedTmdbIds
+            }
+            .mapNotNull { it.toRemoteCalendarEntry() }
+
+        return ApiResponse.Success(merged)
+    }
+
+    private suspend fun fetchCalendarFeed(path: String): ApiResponse<List<SimklCalendarEntry>> =
+        httpClient.safeRequest {
+            url { path(path) }
+            method = HttpMethod.Get
+        }
+}
+
+private fun SimklCalendarEntry.toRemoteCalendarEntry(): RemoteCalendarEntry? {
+    val tmdbId = ids?.tmdb?.toLongOrNull() ?: return null
+    val season = season ?: return null
+    val episodeNumber = episode ?: return null
+    return RemoteCalendarEntry(
+        tmdbId = tmdbId,
+        showTitle = title ?: "",
+        episodeTitle = episodeTitle,
+        seasonNumber = season,
+        episodeNumber = episodeNumber,
+        firstAiredIso = date,
+        runtime = runtime,
+        overview = null,
+        rating = null,
+        votes = null,
+    )
+}

--- a/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklCalendarRemoteDataSource.kt
+++ b/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklCalendarRemoteDataSource.kt
@@ -77,16 +77,15 @@ public class SimklCalendarRemoteDataSource(
 
 private fun SimklCalendarEntry.toRemoteCalendarEntry(): RemoteCalendarEntry? {
     val tmdbId = ids?.tmdb?.toLongOrNull() ?: return null
-    val season = season ?: return null
-    val episodeNumber = episode ?: return null
+    val episodeNumber = episode?.episode ?: return null
     return RemoteCalendarEntry(
         tmdbId = tmdbId,
         showTitle = title ?: "",
-        episodeTitle = episodeTitle,
-        seasonNumber = season,
+        episodeTitle = null,
+        seasonNumber = episode?.season ?: 1,
         episodeNumber = episodeNumber,
         firstAiredIso = date,
-        runtime = runtime,
+        runtime = null,
         overview = null,
         rating = null,
         votes = null,

--- a/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklDataHttpClient.kt
+++ b/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklDataHttpClient.kt
@@ -1,0 +1,69 @@
+package com.thomaskioko.tvmaniac.simkl.implementation
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.EMPTY
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.URLProtocol
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+import com.thomaskioko.tvmaniac.core.logger.Logger as KermitLogger
+
+internal const val SIMKL_DATA_TIMEOUT_DURATION: Long = 60_000
+
+internal fun simklDataHttpClient(
+    isDebug: Boolean = false,
+    json: Json,
+    httpClientEngine: HttpClientEngine,
+    kermitLogger: KermitLogger,
+): HttpClient = HttpClient(httpClientEngine) {
+    install(ContentNegotiation) { json(json = json) }
+
+    install(HttpRequestRetry) {
+        retryIf(3) { _, httpResponse ->
+            when {
+                httpResponse.status.value in 500..599 -> true
+                httpResponse.status == HttpStatusCode.TooManyRequests -> true
+                else -> false
+            }
+        }
+        exponentialDelay(
+            base = 2.0,
+            maxDelayMs = 60_000L,
+            randomizationMs = 1000L,
+        )
+    }
+
+    install(DefaultRequest) {
+        url {
+            protocol = URLProtocol.HTTPS
+            host = "data.simkl.in"
+        }
+    }
+
+    install(HttpTimeout) {
+        requestTimeoutMillis = SIMKL_DATA_TIMEOUT_DURATION
+        connectTimeoutMillis = SIMKL_DATA_TIMEOUT_DURATION
+        socketTimeoutMillis = SIMKL_DATA_TIMEOUT_DURATION
+    }
+
+    install(Logging) {
+        level = if (isDebug) LogLevel.INFO else LogLevel.NONE
+        logger = if (isDebug) {
+            object : Logger {
+                override fun log(message: String) {
+                    kermitLogger.info("SimklDataHttp", message)
+                }
+            }
+        } else {
+            Logger.EMPTY
+        }
+    }
+}

--- a/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklProviderFeatures.kt
+++ b/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklProviderFeatures.kt
@@ -20,5 +20,5 @@ public class SimklProviderFeatures : ProviderFeatures {
     override val supportsContinueWatchingFetch: Boolean = false
     override val supportsFavorites: Boolean = false
     override val supportsLists: Boolean = false
-    override val supportsCalendar: Boolean = false
+    override val supportsCalendar: Boolean = true
 }

--- a/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklStartWatchingRemoteDataSource.kt
+++ b/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklStartWatchingRemoteDataSource.kt
@@ -1,0 +1,45 @@
+package com.thomaskioko.tvmaniac.simkl.implementation
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.map
+import com.thomaskioko.tvmaniac.simkl.api.SimklSyncRemoteDataSource
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklWatchedShow
+import com.thomaskioko.tvmaniac.startwatching.api.RemotePlanToWatchShow
+import com.thomaskioko.tvmaniac.startwatching.api.StartWatchingRemoteDataSource
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.SingleIn
+import kotlin.time.Instant
+
+@SingleIn(AppScope::class)
+@ContributesIntoSet(AppScope::class)
+public class SimklStartWatchingRemoteDataSource(
+    private val syncRemoteDataSource: SimklSyncRemoteDataSource,
+) : StartWatchingRemoteDataSource {
+
+    override val provider: AccountProvider = AccountProvider.SIMKL
+
+    override suspend fun getPlanToWatch(): ApiResponse<List<RemotePlanToWatchShow>> =
+        syncRemoteDataSource.getAllWatchedShows()
+            .map { response ->
+                response.shows
+                    .filter { it.status == PLAN_TO_WATCH_STATUS }
+                    .map { it.toRemotePlanToWatchShow() }
+            }
+
+    private companion object {
+        private const val PLAN_TO_WATCH_STATUS = "plantowatch"
+    }
+}
+
+private fun SimklWatchedShow.toRemotePlanToWatchShow(): RemotePlanToWatchShow = RemotePlanToWatchShow(
+    tmdbId = show.ids.tmdb?.toLongOrNull(),
+    imdbId = show.ids.imdb,
+    providerShowId = show.ids.simkl?.toString(),
+    provider = AccountProvider.SIMKL,
+    title = show.title ?: "",
+    year = show.year,
+    followedAt = lastWatchedAt?.let { runCatching { Instant.parse(it) }.getOrNull() }
+        ?: Instant.fromEpochSeconds(0),
+)

--- a/api/simkl/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklCalendarRemoteDataSourceTest.kt
+++ b/api/simkl/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklCalendarRemoteDataSourceTest.kt
@@ -6,6 +6,7 @@ import com.thomaskioko.tvmaniac.data.calendar.RemoteCalendarEntry
 import com.thomaskioko.tvmaniac.followedshows.api.FollowedShowEntry
 import com.thomaskioko.tvmaniac.followedshows.testing.FakeFollowedShowsDao
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.client.HttpClient
@@ -146,11 +147,35 @@ internal class SimklCalendarRemoteDataSourceTest {
         val entry = success.body.single()
         entry.tmdbId shouldBe trackedTmdbId
         entry.showTitle shouldBe "Breaking Bad"
-        entry.episodeTitle shouldBe "Pilot"
+        entry.episodeTitle.shouldBeNull()
         entry.seasonNumber shouldBe 1
         entry.episodeNumber shouldBe 1
         entry.firstAiredIso shouldBe "2026-04-19T03:00:00.000Z"
-        entry.runtime shouldBe 50
+        entry.runtime.shouldBeNull()
+    }
+
+    @Test
+    fun `should default season to 1 given anime entry without a season`() = runTest {
+        val animeTmdbId = 60625L
+
+        val engine = MockEngine { request ->
+            val path = request.url.encodedPath
+            val body = when {
+                path.endsWith("anime.json") -> ANIME_FEED_SINGLE_SHOW
+                else -> "[]"
+            }
+            respond(body, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+
+        val source = buildSource(
+            engine = engine,
+            followedEntries = listOf(followedEntry(tmdbId = animeTmdbId)),
+        )
+
+        val result = source.getCalendarEntries(startDate = "2026-04-19", days = 7)
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<List<RemoteCalendarEntry>>>()
+        success.body.single().seasonNumber shouldBe 1
     }
 
     @Test
@@ -189,14 +214,14 @@ private val TV_FEED_SINGLE_SHOW = """
   {
     "date": "2026-04-19T03:00:00.000Z",
     "title": "Breaking Bad",
-    "ep_title": "Pilot",
-    "season": 1,
-    "episode": 1,
-    "runtime": 50,
     "ids": {
-      "simkl": 583436,
+      "simkl_id": 583436,
       "tmdb": "1396",
       "imdb": "tt0903747"
+    },
+    "episode": {
+      "season": 1,
+      "episode": 1
     }
   }
 ]
@@ -207,27 +232,27 @@ private val TV_FEED_WITH_TWO_SHOWS = """
   {
     "date": "2026-04-19T03:00:00.000Z",
     "title": "Breaking Bad",
-    "ep_title": "Pilot",
-    "season": 1,
-    "episode": 1,
-    "runtime": 50,
     "ids": {
-      "simkl": 583436,
+      "simkl_id": 583436,
       "tmdb": "1396",
       "imdb": "tt0903747"
+    },
+    "episode": {
+      "season": 1,
+      "episode": 1
     }
   },
   {
     "date": "2026-04-26T03:00:00.000Z",
     "title": "Game of Thrones",
-    "ep_title": "Winter is Coming",
-    "season": 1,
-    "episode": 1,
-    "runtime": 60,
     "ids": {
-      "simkl": 1399,
+      "simkl_id": 1399,
       "tmdb": "1399",
       "imdb": "tt0944947"
+    },
+    "episode": {
+      "season": 1,
+      "episode": 1
     }
   }
 ]
@@ -238,14 +263,13 @@ private val ANIME_FEED_SINGLE_SHOW = """
   {
     "date": "2026-04-20T14:00:00.000Z",
     "title": "Attack on Titan",
-    "ep_title": "To You in 2000 Years",
-    "season": 1,
-    "episode": 1,
-    "runtime": 24,
     "ids": {
-      "simkl": 60625,
+      "simkl_id": 60625,
       "tmdb": "60625",
-      "imdb": "tt2560140"
+      "mal": "16498"
+    },
+    "episode": {
+      "episode": 1
     }
   }
 ]
@@ -256,9 +280,10 @@ private val TV_FEED_WITH_MISSING_IDS = """
   {
     "date": "2026-04-19T03:00:00.000Z",
     "title": "No IDs Show",
-    "ep_title": "Pilot",
-    "season": 1,
-    "episode": 1
+    "episode": {
+      "season": 1,
+      "episode": 1
+    }
   }
 ]
 """.trimIndent()

--- a/api/simkl/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklCalendarRemoteDataSourceTest.kt
+++ b/api/simkl/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklCalendarRemoteDataSourceTest.kt
@@ -1,0 +1,264 @@
+package com.thomaskioko.tvmaniac.simkl.implementation
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.data.calendar.RemoteCalendarEntry
+import com.thomaskioko.tvmaniac.followedshows.api.FollowedShowEntry
+import com.thomaskioko.tvmaniac.followedshows.testing.FakeFollowedShowsDao
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.time.Instant
+
+internal class SimklCalendarRemoteDataSourceTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        prettyPrint = true
+        encodeDefaults = true
+    }
+
+    private fun buildSource(
+        engine: MockEngine,
+        followedEntries: List<FollowedShowEntry> = emptyList(),
+    ): SimklCalendarRemoteDataSource {
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(json = json) }
+        }
+        val dao = FakeFollowedShowsDao()
+        dao.setEntries(followedEntries)
+        return SimklCalendarRemoteDataSource(
+            httpClient = client,
+            followedShowsDao = dao,
+        )
+    }
+
+    @Test
+    fun `should report simkl as its provider`() {
+        val source = buildSource(
+            engine = MockEngine { respond("[]", HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json")) },
+        )
+        source.provider shouldBe AccountProvider.SIMKL
+    }
+
+    @Test
+    fun `should return empty list given no shows are tracked`() = runTest {
+        val engine = MockEngine { respond("[]", HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json")) }
+
+        val source = buildSource(engine = engine, followedEntries = emptyList())
+
+        val result = source.getCalendarEntries(startDate = "2026-04-19", days = 7)
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<List<RemoteCalendarEntry>>>()
+        success.body.shouldBeEmpty()
+    }
+
+    @Test
+    fun `should filter entries to only tracked shows given mixed tmdb ids in feed`() = runTest {
+        val trackedTmdbId = 1396L
+        val untrackedTmdbId = 1399L
+
+        val engine = MockEngine { request ->
+            val path = request.url.encodedPath
+            val body = when {
+                path.endsWith("tv.json") -> TV_FEED_WITH_TWO_SHOWS
+                else -> "[]"
+            }
+            respond(body, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+
+        val source = buildSource(
+            engine = engine,
+            followedEntries = listOf(
+                followedEntry(tmdbId = trackedTmdbId),
+            ),
+        )
+
+        val result = source.getCalendarEntries(startDate = "2026-04-19", days = 7)
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<List<RemoteCalendarEntry>>>()
+        success.body.all { it.tmdbId == trackedTmdbId } shouldBe true
+        success.body.none { it.tmdbId == untrackedTmdbId } shouldBe true
+    }
+
+    @Test
+    fun `should merge tv and anime entries given both feeds have tracked shows`() = runTest {
+        val tvTmdbId = 1396L
+        val animeTmdbId = 60625L
+
+        val engine = MockEngine { request ->
+            val path = request.url.encodedPath
+            val body = when {
+                path.endsWith("tv.json") -> TV_FEED_SINGLE_SHOW
+                path.endsWith("anime.json") -> ANIME_FEED_SINGLE_SHOW
+                else -> "[]"
+            }
+            respond(body, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+
+        val source = buildSource(
+            engine = engine,
+            followedEntries = listOf(
+                followedEntry(tmdbId = tvTmdbId),
+                followedEntry(tmdbId = animeTmdbId),
+            ),
+        )
+
+        val result = source.getCalendarEntries(startDate = "2026-04-19", days = 7)
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<List<RemoteCalendarEntry>>>()
+        success.body.size shouldBe 2
+        success.body.map { it.tmdbId }.toSet() shouldBe setOf(tvTmdbId, animeTmdbId)
+    }
+
+    @Test
+    fun `should map calendar entry fields correctly given valid feed entry`() = runTest {
+        val trackedTmdbId = 1396L
+
+        val engine = MockEngine { request ->
+            val path = request.url.encodedPath
+            val body = when {
+                path.endsWith("tv.json") -> TV_FEED_SINGLE_SHOW
+                else -> "[]"
+            }
+            respond(body, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+
+        val source = buildSource(
+            engine = engine,
+            followedEntries = listOf(followedEntry(tmdbId = trackedTmdbId)),
+        )
+
+        val result = source.getCalendarEntries(startDate = "2026-04-19", days = 7)
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<List<RemoteCalendarEntry>>>()
+        val entry = success.body.single()
+        entry.tmdbId shouldBe trackedTmdbId
+        entry.showTitle shouldBe "Breaking Bad"
+        entry.episodeTitle shouldBe "Pilot"
+        entry.seasonNumber shouldBe 1
+        entry.episodeNumber shouldBe 1
+        entry.firstAiredIso shouldBe "2026-04-19T03:00:00.000Z"
+        entry.runtime shouldBe 50
+    }
+
+    @Test
+    fun `should skip entries without tmdb id given feed contains entries missing ids`() = runTest {
+        val trackedTmdbId = 1396L
+
+        val engine = MockEngine { request ->
+            val path = request.url.encodedPath
+            val body = when {
+                path.endsWith("tv.json") -> TV_FEED_WITH_MISSING_IDS
+                else -> "[]"
+            }
+            respond(body, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+
+        val source = buildSource(
+            engine = engine,
+            followedEntries = listOf(followedEntry(tmdbId = trackedTmdbId)),
+        )
+
+        val result = source.getCalendarEntries(startDate = "2026-04-19", days = 7)
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<List<RemoteCalendarEntry>>>()
+        success.body.shouldBeEmpty()
+    }
+}
+
+private fun followedEntry(tmdbId: Long): FollowedShowEntry = FollowedShowEntry(
+    showId = tmdbId,
+    tmdbId = tmdbId,
+    followedAt = Instant.fromEpochSeconds(0),
+)
+
+private val TV_FEED_SINGLE_SHOW = """
+[
+  {
+    "date": "2026-04-19T03:00:00.000Z",
+    "title": "Breaking Bad",
+    "ep_title": "Pilot",
+    "season": 1,
+    "episode": 1,
+    "runtime": 50,
+    "ids": {
+      "simkl": 583436,
+      "tmdb": "1396",
+      "imdb": "tt0903747"
+    }
+  }
+]
+""".trimIndent()
+
+private val TV_FEED_WITH_TWO_SHOWS = """
+[
+  {
+    "date": "2026-04-19T03:00:00.000Z",
+    "title": "Breaking Bad",
+    "ep_title": "Pilot",
+    "season": 1,
+    "episode": 1,
+    "runtime": 50,
+    "ids": {
+      "simkl": 583436,
+      "tmdb": "1396",
+      "imdb": "tt0903747"
+    }
+  },
+  {
+    "date": "2026-04-26T03:00:00.000Z",
+    "title": "Game of Thrones",
+    "ep_title": "Winter is Coming",
+    "season": 1,
+    "episode": 1,
+    "runtime": 60,
+    "ids": {
+      "simkl": 1399,
+      "tmdb": "1399",
+      "imdb": "tt0944947"
+    }
+  }
+]
+""".trimIndent()
+
+private val ANIME_FEED_SINGLE_SHOW = """
+[
+  {
+    "date": "2026-04-20T14:00:00.000Z",
+    "title": "Attack on Titan",
+    "ep_title": "To You in 2000 Years",
+    "season": 1,
+    "episode": 1,
+    "runtime": 24,
+    "ids": {
+      "simkl": 60625,
+      "tmdb": "60625",
+      "imdb": "tt2560140"
+    }
+  }
+]
+""".trimIndent()
+
+private val TV_FEED_WITH_MISSING_IDS = """
+[
+  {
+    "date": "2026-04-19T03:00:00.000Z",
+    "title": "No IDs Show",
+    "ep_title": "Pilot",
+    "season": 1,
+    "episode": 1
+  }
+]
+""".trimIndent()

--- a/api/simkl/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklStartWatchingRemoteDataSourceTest.kt
+++ b/api/simkl/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklStartWatchingRemoteDataSourceTest.kt
@@ -1,0 +1,178 @@
+package com.thomaskioko.tvmaniac.simkl.implementation
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklAllItemsResponse
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklShowEntry
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklShowIds
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklWatchedShow
+import com.thomaskioko.tvmaniac.simkl.testing.FakeSimklSyncRemoteDataSource
+import com.thomaskioko.tvmaniac.startwatching.api.RemotePlanToWatchShow
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.time.Instant
+
+internal class SimklStartWatchingRemoteDataSourceTest {
+
+    private val syncDataSource = FakeSimklSyncRemoteDataSource()
+    private val source = SimklStartWatchingRemoteDataSource(syncDataSource)
+
+    @Test
+    fun `should report simkl as its provider`() {
+        source.provider shouldBe AccountProvider.SIMKL
+    }
+
+    @Test
+    fun `should return only plantowatch shows given mixed-status response`() = runTest {
+        syncDataSource.setAllWatchedShows(
+            ApiResponse.Success(
+                SimklAllItemsResponse(
+                    shows = listOf(
+                        simklWatchedShow(simklId = 1, tmdb = "100", status = "plantowatch", title = "Plan Show"),
+                        simklWatchedShow(simklId = 2, tmdb = "200", status = "watching", title = "Watching Show"),
+                        simklWatchedShow(simklId = 3, tmdb = "300", status = "completed", title = "Completed Show"),
+                        simklWatchedShow(simklId = 4, tmdb = "400", status = "hold", title = "Hold Show"),
+                    ),
+                ),
+            ),
+        )
+
+        val result = source.getPlanToWatch()
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<List<RemotePlanToWatchShow>>>()
+        success.body.map { it.title } shouldBe listOf("Plan Show")
+    }
+
+    @Test
+    fun `should map plan-to-watch show fields correctly given valid response`() = runTest {
+        syncDataSource.setAllWatchedShows(
+            ApiResponse.Success(
+                SimklAllItemsResponse(
+                    shows = listOf(
+                        simklWatchedShow(
+                            simklId = 583436,
+                            tmdb = "62417",
+                            status = "plantowatch",
+                            title = "Emerald City",
+                            year = 2017,
+                            imdb = "tt3579018",
+                            lastWatchedAt = "2025-01-15T10:00:00Z",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val result = source.getPlanToWatch()
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<List<RemotePlanToWatchShow>>>()
+        val show = success.body.single()
+        show.tmdbId shouldBe 62417L
+        show.imdbId shouldBe "tt3579018"
+        show.providerShowId shouldBe "583436"
+        show.provider shouldBe AccountProvider.SIMKL
+        show.title shouldBe "Emerald City"
+        show.year shouldBe 2017
+        show.followedAt shouldBe Instant.parse("2025-01-15T10:00:00Z")
+    }
+
+    @Test
+    fun `should return empty list given no shows have plantowatch status`() = runTest {
+        syncDataSource.setAllWatchedShows(
+            ApiResponse.Success(
+                SimklAllItemsResponse(
+                    shows = listOf(
+                        simklWatchedShow(simklId = 1, tmdb = "100", status = "watching", title = "Active Show"),
+                        simklWatchedShow(simklId = 2, tmdb = "200", status = "completed", title = "Done Show"),
+                    ),
+                ),
+            ),
+        )
+
+        val result = source.getPlanToWatch()
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<List<RemotePlanToWatchShow>>>()
+        success.body.shouldBeEmpty()
+    }
+
+    @Test
+    fun `should use epoch zero as followedAt given show has no last_watched_at`() = runTest {
+        syncDataSource.setAllWatchedShows(
+            ApiResponse.Success(
+                SimklAllItemsResponse(
+                    shows = listOf(
+                        simklWatchedShow(
+                            simklId = 1,
+                            tmdb = "100",
+                            status = "plantowatch",
+                            title = "No Date Show",
+                            lastWatchedAt = null,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val result = source.getPlanToWatch()
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<List<RemotePlanToWatchShow>>>()
+        success.body.single().followedAt shouldBe Instant.fromEpochSeconds(0)
+    }
+
+    @Test
+    fun `should preserve unauthenticated given sync source returns unauthenticated`() = runTest {
+        syncDataSource.setAllWatchedShows(ApiResponse.Unauthenticated)
+
+        val result = source.getPlanToWatch()
+
+        result.shouldBeInstanceOf<ApiResponse.Unauthenticated>()
+    }
+
+    @Test
+    fun `should include show with null tmdb id in result given simkl show has no tmdb`() = runTest {
+        syncDataSource.setAllWatchedShows(
+            ApiResponse.Success(
+                SimklAllItemsResponse(
+                    shows = listOf(
+                        simklWatchedShow(
+                            simklId = 999,
+                            tmdb = null,
+                            status = "plantowatch",
+                            title = "No TMDB Show",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val result = source.getPlanToWatch()
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<List<RemotePlanToWatchShow>>>()
+        success.body.single().tmdbId shouldBe null
+    }
+}
+
+private fun simklWatchedShow(
+    simklId: Long,
+    tmdb: String?,
+    status: String,
+    title: String,
+    year: Int? = 2020,
+    imdb: String? = null,
+    lastWatchedAt: String? = null,
+): SimklWatchedShow = SimklWatchedShow(
+    status = status,
+    lastWatchedAt = lastWatchedAt,
+    show = SimklShowEntry(
+        title = title,
+        year = year,
+        ids = SimklShowIds(
+            simkl = simklId,
+            tmdb = tmdb,
+            imdb = imdb,
+        ),
+    ),
+)

--- a/api/trakt/implementation/build.gradle.kts
+++ b/api/trakt/implementation/build.gradle.kts
@@ -27,7 +27,9 @@ kotlin {
                 api(projects.data.accountManager.api)
                 api(projects.data.episode.api)
                 api(projects.data.followedshows.api)
+                api(projects.data.calendar.api)
                 api(projects.data.library.api)
+                api(projects.data.startWatching.api)
                 api(projects.data.user.api)
                 api(projects.data.oauth.api)
                 api(projects.data.syncActivity.api)
@@ -48,6 +50,7 @@ kotlin {
                 implementation(projects.api.trakt.api)
                 implementation(projects.api.trakt.testing)
                 implementation(projects.core.networkUtil.api)
+                implementation(projects.data.calendar.api)
             }
         }
 

--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktCalendarRemoteDataSourceAdapter.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktCalendarRemoteDataSourceAdapter.kt
@@ -29,6 +29,7 @@ public class TraktCalendarRemoteDataSourceAdapter(
 private fun com.thomaskioko.tvmaniac.trakt.api.model.TraktCalendarResponse.toRemoteCalendarEntry(): RemoteCalendarEntry =
     RemoteCalendarEntry(
         tmdbId = show.ids.tmdb ?: 0L,
+        episodeTraktId = episode.ids.trakt.toLong(),
         showTitle = show.title,
         episodeTitle = episode.title,
         seasonNumber = episode.seasonNumber,

--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktCalendarRemoteDataSourceAdapter.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktCalendarRemoteDataSourceAdapter.kt
@@ -1,0 +1,41 @@
+package com.thomaskioko.trakt.service.implementation.sync
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.map
+import com.thomaskioko.tvmaniac.data.calendar.CalendarRemoteDataSource
+import com.thomaskioko.tvmaniac.data.calendar.RemoteCalendarEntry
+import com.thomaskioko.tvmaniac.trakt.api.TraktCalendarRemoteDataSource
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.SingleIn
+
+@SingleIn(AppScope::class)
+@ContributesIntoSet(AppScope::class)
+public class TraktCalendarRemoteDataSourceAdapter(
+    private val traktCalendarDataSource: TraktCalendarRemoteDataSource,
+) : CalendarRemoteDataSource {
+
+    override val provider: AccountProvider = AccountProvider.TRAKT
+
+    override suspend fun getCalendarEntries(
+        startDate: String,
+        days: Int,
+    ): ApiResponse<List<RemoteCalendarEntry>> =
+        traktCalendarDataSource.getMyShowsCalendar(startDate = startDate, days = days)
+            .map { responses -> responses.map { it.toRemoteCalendarEntry() } }
+}
+
+private fun com.thomaskioko.tvmaniac.trakt.api.model.TraktCalendarResponse.toRemoteCalendarEntry(): RemoteCalendarEntry =
+    RemoteCalendarEntry(
+        tmdbId = show.ids.tmdb ?: 0L,
+        showTitle = show.title,
+        episodeTitle = episode.title,
+        seasonNumber = episode.seasonNumber,
+        episodeNumber = episode.episodeNumber,
+        firstAiredIso = firstAired,
+        runtime = episode.runtime,
+        overview = episode.overview,
+        rating = episode.rating,
+        votes = episode.votes,
+    )

--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktStartWatchingRemoteDataSource.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktStartWatchingRemoteDataSource.kt
@@ -1,0 +1,42 @@
+package com.thomaskioko.trakt.service.implementation.sync
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.map
+import com.thomaskioko.tvmaniac.startwatching.api.RemotePlanToWatchShow
+import com.thomaskioko.tvmaniac.startwatching.api.StartWatchingRemoteDataSource
+import com.thomaskioko.tvmaniac.trakt.api.TraktListRemoteDataSource
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktFollowedShowResponse
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.SingleIn
+import kotlin.time.Instant
+
+@SingleIn(AppScope::class)
+@ContributesIntoSet(AppScope::class)
+public class TraktStartWatchingRemoteDataSource(
+    private val remoteDataSource: TraktListRemoteDataSource,
+) : StartWatchingRemoteDataSource {
+
+    override val provider: AccountProvider = AccountProvider.TRAKT
+
+    override suspend fun getPlanToWatch(): ApiResponse<List<RemotePlanToWatchShow>> =
+        remoteDataSource.getWatchList(sortBy = SORT_BY, sortHow = SORT_HOW)
+            .map { shows -> shows.map { it.toRemotePlanToWatchShow() } }
+
+    private companion object {
+        private const val SORT_BY = "added"
+        private const val SORT_HOW = "desc"
+    }
+}
+
+private fun TraktFollowedShowResponse.toRemotePlanToWatchShow(): RemotePlanToWatchShow =
+    RemotePlanToWatchShow(
+        tmdbId = show.ids.tmdb,
+        imdbId = show.ids.imdb,
+        providerShowId = show.ids.trakt.toString(),
+        provider = AccountProvider.TRAKT,
+        title = show.title,
+        year = show.year,
+        followedAt = Instant.parse(listedAt),
+    )

--- a/api/trakt/implementation/src/commonTest/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktCalendarRemoteDataSourceAdapterTest.kt
+++ b/api/trakt/implementation/src/commonTest/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktCalendarRemoteDataSourceAdapterTest.kt
@@ -50,6 +50,7 @@ internal class TraktCalendarRemoteDataSourceAdapterTest {
                         overview = "Walt cooks meth.",
                         rating = 8.5,
                         votes = 120,
+                        episodeTraktId = 73640,
                     ),
                 ),
             ),
@@ -69,6 +70,7 @@ internal class TraktCalendarRemoteDataSourceAdapterTest {
         entry.overview shouldBe "Walt cooks meth."
         entry.rating shouldBe 8.5
         entry.votes shouldBe 120
+        entry.episodeTraktId shouldBe 73640L
     }
 
     @Test
@@ -121,13 +123,14 @@ private fun traktCalendarResponse(
     overview: String?,
     rating: Double?,
     votes: Int?,
+    episodeTraktId: Int = 1,
 ): TraktCalendarResponse = TraktCalendarResponse(
     firstAired = firstAired,
     episode = TraktCalendarEpisode(
         seasonNumber = seasonNumber,
         episodeNumber = episodeNumber,
         title = episodeTitle,
-        ids = EpisodeIds(trakt = 1, tmdb = null),
+        ids = EpisodeIds(trakt = episodeTraktId, tmdb = null),
         runtime = runtime,
         overview = overview,
         rating = rating,

--- a/api/trakt/implementation/src/commonTest/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktCalendarRemoteDataSourceAdapterTest.kt
+++ b/api/trakt/implementation/src/commonTest/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktCalendarRemoteDataSourceAdapterTest.kt
@@ -1,0 +1,140 @@
+package com.thomaskioko.trakt.service.implementation.sync
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.data.calendar.RemoteCalendarEntry
+import com.thomaskioko.tvmaniac.trakt.api.model.EpisodeIds
+import com.thomaskioko.tvmaniac.trakt.api.model.ShowIds
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktCalendarEpisode
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktCalendarResponse
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktCalendarShow
+import com.thomaskioko.tvmaniac.trakt.testing.FakeTraktCalendarRemoteDataSource
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+internal class TraktCalendarRemoteDataSourceAdapterTest {
+
+    private val traktDataSource = FakeTraktCalendarRemoteDataSource()
+    private val adapter = TraktCalendarRemoteDataSourceAdapter(traktDataSource)
+
+    @Test
+    fun `should report trakt as its provider`() {
+        adapter.provider shouldBe AccountProvider.TRAKT
+    }
+
+    @Test
+    fun `should return empty list given trakt calendar returns no entries`() = runTest {
+        traktDataSource.setCalendarEntries(ApiResponse.Success(emptyList()))
+
+        val result = adapter.getCalendarEntries(startDate = "2026-04-19", days = 7)
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<List<RemoteCalendarEntry>>>()
+        success.body shouldBe emptyList()
+    }
+
+    @Test
+    fun `should map trakt response to remote calendar entries given valid calendar data`() = runTest {
+        traktDataSource.setCalendarEntries(
+            ApiResponse.Success(
+                listOf(
+                    traktCalendarResponse(
+                        firstAired = "2026-04-19T03:00:00.000Z",
+                        tmdbId = 1396L,
+                        showTitle = "Breaking Bad",
+                        episodeTitle = "Pilot",
+                        seasonNumber = 1,
+                        episodeNumber = 1,
+                        runtime = 50,
+                        overview = "Walt cooks meth.",
+                        rating = 8.5,
+                        votes = 120,
+                    ),
+                ),
+            ),
+        )
+
+        val result = adapter.getCalendarEntries(startDate = "2026-04-19", days = 7)
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<List<RemoteCalendarEntry>>>()
+        val entry = success.body.single()
+        entry.tmdbId shouldBe 1396L
+        entry.showTitle shouldBe "Breaking Bad"
+        entry.episodeTitle shouldBe "Pilot"
+        entry.seasonNumber shouldBe 1
+        entry.episodeNumber shouldBe 1
+        entry.firstAiredIso shouldBe "2026-04-19T03:00:00.000Z"
+        entry.runtime shouldBe 50
+        entry.overview shouldBe "Walt cooks meth."
+        entry.rating shouldBe 8.5
+        entry.votes shouldBe 120
+    }
+
+    @Test
+    fun `should use zero as tmdb id given trakt entry has no tmdb id`() = runTest {
+        traktDataSource.setCalendarEntries(
+            ApiResponse.Success(
+                listOf(
+                    traktCalendarResponse(
+                        firstAired = "2026-04-19T03:00:00.000Z",
+                        tmdbId = null,
+                        showTitle = "Unknown Show",
+                        episodeTitle = null,
+                        seasonNumber = 1,
+                        episodeNumber = 1,
+                        runtime = null,
+                        overview = null,
+                        rating = null,
+                        votes = null,
+                    ),
+                ),
+            ),
+        )
+
+        val result = adapter.getCalendarEntries(startDate = "2026-04-19", days = 7)
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<List<RemoteCalendarEntry>>>()
+        success.body.single().tmdbId shouldBe 0L
+    }
+
+    @Test
+    fun `should propagate error given trakt calendar returns error`() = runTest {
+        traktDataSource.setCalendarEntries(
+            ApiResponse.Error.HttpError(code = 500, errorBody = null, errorMessage = "Server error"),
+        )
+
+        val result = adapter.getCalendarEntries(startDate = "2026-04-19", days = 7)
+
+        result.shouldBeInstanceOf<ApiResponse.Error.HttpError<*>>()
+    }
+}
+
+private fun traktCalendarResponse(
+    firstAired: String,
+    tmdbId: Long?,
+    showTitle: String,
+    episodeTitle: String?,
+    seasonNumber: Int,
+    episodeNumber: Int,
+    runtime: Int?,
+    overview: String?,
+    rating: Double?,
+    votes: Int?,
+): TraktCalendarResponse = TraktCalendarResponse(
+    firstAired = firstAired,
+    episode = TraktCalendarEpisode(
+        seasonNumber = seasonNumber,
+        episodeNumber = episodeNumber,
+        title = episodeTitle,
+        ids = EpisodeIds(trakt = 1, tmdb = null),
+        runtime = runtime,
+        overview = overview,
+        rating = rating,
+        votes = votes,
+    ),
+    show = TraktCalendarShow(
+        title = showTitle,
+        ids = ShowIds(trakt = 1L, tmdb = tmdbId),
+    ),
+)

--- a/api/trakt/implementation/src/commonTest/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktStartWatchingRemoteDataSourceTest.kt
+++ b/api/trakt/implementation/src/commonTest/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktStartWatchingRemoteDataSourceTest.kt
@@ -1,0 +1,123 @@
+package com.thomaskioko.trakt.service.implementation.sync
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.startwatching.api.RemotePlanToWatchShow
+import com.thomaskioko.tvmaniac.trakt.api.model.IdsResponse
+import com.thomaskioko.tvmaniac.trakt.api.model.ShowResponse
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktFollowedShowResponse
+import com.thomaskioko.tvmaniac.trakt.testing.FakeTraktListRemoteDataSource
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.time.Instant
+
+internal class TraktStartWatchingRemoteDataSourceTest {
+
+    private val remoteDataSource = FakeTraktListRemoteDataSource()
+    private val source = TraktStartWatchingRemoteDataSource(remoteDataSource)
+
+    @Test
+    fun `should report trakt as its provider`() {
+        source.provider shouldBe AccountProvider.TRAKT
+    }
+
+    @Test
+    fun `should map watchlist shows to plan-to-watch given successful response`() = runTest {
+        remoteDataSource.setWatchList(
+            ApiResponse.Success(
+                listOf(
+                    traktFollowedShow(
+                        traktId = 1,
+                        tmdbId = 10,
+                        title = "Severance",
+                        year = 2022,
+                        listedAt = "2025-01-01T00:00:00Z",
+                    ),
+                ),
+            ),
+        )
+
+        val result = source.getPlanToWatch()
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<List<RemotePlanToWatchShow>>>()
+        success.body shouldBe listOf(
+            RemotePlanToWatchShow(
+                tmdbId = 10,
+                imdbId = null,
+                providerShowId = "1",
+                provider = AccountProvider.TRAKT,
+                title = "Severance",
+                year = 2022,
+                followedAt = Instant.parse("2025-01-01T00:00:00Z"),
+            ),
+        )
+    }
+
+    @Test
+    fun `should return empty list given no watchlist items`() = runTest {
+        remoteDataSource.setWatchList(ApiResponse.Success(emptyList()))
+
+        val result = source.getPlanToWatch()
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<List<RemotePlanToWatchShow>>>()
+        success.body shouldBe emptyList()
+    }
+
+    @Test
+    fun `should preserve unauthenticated given remote source returns unauthenticated`() = runTest {
+        remoteDataSource.setWatchList(ApiResponse.Unauthenticated)
+
+        val result = source.getPlanToWatch()
+
+        result.shouldBeInstanceOf<ApiResponse.Unauthenticated>()
+    }
+
+    @Test
+    fun `should map imdb id given show has imdb id`() = runTest {
+        remoteDataSource.setWatchList(
+            ApiResponse.Success(
+                listOf(
+                    traktFollowedShow(
+                        traktId = 2,
+                        tmdbId = 20,
+                        title = "The Bear",
+                        year = 2023,
+                        listedAt = "2025-06-01T00:00:00Z",
+                        imdbId = "tt14452776",
+                    ),
+                ),
+            ),
+        )
+
+        val result = source.getPlanToWatch()
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<List<RemotePlanToWatchShow>>>()
+        success.body.first().imdbId shouldBe "tt14452776"
+    }
+}
+
+private fun traktFollowedShow(
+    traktId: Long,
+    tmdbId: Long,
+    title: String,
+    year: Int?,
+    listedAt: String,
+    imdbId: String? = null,
+): TraktFollowedShowResponse = TraktFollowedShowResponse(
+    rank = 1,
+    id = traktId.toInt(),
+    listedAt = listedAt,
+    type = "show",
+    show = ShowResponse(
+        title = title,
+        year = year,
+        ids = IdsResponse(
+            slug = "slug-$traktId",
+            trakt = traktId,
+            tmdb = tmdbId,
+            imdb = imdbId,
+        ),
+    ),
+)

--- a/api/trakt/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/testing/FakeTraktCalendarRemoteDataSource.kt
+++ b/api/trakt/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/testing/FakeTraktCalendarRemoteDataSource.kt
@@ -1,0 +1,19 @@
+package com.thomaskioko.tvmaniac.trakt.testing
+
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.trakt.api.TraktCalendarRemoteDataSource
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktCalendarResponse
+
+public class FakeTraktCalendarRemoteDataSource(
+    private var calendarResponse: ApiResponse<List<TraktCalendarResponse>> = ApiResponse.Success(emptyList()),
+) : TraktCalendarRemoteDataSource {
+
+    public fun setCalendarEntries(response: ApiResponse<List<TraktCalendarResponse>>) {
+        calendarResponse = response
+    }
+
+    override suspend fun getMyShowsCalendar(
+        startDate: String,
+        days: Int,
+    ): ApiResponse<List<TraktCalendarResponse>> = calendarResponse
+}

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/robot/CalendarRobot.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/robot/CalendarRobot.kt
@@ -35,6 +35,7 @@ internal class CalendarRobot(composeUi: ComposeUiTest) : BaseRobot<CalendarRobot
 
     fun assertDateHeaderDisplayed(text: String) = apply {
         val tag = CalendarTestTags.dateHeader(text)
+        scrollTo(tag)
         assertDisplayed(tag)
         assertTextEquals(tag, text)
     }

--- a/core/base/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/base/Qualifiers.kt
+++ b/core/base/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/base/Qualifiers.kt
@@ -41,6 +41,10 @@ public annotation class SimklApi
 
 @Qualifier
 @Retention(BINARY)
+public annotation class SimklDataApi
+
+@Qualifier
+@Retention(BINARY)
 public annotation class IsDebugBuild
 
 @Qualifier

--- a/core/integration/infra/src/androidMain/resources/fixtures/simkl/calendar/anime.json
+++ b/core/integration/infra/src/androidMain/resources/fixtures/simkl/calendar/anime.json
@@ -2,14 +2,13 @@
   {
     "date": "2026-04-20T14:00:00.000Z",
     "title": "Attack on Titan",
-    "ep_title": "To You, in 2000 Years",
-    "season": 1,
-    "episode": 1,
-    "runtime": 24,
     "ids": {
-      "simkl": 60625,
+      "simkl_id": 60625,
       "tmdb": "60625",
-      "imdb": "tt2560140"
+      "mal": "16498"
+    },
+    "episode": {
+      "episode": 1
     }
   }
 ]

--- a/core/integration/infra/src/androidMain/resources/fixtures/simkl/calendar/anime.json
+++ b/core/integration/infra/src/androidMain/resources/fixtures/simkl/calendar/anime.json
@@ -1,0 +1,15 @@
+[
+  {
+    "date": "2026-04-20T14:00:00.000Z",
+    "title": "Attack on Titan",
+    "ep_title": "To You, in 2000 Years",
+    "season": 1,
+    "episode": 1,
+    "runtime": 24,
+    "ids": {
+      "simkl": 60625,
+      "tmdb": "60625",
+      "imdb": "tt2560140"
+    }
+  }
+]

--- a/core/integration/infra/src/androidMain/resources/fixtures/simkl/calendar/tv.json
+++ b/core/integration/infra/src/androidMain/resources/fixtures/simkl/calendar/tv.json
@@ -2,40 +2,40 @@
   {
     "date": "2026-04-19T03:00:00.000Z",
     "title": "Breaking Bad",
-    "ep_title": "Pilot",
-    "season": 1,
-    "episode": 1,
-    "runtime": 50,
     "ids": {
-      "simkl": 583436,
+      "simkl_id": 583436,
       "tmdb": "1396",
       "imdb": "tt0903747"
+    },
+    "episode": {
+      "season": 1,
+      "episode": 1
     }
   },
   {
     "date": "2026-04-19T03:00:00.000Z",
     "title": "Breaking Bad",
-    "ep_title": "Cat's in the Bag...",
-    "season": 1,
-    "episode": 2,
-    "runtime": 48,
     "ids": {
-      "simkl": 583436,
+      "simkl_id": 583436,
       "tmdb": "1396",
       "imdb": "tt0903747"
+    },
+    "episode": {
+      "season": 1,
+      "episode": 2
     }
   },
   {
     "date": "2026-04-26T03:00:00.000Z",
     "title": "Game of Thrones",
-    "ep_title": "Winter is Coming",
-    "season": 1,
-    "episode": 1,
-    "runtime": 60,
     "ids": {
-      "simkl": 1399,
+      "simkl_id": 1399,
       "tmdb": "1399",
       "imdb": "tt0944947"
+    },
+    "episode": {
+      "season": 1,
+      "episode": 1
     }
   }
 ]

--- a/core/integration/infra/src/androidMain/resources/fixtures/simkl/calendar/tv.json
+++ b/core/integration/infra/src/androidMain/resources/fixtures/simkl/calendar/tv.json
@@ -1,0 +1,41 @@
+[
+  {
+    "date": "2026-04-19T03:00:00.000Z",
+    "title": "Breaking Bad",
+    "ep_title": "Pilot",
+    "season": 1,
+    "episode": 1,
+    "runtime": 50,
+    "ids": {
+      "simkl": 583436,
+      "tmdb": "1396",
+      "imdb": "tt0903747"
+    }
+  },
+  {
+    "date": "2026-04-19T03:00:00.000Z",
+    "title": "Breaking Bad",
+    "ep_title": "Cat's in the Bag...",
+    "season": 1,
+    "episode": 2,
+    "runtime": 48,
+    "ids": {
+      "simkl": 583436,
+      "tmdb": "1396",
+      "imdb": "tt0903747"
+    }
+  },
+  {
+    "date": "2026-04-26T03:00:00.000Z",
+    "title": "Game of Thrones",
+    "ep_title": "Winter is Coming",
+    "season": 1,
+    "episode": 1,
+    "runtime": 60,
+    "ids": {
+      "simkl": 1399,
+      "tmdb": "1399",
+      "imdb": "tt0944947"
+    }
+  }
+]

--- a/data/calendar/api/build.gradle.kts
+++ b/data/calendar/api/build.gradle.kts
@@ -7,6 +7,8 @@ kotlin {
         commonMain {
             dependencies {
                 api(libs.coroutines.core)
+                api(projects.core.networkUtil.api)
+                api(projects.data.accountManager.api)
             }
         }
     }

--- a/data/calendar/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/CalendarDao.kt
+++ b/data/calendar/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/CalendarDao.kt
@@ -6,6 +6,7 @@ public interface CalendarDao {
     public fun observeEntriesBetweenDates(startDate: Long, endDate: Long): Flow<List<CalendarEntry>>
     public fun hasEntriesInRange(startDate: Long, endDate: Long): Boolean
     public fun upsert(entry: CalendarEntry)
+    public fun upsertFromRemote(entry: RemoteCalendarEntry, posterPath: String?)
     public fun deleteEntriesInRange(startDate: Long, endDate: Long)
     public fun deleteOldEntries(cutoffDate: Long)
     public fun deleteAll()

--- a/data/calendar/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/CalendarRemoteDataSource.kt
+++ b/data/calendar/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/CalendarRemoteDataSource.kt
@@ -1,0 +1,12 @@
+package com.thomaskioko.tvmaniac.data.calendar
+
+import com.thomaskioko.tvmaniac.accountmanager.api.ProviderScoped
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+
+public interface CalendarRemoteDataSource : ProviderScoped {
+
+    public suspend fun getCalendarEntries(
+        startDate: String,
+        days: Int,
+    ): ApiResponse<List<RemoteCalendarEntry>>
+}

--- a/data/calendar/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/RemoteCalendarEntry.kt
+++ b/data/calendar/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/RemoteCalendarEntry.kt
@@ -1,0 +1,14 @@
+package com.thomaskioko.tvmaniac.data.calendar
+
+public data class RemoteCalendarEntry(
+    val tmdbId: Long,
+    val showTitle: String,
+    val episodeTitle: String?,
+    val seasonNumber: Int,
+    val episodeNumber: Int,
+    val firstAiredIso: String,
+    val runtime: Int?,
+    val overview: String?,
+    val rating: Double?,
+    val votes: Int?,
+)

--- a/data/calendar/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/RemoteCalendarEntry.kt
+++ b/data/calendar/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/RemoteCalendarEntry.kt
@@ -2,6 +2,7 @@ package com.thomaskioko.tvmaniac.data.calendar
 
 public data class RemoteCalendarEntry(
     val tmdbId: Long,
+    val episodeTraktId: Long?,
     val showTitle: String,
     val episodeTitle: String?,
     val seasonNumber: Int,

--- a/data/calendar/implementation/build.gradle.kts
+++ b/data/calendar/implementation/build.gradle.kts
@@ -12,8 +12,8 @@ kotlin {
             dependencies {
                 api(libs.coroutines.core)
                 api(libs.store5)
-                api(projects.api.trakt.api)
                 api(projects.core.base)
+                api(projects.data.accountManager.api)
                 api(projects.data.calendar.api)
                 api(projects.data.database.sqldelight)
                 api(projects.data.requestManager.api)

--- a/data/calendar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/implementation/CalendarStore.kt
+++ b/data/calendar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/implementation/CalendarStore.kt
@@ -1,23 +1,24 @@
 package com.thomaskioko.tvmaniac.data.calendar.implementation
 
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
-import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.apiFetcher
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.storeBuilder
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.usingDispatchers
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.AuthenticationException
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.getOrThrow
 import com.thomaskioko.tvmaniac.data.calendar.CalendarDao
 import com.thomaskioko.tvmaniac.data.calendar.CalendarEntry
+import com.thomaskioko.tvmaniac.data.calendar.CalendarRemoteDataSource
+import com.thomaskioko.tvmaniac.data.calendar.RemoteCalendarEntry
 import com.thomaskioko.tvmaniac.db.DatabaseTransactionRunner
 import com.thomaskioko.tvmaniac.resourcemanager.api.RequestManagerRepository
 import com.thomaskioko.tvmaniac.resourcemanager.api.RequestTypeConfig.CALENDAR_SHOWS
 import com.thomaskioko.tvmaniac.shows.api.TvShowsDao
-import com.thomaskioko.tvmaniac.trakt.api.TraktCalendarRemoteDataSource
-import com.thomaskioko.tvmaniac.trakt.api.model.TraktCalendarResponse
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.withContext
+import org.mobilenativefoundation.store.store5.Fetcher
 import org.mobilenativefoundation.store.store5.SourceOfTruth
 import org.mobilenativefoundation.store.store5.Store
 import org.mobilenativefoundation.store.store5.Validator
-import kotlin.time.Instant
 
 public data class CalendarParams(
     val startDate: String,
@@ -28,51 +29,34 @@ public data class CalendarParams(
 
 @Inject
 public class CalendarStore(
-    private val calendarDataSource: TraktCalendarRemoteDataSource,
+    private val activeSource: () -> CalendarRemoteDataSource?,
     private val calendarDao: CalendarDao,
     private val tvShowsDao: TvShowsDao,
     private val requestManagerRepository: RequestManagerRepository,
     private val databaseTransactionRunner: DatabaseTransactionRunner,
     private val dispatchers: AppCoroutineDispatchers,
 ) : Store<CalendarParams, List<CalendarEntry>> by storeBuilder(
-    fetcher = apiFetcher { params: CalendarParams ->
-        calendarDataSource.getMyShowsCalendar(params.startDate, params.days)
+    fetcher = Fetcher.of { params: CalendarParams ->
+        val source = activeSource() ?: throw AuthenticationException("No active calendar provider")
+        source.getCalendarEntries(params.startDate, params.days).getOrThrow()
     },
     sourceOfTruth = SourceOfTruth.of(
         reader = { params: CalendarParams ->
             calendarDao.observeEntriesBetweenDates(params.startEpoch, params.endEpoch)
         },
-        writer = { params: CalendarParams, response: List<TraktCalendarResponse> ->
+        writer = { params: CalendarParams, response: List<RemoteCalendarEntry> ->
             withContext(dispatchers.databaseWrite) {
                 databaseTransactionRunner {
                     calendarDao.deleteEntriesInRange(params.startEpoch, params.endEpoch)
 
-                    val showIds = response.map { it.show.ids.trakt }.distinct()
-                    val showPosters = tvShowsDao.getShowsByIds(showIds)
-                        .associate { it.showId to it.posterPath }
+                    val tmdbIds = response.map { it.tmdbId }.distinct()
+                    val postersByTmdbId = tvShowsDao.getShowsByIds(tmdbIds)
+                        .associate { it.tmdbId to it.posterPath }
 
-                    response.forEach { calendarResponse ->
-                        val showId = calendarResponse.show.ids.trakt
-                        val firstAiredEpoch = Instant.parse(calendarResponse.firstAired).toEpochMilliseconds()
-
-                        val posterPath = showPosters[showId]
-
-                        calendarDao.upsert(
-                            CalendarEntry(
-                                showId = showId,
-                                episodeId = calendarResponse.episode.ids.trakt.toLong(),
-                                seasonNumber = calendarResponse.episode.seasonNumber,
-                                episodeNumber = calendarResponse.episode.episodeNumber,
-                                episodeTitle = calendarResponse.episode.title,
-                                airDate = firstAiredEpoch,
-                                showTitle = calendarResponse.show.title,
-                                showPosterPath = posterPath,
-                                network = null,
-                                runtime = calendarResponse.episode.runtime,
-                                overview = calendarResponse.episode.overview,
-                                rating = calendarResponse.episode.rating,
-                                votes = calendarResponse.episode.votes,
-                            ),
+                    response.forEach { entry ->
+                        calendarDao.upsertFromRemote(
+                            entry = entry,
+                            posterPath = postersByTmdbId[entry.tmdbId],
                         )
                     }
                 }

--- a/data/calendar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/implementation/DefaultCalendarDao.kt
+++ b/data/calendar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/implementation/DefaultCalendarDao.kt
@@ -5,6 +5,7 @@ import app.cash.sqldelight.coroutines.mapToList
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.data.calendar.CalendarDao
 import com.thomaskioko.tvmaniac.data.calendar.CalendarEntry
+import com.thomaskioko.tvmaniac.data.calendar.RemoteCalendarEntry
 import com.thomaskioko.tvmaniac.db.ObserveEntriesBetweenDates
 import com.thomaskioko.tvmaniac.db.ShowIdResolver
 import com.thomaskioko.tvmaniac.db.TvManiacDatabase
@@ -13,6 +14,7 @@ import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlin.time.Instant
 
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
@@ -44,6 +46,26 @@ public class DefaultCalendarDao(
             show_title = entry.showTitle,
             show_poster_path = entry.showPosterPath,
             network = entry.network,
+            runtime = entry.runtime?.toLong(),
+            overview = entry.overview,
+            rating = entry.rating,
+            votes = entry.votes?.toLong(),
+        )
+    }
+
+    override fun upsertFromRemote(entry: RemoteCalendarEntry, posterPath: String?) {
+        val internalShowId = showIdResolver.showIdForTmdbId(entry.tmdbId) ?: return
+        val airDateEpoch = Instant.parse(entry.firstAiredIso).toEpochMilliseconds()
+        database.calendarQueries.upsert(
+            show_id = internalShowId,
+            trakt_id = 0L,
+            season_number = entry.seasonNumber.toLong(),
+            episode_number = entry.episodeNumber.toLong(),
+            episode_title = entry.episodeTitle,
+            air_date = airDateEpoch,
+            show_title = entry.showTitle,
+            show_poster_path = posterPath,
+            network = null,
             runtime = entry.runtime?.toLong(),
             overview = entry.overview,
             rating = entry.rating,

--- a/data/calendar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/implementation/DefaultCalendarDao.kt
+++ b/data/calendar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/implementation/DefaultCalendarDao.kt
@@ -58,7 +58,7 @@ public class DefaultCalendarDao(
         val airDateEpoch = Instant.parse(entry.firstAiredIso).toEpochMilliseconds()
         database.calendarQueries.upsert(
             show_id = internalShowId,
-            trakt_id = 0L,
+            trakt_id = entry.episodeTraktId ?: 0L,
             season_number = entry.seasonNumber.toLong(),
             episode_number = entry.episodeNumber.toLong(),
             episode_title = entry.episodeTitle,

--- a/data/calendar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/implementation/di/CalendarMultibindings.kt
+++ b/data/calendar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/implementation/di/CalendarMultibindings.kt
@@ -1,0 +1,27 @@
+package com.thomaskioko.tvmaniac.data.calendar.implementation.di
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
+import com.thomaskioko.tvmaniac.data.calendar.CalendarRemoteDataSource
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Multibinds
+import dev.zacsweers.metro.Provides
+
+@ContributesTo(AppScope::class)
+public interface CalendarMultibindings {
+
+    @Multibinds(allowEmpty = true)
+    public fun calendarRemoteDataSources(): Set<CalendarRemoteDataSource>
+}
+
+@BindingContainer
+@ContributesTo(AppScope::class)
+public object ActiveCalendarRemoteDataSourceBindingContainer {
+
+    @Provides
+    public fun activeCalendarRemoteDataSource(
+        sources: Set<CalendarRemoteDataSource>,
+        accountManager: AccountManager,
+    ): CalendarRemoteDataSource? = sources.firstOrNull { it.provider == accountManager.getActiveProvider() }
+}

--- a/data/calendar/testing/build.gradle.kts
+++ b/data/calendar/testing/build.gradle.kts
@@ -4,6 +4,11 @@ plugins {
 
 kotlin {
     sourceSets {
+
+        androidMain.dependencies {
+            api(projects.core.networkUtil.api)
+            api(projects.data.accountManager.api)
+        }
         commonMain {
             dependencies {
                 api(projects.data.calendar.api)

--- a/data/calendar/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/testing/FakeCalendarRemoteDataSource.kt
+++ b/data/calendar/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/calendar/testing/FakeCalendarRemoteDataSource.kt
@@ -1,0 +1,17 @@
+package com.thomaskioko.tvmaniac.data.calendar.testing
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.data.calendar.CalendarRemoteDataSource
+import com.thomaskioko.tvmaniac.data.calendar.RemoteCalendarEntry
+
+public class FakeCalendarRemoteDataSource(
+    override val provider: AccountProvider = AccountProvider.TRAKT,
+    private val calendarResponse: ApiResponse<List<RemoteCalendarEntry>> = ApiResponse.Success(emptyList()),
+) : CalendarRemoteDataSource {
+
+    override suspend fun getCalendarEntries(
+        startDate: String,
+        days: Int,
+    ): ApiResponse<List<RemoteCalendarEntry>> = calendarResponse
+}

--- a/data/episode/implementation/build.gradle.kts
+++ b/data/episode/implementation/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
             dependencies {
                 api(libs.coroutines.core)
                 api(libs.store5)
-                api(projects.api.trakt.api)
                 api(projects.core.base)
+                api(projects.data.calendar.api)
                 api(projects.core.logger.api)
                 api(projects.core.syncstate.api)
                 api(projects.core.util.api)
@@ -43,6 +43,7 @@ kotlin {
                 implementation(projects.core.util.testing)
                 implementation(projects.core.syncstate.testing)
                 implementation(projects.data.accountManager.testing)
+                implementation(projects.data.calendar.testing)
                 implementation(projects.data.database.testing)
                 implementation(projects.data.datastore.testing)
                 implementation(projects.data.episode.testing)

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/UpcomingEpisodesStore.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/UpcomingEpisodesStore.kt
@@ -1,15 +1,18 @@
 package com.thomaskioko.tvmaniac.episodes.implementation
 
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
-import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.apiFetcher
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.storeBuilder
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.AuthenticationException
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.getOrThrow
+import com.thomaskioko.tvmaniac.data.calendar.CalendarRemoteDataSource
+import com.thomaskioko.tvmaniac.data.calendar.RemoteCalendarEntry
 import com.thomaskioko.tvmaniac.episodes.api.EpisodesDao
 import com.thomaskioko.tvmaniac.resourcemanager.api.RequestManagerRepository
 import com.thomaskioko.tvmaniac.resourcemanager.api.RequestTypeConfig.UPCOMING_EPISODES
-import com.thomaskioko.tvmaniac.trakt.api.TraktCalendarRemoteDataSource
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.withContext
+import org.mobilenativefoundation.store.store5.Fetcher
 import org.mobilenativefoundation.store.store5.SourceOfTruth
 import org.mobilenativefoundation.store.store5.Store
 import org.mobilenativefoundation.store.store5.Validator
@@ -22,24 +25,24 @@ public data class UpcomingEpisodesParams(
 
 @Inject
 public class UpcomingEpisodesStore(
-    private val calendarDataSource: TraktCalendarRemoteDataSource,
+    private val activeSource: () -> CalendarRemoteDataSource?,
     private val episodesDao: EpisodesDao,
     private val requestManagerRepository: RequestManagerRepository,
     private val dispatchers: AppCoroutineDispatchers,
 ) : Store<UpcomingEpisodesParams, Unit> by storeBuilder(
-    fetcher = apiFetcher { params: UpcomingEpisodesParams ->
-        calendarDataSource.getMyShowsCalendar(params.startDate, params.days)
+    fetcher = Fetcher.of { params: UpcomingEpisodesParams ->
+        val source = activeSource() ?: throw AuthenticationException("No active calendar provider")
+        source.getCalendarEntries(startDate = params.startDate, days = params.days).getOrThrow()
     },
     sourceOfTruth = SourceOfTruth.of(
         reader = { flowOf(Unit) },
-        writer = { _, response ->
-            response.forEach { calendarEntry ->
-                val traktId = calendarEntry.show.ids.trakt
-                val firstAiredEpoch = Instant.parse(calendarEntry.firstAired).toEpochMilliseconds()
+        writer = { _, response: List<RemoteCalendarEntry> ->
+            response.forEach { entry ->
+                val firstAiredEpoch = Instant.parse(entry.firstAiredIso).toEpochMilliseconds()
                 episodesDao.updateFirstAired(
-                    showId = traktId,
-                    seasonNumber = calendarEntry.episode.seasonNumber.toLong(),
-                    episodeNumber = calendarEntry.episode.episodeNumber.toLong(),
+                    showId = entry.tmdbId,
+                    seasonNumber = entry.seasonNumber.toLong(),
+                    episodeNumber = entry.episodeNumber.toLong(),
                     firstAired = firstAiredEpoch,
                 )
             }

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepositorySyncErrorTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepositorySyncErrorTest.kt
@@ -3,7 +3,7 @@ package com.thomaskioko.tvmaniac.episodes.implementation
 import app.cash.turbine.test
 import com.thomaskioko.tvmaniac.core.base.coroutines.FakeAppScopeLauncher
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
-import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.data.calendar.testing.FakeCalendarRemoteDataSource
 import com.thomaskioko.tvmaniac.database.test.BaseDatabaseTest
 import com.thomaskioko.tvmaniac.datastore.testing.FakeDatastoreRepository
 import com.thomaskioko.tvmaniac.db.Id
@@ -13,8 +13,6 @@ import com.thomaskioko.tvmaniac.episodes.testing.FakeWatchedEpisodeSyncRepositor
 import com.thomaskioko.tvmaniac.requestmanager.testing.FakeRequestManagerRepository
 import com.thomaskioko.tvmaniac.syncstate.api.SyncError
 import com.thomaskioko.tvmaniac.syncstate.testing.FakeSyncObserver
-import com.thomaskioko.tvmaniac.trakt.api.TraktCalendarRemoteDataSource
-import com.thomaskioko.tvmaniac.trakt.api.model.TraktCalendarResponse
 import com.thomaskioko.tvmaniac.util.testing.FakeDateTimeProvider
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -131,7 +129,7 @@ internal class DefaultEpisodeRepositorySyncErrorTest : BaseDatabaseTest() {
         val watchedEpisodeDao = DefaultWatchedEpisodeDao(database, showIdResolver, dispatchers, fakeDateTimeProvider)
         val episodesDao = DefaultEpisodesDao(database, showIdResolver, dispatchers, fakeDateTimeProvider)
         val upcomingEpisodesStore = UpcomingEpisodesStore(
-            calendarDataSource = NoOpCalendarDataSource,
+            activeSource = { FakeCalendarRemoteDataSource() },
             episodesDao = episodesDao,
             requestManagerRepository = requestManagerRepository,
             dispatchers = dispatchers,
@@ -193,11 +191,4 @@ internal class DefaultEpisodeRepositorySyncErrorTest : BaseDatabaseTest() {
         private const val SHOW_ID = 1L
         private const val EPISODE_ID = 101L
     }
-}
-
-private object NoOpCalendarDataSource : TraktCalendarRemoteDataSource {
-    override suspend fun getMyShowsCalendar(
-        startDate: String,
-        days: Int,
-    ): ApiResponse<List<TraktCalendarResponse>> = ApiResponse.Success(emptyList())
 }

--- a/data/followedshows/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/testing/FakeFollowedShowsDao.kt
+++ b/data/followedshows/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/followedshows/testing/FakeFollowedShowsDao.kt
@@ -70,6 +70,11 @@ public class FakeFollowedShowsDao : FollowedShowsDao {
     override fun countPendingActions(): Long =
         entriesFlow.value.count { it.pendingAction != PendingAction.NOTHING }.toLong()
 
+    public fun setEntries(entries: List<FollowedShowEntry>) {
+        entriesFlow.value = entries
+        nextId = (entries.maxOfOrNull { it.id } ?: 0L) + 1L
+    }
+
     public fun clear() {
         entriesFlow.value = emptyList()
         nextId = 1L

--- a/data/start-watching/api/build.gradle.kts
+++ b/data/start-watching/api/build.gradle.kts
@@ -7,6 +7,8 @@ kotlin {
         commonMain {
             dependencies {
                 api(libs.coroutines.core)
+                api(projects.core.networkUtil.api)
+                api(projects.data.accountManager.api)
             }
         }
     }

--- a/data/start-watching/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/api/RemotePlanToWatchShow.kt
+++ b/data/start-watching/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/api/RemotePlanToWatchShow.kt
@@ -1,0 +1,14 @@
+package com.thomaskioko.tvmaniac.startwatching.api
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import kotlin.time.Instant
+
+public data class RemotePlanToWatchShow(
+    val tmdbId: Long?,
+    val imdbId: String?,
+    val providerShowId: String?,
+    val provider: AccountProvider,
+    val title: String,
+    val year: Int?,
+    val followedAt: Instant,
+)

--- a/data/start-watching/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/api/StartWatchingRemoteDataSource.kt
+++ b/data/start-watching/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/api/StartWatchingRemoteDataSource.kt
@@ -1,0 +1,9 @@
+package com.thomaskioko.tvmaniac.startwatching.api
+
+import com.thomaskioko.tvmaniac.accountmanager.api.ProviderScoped
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+
+public interface StartWatchingRemoteDataSource : ProviderScoped {
+
+    public suspend fun getPlanToWatch(): ApiResponse<List<RemotePlanToWatchShow>>
+}

--- a/data/start-watching/implementation/build.gradle.kts
+++ b/data/start-watching/implementation/build.gradle.kts
@@ -13,9 +13,9 @@ kotlin {
                 api(libs.coroutines.core)
                 api(libs.store5)
                 api(projects.api.tmdb.api)
-                api(projects.api.trakt.api)
                 api(projects.core.base)
                 api(projects.core.logger.api)
+                api(projects.core.networkUtil.api)
                 api(projects.core.util.api)
                 api(projects.data.accountManager.api)
                 api(projects.data.database.sqldelight)
@@ -24,7 +24,6 @@ kotlin {
                 api(projects.data.shows.api)
                 api(projects.data.startWatching.api)
 
-                implementation(projects.core.networkUtil.api)
                 implementation(libs.sqldelight.extensions)
             }
         }
@@ -32,7 +31,12 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(libs.bundles.unittest)
+                implementation(projects.api.tmdb.testing)
+                implementation(projects.core.util.testing)
                 implementation(projects.data.database.testing)
+                implementation(projects.data.followedshows.implementation)
+                implementation(projects.data.requestManager.testing)
+                implementation(projects.data.shows.implementation)
             }
         }
     }

--- a/data/start-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/implementation/StartWatchingWatchlistStore.kt
+++ b/data/start-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/implementation/StartWatchingWatchlistStore.kt
@@ -4,9 +4,11 @@ import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.storeBuilder
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.usingDispatchers
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.AuthenticationException
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.getOrThrow
 import com.thomaskioko.tvmaniac.db.DatabaseTransactionRunner
 import com.thomaskioko.tvmaniac.db.Id
+import com.thomaskioko.tvmaniac.db.TmdbId
 import com.thomaskioko.tvmaniac.followedshows.api.FollowedShowEntry
 import com.thomaskioko.tvmaniac.followedshows.api.FollowedShowsDao
 import com.thomaskioko.tvmaniac.followedshows.api.PendingAction
@@ -14,9 +16,9 @@ import com.thomaskioko.tvmaniac.resourcemanager.api.RequestManagerRepository
 import com.thomaskioko.tvmaniac.resourcemanager.api.RequestTypeConfig.START_WATCHING_SYNC
 import com.thomaskioko.tvmaniac.shows.api.ShowToPersist
 import com.thomaskioko.tvmaniac.shows.api.TvShowsDao
+import com.thomaskioko.tvmaniac.startwatching.api.RemotePlanToWatchShow
+import com.thomaskioko.tvmaniac.startwatching.api.StartWatchingRemoteDataSource
 import com.thomaskioko.tvmaniac.tmdb.api.TmdbShowDetailsNetworkDataSource
-import com.thomaskioko.tvmaniac.trakt.api.TraktListRemoteDataSource
-import com.thomaskioko.tvmaniac.trakt.api.model.TraktFollowedShowResponse
 import com.thomaskioko.tvmaniac.util.api.FormatterUtil
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
@@ -29,12 +31,11 @@ import org.mobilenativefoundation.store.store5.Fetcher
 import org.mobilenativefoundation.store.store5.SourceOfTruth
 import org.mobilenativefoundation.store.store5.Store
 import org.mobilenativefoundation.store.store5.Validator
-import kotlin.time.Instant
 
 @Inject
 @SingleIn(AppScope::class)
 public class StartWatchingWatchlistStore(
-    private val traktListDataSource: TraktListRemoteDataSource,
+    private val activeSource: () -> StartWatchingRemoteDataSource?,
     private val tmdbDataSource: TmdbShowDetailsNetworkDataSource,
     private val followedShowsDao: FollowedShowsDao,
     private val tvShowsDao: TvShowsDao,
@@ -45,20 +46,28 @@ public class StartWatchingWatchlistStore(
 ) : Store<Unit, List<FollowedShowEntry>> by storeBuilder(
     fetcher = Fetcher.of { _: Unit ->
         coroutineScope {
-            traktListDataSource.getWatchList(sortBy = "added", sortHow = "desc")
+            val source = activeSource()
+                ?: throw AuthenticationException("No active sync provider")
+            source.getPlanToWatch()
                 .getOrThrow()
-                .map { followedShow ->
+                .mapNotNull { show ->
+                    val tmdbId = show.tmdbId ?: return@mapNotNull null
+                    tmdbId to show
+                }
+                .map { (tmdbId, show) ->
                     async {
-                        when (val tmdb = tmdbDataSource.getShowDetails(followedShow.show.ids.tmdb)) {
-                            is ApiResponse.Success -> FollowedShowWithImages(
-                                response = followedShow,
+                        when (val tmdb = tmdbDataSource.getShowDetails(tmdbId)) {
+                            is ApiResponse.Success -> PlanToWatchWithImages(
+                                show = show,
+                                resolvedTmdbId = tmdbId,
                                 tmdbPosterPath = tmdb.body.posterPath,
                                 tmdbBackdropPath = tmdb.body.backdropPath,
                             )
                             is ApiResponse.Unauthenticated,
                             is ApiResponse.Error,
-                            -> FollowedShowWithImages(
-                                response = followedShow,
+                            -> PlanToWatchWithImages(
+                                show = show,
+                                resolvedTmdbId = tmdbId,
                                 tmdbPosterPath = null,
                                 tmdbBackdropPath = null,
                             )
@@ -70,26 +79,24 @@ public class StartWatchingWatchlistStore(
     },
     sourceOfTruth = SourceOfTruth.of(
         reader = { _: Unit -> followedShowsDao.entriesObservable() },
-        writer = { _: Unit, response: List<FollowedShowWithImages> ->
+        writer = { _: Unit, response: List<PlanToWatchWithImages> ->
             transactionRunner {
                 val currentEntries = followedShowsDao.entriesWithNoPendingAction()
-                val networkTraktIds = response.map { it.response.show.ids.trakt }.toSet()
+                val networkTmdbIds = response.map { it.resolvedTmdbId }.toSet()
 
                 response.forEach { item ->
-                    val entry = item.response.toFollowedShowEntry()
-
                     tvShowsDao.upsertMerging(
-                        item.response.toTvshow(
+                        item.toShowToPersist(
                             posterPath = item.tmdbPosterPath?.let { formatterUtil.formatTmdbPosterPath(it) },
                             backdropPath = item.tmdbBackdropPath?.let { formatterUtil.formatTmdbPosterPath(it) },
                         ),
                     )
 
-                    val _ = followedShowsDao.upsert(entry)
+                    val _ = followedShowsDao.upsert(item.toFollowedShowEntry())
                 }
 
                 currentEntries.forEach { localEntry ->
-                    if (localEntry.showId !in networkTraktIds) {
+                    if (localEntry.showId !in networkTmdbIds) {
                         followedShowsDao.deleteById(localEntry.id)
                     }
                 }
@@ -117,22 +124,26 @@ public class StartWatchingWatchlistStore(
     },
 ).build()
 
-private data class FollowedShowWithImages(
-    val response: TraktFollowedShowResponse,
+private data class PlanToWatchWithImages(
+    val show: RemotePlanToWatchShow,
+    val resolvedTmdbId: Long,
     val tmdbPosterPath: String?,
     val tmdbBackdropPath: String?,
 )
 
-private fun TraktFollowedShowResponse.toFollowedShowEntry(): FollowedShowEntry = FollowedShowEntry(
-    showId = show.ids.tmdb,
-    tmdbId = show.ids.tmdb,
-    followedAt = Instant.parse(listedAt),
+private fun PlanToWatchWithImages.toFollowedShowEntry(): FollowedShowEntry = FollowedShowEntry(
+    showId = resolvedTmdbId,
+    tmdbId = resolvedTmdbId,
+    followedAt = show.followedAt,
     pendingAction = PendingAction.NOTHING,
 )
 
-private fun TraktFollowedShowResponse.toTvshow(posterPath: String?, backdropPath: String?): ShowToPersist = ShowToPersist(
-    showId = Id(show.ids.trakt),
-    tmdbId = Id(show.ids.tmdb),
+private fun PlanToWatchWithImages.toShowToPersist(
+    posterPath: String?,
+    backdropPath: String?,
+): ShowToPersist = ShowToPersist(
+    showId = null,
+    tmdbId = Id<TmdbId>(resolvedTmdbId),
     name = show.title,
     overview = "",
     language = null,

--- a/data/start-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/implementation/di/StartWatchingMultibindings.kt
+++ b/data/start-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/implementation/di/StartWatchingMultibindings.kt
@@ -1,0 +1,26 @@
+package com.thomaskioko.tvmaniac.startwatching.implementation.di
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
+import com.thomaskioko.tvmaniac.startwatching.api.StartWatchingRemoteDataSource
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Multibinds
+import dev.zacsweers.metro.Provides
+
+@ContributesTo(AppScope::class)
+public interface StartWatchingMultibindings {
+
+    @Multibinds(allowEmpty = true)
+    public fun startWatchingRemoteDataSources(): Set<StartWatchingRemoteDataSource>
+}
+
+@BindingContainer
+@ContributesTo(AppScope::class)
+public object ActiveStartWatchingRemoteDataSourceBindingContainer {
+    @Provides
+    public fun activeStartWatchingRemoteDataSource(
+        sources: Set<StartWatchingRemoteDataSource>,
+        accountManager: AccountManager,
+    ): StartWatchingRemoteDataSource? = sources.firstOrNull { it.provider == accountManager.getActiveProvider() }
+}

--- a/data/start-watching/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/startwatching/implementation/StartWatchingWatchlistStoreTest.kt
+++ b/data/start-watching/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/startwatching/implementation/StartWatchingWatchlistStoreTest.kt
@@ -1,0 +1,309 @@
+package com.thomaskioko.tvmaniac.startwatching.implementation
+
+import app.cash.turbine.test
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.database.test.BaseDatabaseTest
+import com.thomaskioko.tvmaniac.db.DatabaseTransactionRunner
+import com.thomaskioko.tvmaniac.db.Id
+import com.thomaskioko.tvmaniac.db.TmdbId
+import com.thomaskioko.tvmaniac.followedshows.api.FollowedShowsDao
+import com.thomaskioko.tvmaniac.followedshows.implementation.DefaultFollowedShowsDao
+import com.thomaskioko.tvmaniac.requestmanager.testing.FakeRequestManagerRepository
+import com.thomaskioko.tvmaniac.shows.api.TvShowsDao
+import com.thomaskioko.tvmaniac.shows.implementation.DefaultTvShowsDao
+import com.thomaskioko.tvmaniac.startwatching.api.RemotePlanToWatchShow
+import com.thomaskioko.tvmaniac.startwatching.api.StartWatchingRemoteDataSource
+import com.thomaskioko.tvmaniac.tmdb.api.model.CreditsResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.NetworksResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.TmdbShowDetailsResponse
+import com.thomaskioko.tvmaniac.tmdb.api.model.VideosResponse
+import com.thomaskioko.tvmaniac.tmdb.testing.FakeTmdbShowDetailsNetworkDataSource
+import com.thomaskioko.tvmaniac.util.testing.FakeFormatterUtil
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.mobilenativefoundation.store.store5.StoreReadRequest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.time.Instant
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class StartWatchingWatchlistStoreTest : BaseDatabaseTest() {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val dispatchers = AppCoroutineDispatchers(
+        main = testDispatcher,
+        io = testDispatcher,
+        computation = testDispatcher,
+        databaseWrite = testDispatcher,
+        databaseRead = testDispatcher,
+    )
+
+    private val fakeRequestManager = FakeRequestManagerRepository(initialRequestValid = false)
+    private val fakeTmdbDetailsSource = FakeTmdbShowDetailsNetworkDataSource()
+    private val fakeFormatterUtil = FakeFormatterUtil()
+    private val transactionRunner = ImmediateTransactionRunner()
+
+    private lateinit var tvShowsDao: TvShowsDao
+    private lateinit var followedShowsDao: FollowedShowsDao
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        tvShowsDao = DefaultTvShowsDao(database = database, dispatchers = dispatchers)
+        followedShowsDao = DefaultFollowedShowsDao(
+            database = database,
+            showIdResolver = showIdResolver,
+            dispatchers = dispatchers,
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+        closeDb()
+    }
+
+    private fun buildStore(activeSource: () -> StartWatchingRemoteDataSource?): StartWatchingWatchlistStore =
+        StartWatchingWatchlistStore(
+            activeSource = activeSource,
+            tmdbDataSource = fakeTmdbDetailsSource,
+            followedShowsDao = followedShowsDao,
+            tvShowsDao = tvShowsDao,
+            requestManagerRepository = fakeRequestManager,
+            transactionRunner = transactionRunner,
+            formatterUtil = fakeFormatterUtil,
+            dispatchers = dispatchers,
+        )
+
+    @Test
+    fun `should write followed show given trakt plan-to-watch show with tmdb id`() = runTest(testDispatcher) {
+        val source = FakeStartWatchingSource(provider = AccountProvider.TRAKT)
+        source.setPlanToWatch(
+            listOf(
+                RemotePlanToWatchShow(
+                    tmdbId = TMDB_ID,
+                    imdbId = IMDB_ID,
+                    providerShowId = TRAKT_ID.toString(),
+                    provider = AccountProvider.TRAKT,
+                    title = SHOW_TITLE,
+                    year = 2022,
+                    followedAt = FOLLOWED_AT,
+                ),
+            ),
+        )
+        fakeTmdbDetailsSource.setDefaultShowDetails(
+            ApiResponse.Success(
+                buildTmdbDetailsResponse(
+                    id = TMDB_ID.toInt(),
+                    name = SHOW_TITLE,
+                    posterPath = "/poster.jpg",
+                    backdropPath = "/backdrop.jpg",
+                ),
+            ),
+        )
+        val store = buildStore { source }
+
+        store.stream(StoreReadRequest.fresh(Unit)).test {
+            awaitItem()
+            awaitItem()
+            cancelAndConsumeRemainingEvents()
+        }
+
+        val tvshow = database.tvShowQueries.tvshowByTmdbId(Id<TmdbId>(TMDB_ID)).executeAsOneOrNull()
+        tvshow.shouldNotBeNull()
+        tvshow.name shouldBe SHOW_TITLE
+
+        val followedCount = database.followedShowsQueries.countEntries().executeAsOne()
+        followedCount shouldBe 1L
+    }
+
+    @Test
+    fun `should write followed show given simkl plan-to-watch show with tmdb id`() = runTest(testDispatcher) {
+        val source = FakeStartWatchingSource(provider = AccountProvider.SIMKL)
+        source.setPlanToWatch(
+            listOf(
+                RemotePlanToWatchShow(
+                    tmdbId = TMDB_ID,
+                    imdbId = IMDB_ID,
+                    providerShowId = SIMKL_ID,
+                    provider = AccountProvider.SIMKL,
+                    title = SHOW_TITLE,
+                    year = 2021,
+                    followedAt = FOLLOWED_AT,
+                ),
+            ),
+        )
+        fakeTmdbDetailsSource.setDefaultShowDetails(
+            ApiResponse.Success(
+                buildTmdbDetailsResponse(
+                    id = TMDB_ID.toInt(),
+                    name = SHOW_TITLE,
+                    posterPath = null,
+                    backdropPath = null,
+                ),
+            ),
+        )
+        val store = buildStore { source }
+
+        store.stream(StoreReadRequest.fresh(Unit)).test {
+            awaitItem()
+            awaitItem()
+            cancelAndConsumeRemainingEvents()
+        }
+
+        val followedCount = database.followedShowsQueries.countEntries().executeAsOne()
+        followedCount shouldBe 1L
+    }
+
+    @Test
+    fun `should skip show given plan-to-watch show has no tmdb id`() = runTest(testDispatcher) {
+        val source = FakeStartWatchingSource(provider = AccountProvider.SIMKL)
+        source.setPlanToWatch(
+            listOf(
+                RemotePlanToWatchShow(
+                    tmdbId = null,
+                    imdbId = IMDB_ID,
+                    providerShowId = SIMKL_ID,
+                    provider = AccountProvider.SIMKL,
+                    title = SHOW_TITLE,
+                    year = 2021,
+                    followedAt = FOLLOWED_AT,
+                ),
+            ),
+        )
+        val store = buildStore { source }
+
+        store.stream(StoreReadRequest.fresh(Unit)).test {
+            awaitItem()
+            awaitItem()
+            cancelAndConsumeRemainingEvents()
+        }
+
+        val followedCount = database.followedShowsQueries.countEntries().executeAsOne()
+        followedCount shouldBe 0L
+    }
+
+    @Test
+    fun `should remove stale entries given show no longer in plan-to-watch`() = runTest(testDispatcher) {
+        val source = FakeStartWatchingSource(provider = AccountProvider.TRAKT)
+        source.setPlanToWatch(
+            listOf(
+                RemotePlanToWatchShow(
+                    tmdbId = TMDB_ID,
+                    imdbId = IMDB_ID,
+                    providerShowId = TRAKT_ID.toString(),
+                    provider = AccountProvider.TRAKT,
+                    title = SHOW_TITLE,
+                    year = 2022,
+                    followedAt = FOLLOWED_AT,
+                ),
+            ),
+        )
+        fakeTmdbDetailsSource.setDefaultShowDetails(
+            ApiResponse.Success(
+                buildTmdbDetailsResponse(id = TMDB_ID.toInt(), name = SHOW_TITLE, posterPath = null, backdropPath = null),
+            ),
+        )
+        val store = buildStore { source }
+
+        store.stream(StoreReadRequest.fresh(Unit)).test {
+            awaitItem()
+            awaitItem()
+            cancelAndConsumeRemainingEvents()
+        }
+
+        var followedCount = database.followedShowsQueries.countEntries().executeAsOne()
+        followedCount shouldBe 1L
+
+        source.setPlanToWatch(emptyList())
+        fakeRequestManager.requestValid = false
+
+        store.stream(StoreReadRequest.fresh(Unit)).test {
+            awaitItem()
+            awaitItem()
+            cancelAndConsumeRemainingEvents()
+        }
+
+        followedCount = database.followedShowsQueries.countEntries().executeAsOne()
+        followedCount shouldBe 0L
+    }
+
+    @Test
+    fun `should not write any followed shows given no active provider`() = runTest(testDispatcher) {
+        val store = buildStore { null }
+
+        store.stream(StoreReadRequest.fresh(Unit)).test {
+            cancelAndConsumeRemainingEvents()
+        }
+
+        val followedCount = database.followedShowsQueries.countEntries().executeAsOne()
+        followedCount shouldBe 0L
+    }
+
+    private companion object {
+        private const val TMDB_ID = 42L
+        private const val TRAKT_ID = 1001L
+        private const val SIMKL_ID = "583436"
+        private const val IMDB_ID = "tt1234567"
+        private const val SHOW_TITLE = "Test Show"
+        private val FOLLOWED_AT = Instant.parse("2025-03-01T00:00:00Z")
+    }
+}
+
+private class ImmediateTransactionRunner : DatabaseTransactionRunner {
+    override fun <T> invoke(block: () -> T): T = block()
+}
+
+private class FakeStartWatchingSource(
+    override val provider: AccountProvider,
+) : StartWatchingRemoteDataSource {
+
+    private var shows: List<RemotePlanToWatchShow> = emptyList()
+
+    fun setPlanToWatch(shows: List<RemotePlanToWatchShow>) {
+        this.shows = shows
+    }
+
+    override suspend fun getPlanToWatch(): ApiResponse<List<RemotePlanToWatchShow>> =
+        ApiResponse.Success(shows)
+}
+
+private fun buildTmdbDetailsResponse(
+    id: Int,
+    name: String,
+    posterPath: String?,
+    backdropPath: String?,
+): TmdbShowDetailsResponse = TmdbShowDetailsResponse(
+    adult = false,
+    backdropPath = backdropPath,
+    episodeRunTime = arrayListOf(),
+    firstAirDate = null,
+    genres = arrayListOf(),
+    id = id,
+    lastAirDate = null,
+    lastEpisodeToAir = null,
+    name = name,
+    nextEpisodeToAir = null,
+    networks = arrayListOf(NetworksResponse(id = 1, name = "Test Network")),
+    numberOfEpisodes = 0,
+    numberOfSeasons = 0,
+    overview = "",
+    popularity = 0.0,
+    posterPath = posterPath,
+    seasons = arrayListOf(),
+    status = "Returning Series",
+    voteAverage = 0.0,
+    voteCount = 0,
+    videos = VideosResponse(results = arrayListOf()),
+    credits = CreditsResponse(cast = arrayListOf()),
+    originalLanguage = "en",
+)

--- a/data/start-watching/testing/build.gradle.kts
+++ b/data/start-watching/testing/build.gradle.kts
@@ -6,6 +6,8 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
+                api(projects.core.networkUtil.api)
+                api(projects.data.accountManager.api)
                 api(projects.data.startWatching.api)
                 api(libs.coroutines.core)
             }

--- a/data/start-watching/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/testing/FakeStartWatchingRemoteDataSource.kt
+++ b/data/start-watching/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/testing/FakeStartWatchingRemoteDataSource.kt
@@ -1,0 +1,14 @@
+package com.thomaskioko.tvmaniac.startwatching.testing
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.startwatching.api.RemotePlanToWatchShow
+import com.thomaskioko.tvmaniac.startwatching.api.StartWatchingRemoteDataSource
+
+public class FakeStartWatchingRemoteDataSource(
+    override val provider: AccountProvider = AccountProvider.TRAKT,
+    private val planToWatchResponse: ApiResponse<List<RemotePlanToWatchShow>> = ApiResponse.Success(emptyList()),
+) : StartWatchingRemoteDataSource {
+
+    override suspend fun getPlanToWatch(): ApiResponse<List<RemotePlanToWatchShow>> = planToWatchResponse
+}

--- a/domain/notifications/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/notifications/EpisodeNotificationWorker.kt
+++ b/domain/notifications/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/notifications/EpisodeNotificationWorker.kt
@@ -7,7 +7,7 @@ import com.thomaskioko.tvmaniac.core.tasks.api.TaskConstraints
 import com.thomaskioko.tvmaniac.core.tasks.api.WorkerResult
 import com.thomaskioko.tvmaniac.domain.notifications.interactor.RefreshUpcomingSeasonDetailsInteractor
 import com.thomaskioko.tvmaniac.domain.notifications.interactor.ScheduleEpisodeNotificationsInteractor
-import com.thomaskioko.tvmaniac.domain.notifications.interactor.SyncTraktCalendarInteractor
+import com.thomaskioko.tvmaniac.domain.notifications.interactor.SyncCalendarInteractor
 import com.thomaskioko.tvmaniac.syncstate.api.SyncError
 import com.thomaskioko.tvmaniac.syncstate.api.SyncObserver
 import dev.zacsweers.metro.AppScope
@@ -18,7 +18,7 @@ import kotlin.time.Duration.Companion.hours
 @SingleIn(AppScope::class)
 @ContributesIntoSet(AppScope::class)
 public class EpisodeNotificationWorker(
-    private val syncTraktCalendarInteractor: Lazy<SyncTraktCalendarInteractor>,
+    private val syncTraktCalendarInteractor: Lazy<SyncCalendarInteractor>,
     private val refreshInteractor: Lazy<RefreshUpcomingSeasonDetailsInteractor>,
     private val scheduleInteractor: Lazy<ScheduleEpisodeNotificationsInteractor>,
     private val syncObserver: SyncObserver,
@@ -38,7 +38,7 @@ public class EpisodeNotificationWorker(
 
         runCatching {
             syncTraktCalendarInteractor.value.executeSync(
-                SyncTraktCalendarInteractor.Params(forceRefresh = true),
+                SyncCalendarInteractor.Params(forceRefresh = true),
             )
         }.onFailure { logger.error(TAG, "Calendar sync failed: ${it.message}") }
 

--- a/domain/notifications/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/notifications/interactor/SyncCalendarInteractor.kt
+++ b/domain/notifications/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/notifications/interactor/SyncCalendarInteractor.kt
@@ -1,0 +1,45 @@
+package com.thomaskioko.tvmaniac.domain.notifications.interactor
+
+import com.thomaskioko.tvmaniac.accountmanager.api.ProviderFeatures
+import com.thomaskioko.tvmaniac.core.base.interactor.Interactor
+import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
+import com.thomaskioko.tvmaniac.core.logger.Logger
+import com.thomaskioko.tvmaniac.episodes.api.EpisodeRepository
+import com.thomaskioko.tvmaniac.util.api.DateTimeProvider
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.withContext
+
+@Inject
+@SingleIn(AppScope::class)
+public class SyncCalendarInteractor(
+    private val episodeRepository: EpisodeRepository,
+    private val dateTimeProvider: DateTimeProvider,
+    private val activeProviderFeatures: () -> ProviderFeatures,
+    private val logger: Logger,
+    private val dispatchers: AppCoroutineDispatchers,
+) : Interactor<SyncCalendarInteractor.Params>() {
+
+    override suspend fun doWork(params: Params) {
+        if (!activeProviderFeatures().supportsCalendar) return
+
+        logger.debug(TAG, "Starting calendar sync")
+        withContext(dispatchers.io) {
+            episodeRepository.syncUpcomingEpisodesFromTrakt(
+                startDate = dateTimeProvider.todayAsIsoDate(),
+                days = params.days,
+                forceRefresh = params.forceRefresh,
+            )
+        }
+    }
+
+    public data class Params(
+        val days: Int = 7,
+        val forceRefresh: Boolean = false,
+    )
+
+    private companion object {
+        private const val TAG = "SyncCalendar"
+    }
+}

--- a/domain/notifications/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/notifications/interactor/SyncCalendarInteractorTest.kt
+++ b/domain/notifications/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/notifications/interactor/SyncCalendarInteractorTest.kt
@@ -1,0 +1,102 @@
+package com.thomaskioko.tvmaniac.domain.notifications.interactor
+
+import com.thomaskioko.tvmaniac.accountmanager.testing.FakeProviderFeatures
+import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
+import com.thomaskioko.tvmaniac.core.logger.fixture.FakeLogger
+import com.thomaskioko.tvmaniac.db.EpisodeById
+import com.thomaskioko.tvmaniac.episodes.api.EpisodeRepository
+import com.thomaskioko.tvmaniac.episodes.api.model.RecentlyWatchedEpisode
+import com.thomaskioko.tvmaniac.episodes.api.model.SeasonWatchProgress
+import com.thomaskioko.tvmaniac.episodes.api.model.ShowWatchProgress
+import com.thomaskioko.tvmaniac.episodes.api.model.UpcomingEpisode
+import com.thomaskioko.tvmaniac.util.testing.FakeDateTimeProvider
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.time.Duration
+
+class SyncCalendarInteractorTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val dispatchers = AppCoroutineDispatchers(
+        main = testDispatcher,
+        io = testDispatcher,
+        computation = testDispatcher,
+        databaseWrite = testDispatcher,
+        databaseRead = testDispatcher,
+    )
+    private val dateTimeProvider = FakeDateTimeProvider()
+
+    private fun buildInteractor(
+        episodeRepository: EpisodeRepository,
+        supportsCalendar: Boolean,
+    ) = SyncCalendarInteractor(
+        episodeRepository = episodeRepository,
+        dateTimeProvider = dateTimeProvider,
+        activeProviderFeatures = { FakeProviderFeatures(supportsCalendar = supportsCalendar) },
+        logger = FakeLogger(),
+        dispatchers = dispatchers,
+    )
+
+    @Test
+    fun `should skip calendar sync given provider does not support calendar`() = runTest(testDispatcher) {
+        val episodeRepository = CountingCalendarEpisodeRepository()
+
+        buildInteractor(episodeRepository = episodeRepository, supportsCalendar = false)
+            .executeSync(SyncCalendarInteractor.Params())
+
+        episodeRepository.syncUpcomingCount shouldBe 0
+    }
+
+    @Test
+    fun `should run calendar sync given provider supports calendar`() = runTest(testDispatcher) {
+        val episodeRepository = CountingCalendarEpisodeRepository()
+
+        buildInteractor(episodeRepository = episodeRepository, supportsCalendar = true)
+            .executeSync(SyncCalendarInteractor.Params())
+
+        episodeRepository.syncUpcomingCount shouldBe 1
+    }
+
+    @Test
+    fun `should pass forceRefresh parameter to episode repository given forceRefresh is true`() = runTest(testDispatcher) {
+        val episodeRepository = CountingCalendarEpisodeRepository()
+
+        buildInteractor(episodeRepository = episodeRepository, supportsCalendar = true)
+            .executeSync(SyncCalendarInteractor.Params(days = 14, forceRefresh = true))
+
+        episodeRepository.syncUpcomingCount shouldBe 1
+        episodeRepository.lastForceRefresh shouldBe true
+        episodeRepository.lastDays shouldBe 14
+    }
+}
+
+private class CountingCalendarEpisodeRepository : EpisodeRepository {
+    var syncUpcomingCount: Int = 0
+    var lastForceRefresh: Boolean = false
+    var lastDays: Int = 0
+
+    override fun observeEpisodeById(episodeId: Long): Flow<EpisodeById?> = flowOf(null)
+    override fun observeRecentlyWatched(limit: Long): Flow<List<RecentlyWatchedEpisode>> = flowOf(emptyList())
+    override suspend fun markEpisodeAsWatched(showId: Long, episodeId: Long, seasonNumber: Long, episodeNumber: Long) {}
+    override suspend fun markEpisodeAndPreviousEpisodesWatched(showId: Long, episodeId: Long, seasonNumber: Long, episodeNumber: Long) {}
+    override suspend fun markEpisodeAsUnwatched(showId: Long, episodeId: Long) {}
+    override fun observeSeasonWatchProgress(showId: Long, seasonNumber: Long): Flow<SeasonWatchProgress> =
+        flowOf(SeasonWatchProgress(0, 0, 0, 0))
+    override fun observeShowWatchProgress(showId: Long): Flow<ShowWatchProgress> =
+        flowOf(ShowWatchProgress(0, 0, 0))
+    override fun observeAllSeasonsWatchProgress(showId: Long): Flow<List<SeasonWatchProgress>> = flowOf(emptyList())
+    override suspend fun markSeasonWatched(showId: Long, seasonNumber: Long) {}
+    override suspend fun markSeasonAndPreviousSeasonsWatched(showId: Long, seasonNumber: Long) {}
+    override suspend fun markSeasonUnwatched(showId: Long, seasonNumber: Long) {}
+    override fun observeUnwatchedCountInPreviousSeasons(showId: Long, seasonNumber: Long): Flow<Long> = flowOf(0L)
+    override suspend fun getUpcomingEpisodesFromFollowedShows(limit: Duration): List<UpcomingEpisode> = emptyList()
+    override suspend fun syncUpcomingEpisodesFromTrakt(startDate: String, days: Int, forceRefresh: Boolean) {
+        syncUpcomingCount++
+        lastForceRefresh = forceRefresh
+        lastDays = days
+    }
+}


### PR DESCRIPTION
## Description
This PR integrates Simkl as a remote data source for the calendar and "Plan to Watch" (Start Watching) features. It abstracts the synchronization logic to support multiple providers (Trakt and Simkl) and updates the domain layer to handle cross-platform sync. #727 

## Changes
- Implement Simkl remote data sources for calendar and watchlist synchronization.
- Generalize calendar and start watching data stores to support multibindings from multiple providers.
- Add Trakt adapters to maintain compatibility while transitioning to the new data source abstraction.
- Enhance calendar synchronization interactor and background worker.
