### PR TITLE
refactor: Decouple DataStore Implementation

### DIFF
--- a/core/imageloading/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/imageloading/api/ImageQualityPreference.kt
+++ b/core/imageloading/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/imageloading/api/ImageQualityPreference.kt
@@ -1,0 +1,7 @@
+package com.thomaskioko.tvmaniac.imageloading.api
+
+import kotlinx.coroutines.flow.Flow
+
+public interface ImageQualityPreference {
+    public fun observeImageQuality(): Flow<String>
+}

--- a/core/imageloading/implementation/build.gradle.kts
+++ b/core/imageloading/implementation/build.gradle.kts
@@ -12,7 +12,6 @@ scaffold {
 dependencies {
     api(projects.core.imageloading.api)
     api(projects.domain.theme)
-    api(projects.data.datastore.api)
     api(projects.core.base)
 
     api(libs.coil.base)

--- a/core/imageloading/implementation/src/main/kotlin/com/thomaskioko/tvmaniac/imageloading/implementation/DefaultImageQualityProvider.kt
+++ b/core/imageloading/implementation/src/main/kotlin/com/thomaskioko/tvmaniac/imageloading/implementation/DefaultImageQualityProvider.kt
@@ -1,8 +1,8 @@
 package com.thomaskioko.tvmaniac.imageloading.implementation
 
 import com.thomaskioko.tvmaniac.core.base.IoCoroutineScope
-import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
 import com.thomaskioko.tvmaniac.domain.theme.ImageQuality
+import com.thomaskioko.tvmaniac.imageloading.api.ImageQualityPreference
 import com.thomaskioko.tvmaniac.imageloading.api.ImageQualityProvider
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
@@ -18,16 +18,16 @@ import kotlinx.coroutines.launch
 @ContributesBinding(AppScope::class)
 public class DefaultImageQualityProvider(
     @IoCoroutineScope coroutineScope: CoroutineScope,
-    private val datastoreRepository: DatastoreRepository,
+    private val imageQualityPreference: ImageQualityPreference,
 ) : ImageQualityProvider {
 
     private val currentQuality = MutableStateFlow(ImageQuality.AUTO)
 
     init {
         coroutineScope.launch {
-            datastoreRepository.observeImageQuality()
-                .collectLatest { quality ->
-                    currentQuality.value = ImageQuality.valueOf(quality.name)
+            imageQualityPreference.observeImageQuality()
+                .collectLatest { name ->
+                    currentQuality.value = ImageQuality.entries.firstOrNull { it.name == name } ?: ImageQuality.AUTO
                 }
         }
     }

--- a/core/locale/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/locale/api/LanguagePreference.kt
+++ b/core/locale/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/locale/api/LanguagePreference.kt
@@ -1,0 +1,9 @@
+package com.thomaskioko.tvmaniac.locale.api
+
+import kotlinx.coroutines.flow.Flow
+
+public interface LanguagePreference {
+    public fun observeLanguage(): Flow<String>
+
+    public suspend fun saveLanguage(languageCode: String)
+}

--- a/core/locale/implementation/build.gradle.kts
+++ b/core/locale/implementation/build.gradle.kts
@@ -25,7 +25,6 @@ kotlin {
             dependencies {
                 api(libs.coroutines.core)
                 api(projects.core.locale.api)
-                api(projects.data.datastore.api)
                 implementation(projects.core.base)
             }
         }

--- a/core/locale/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/locale/implementation/DefaultLocaleProvider.kt
+++ b/core/locale/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/locale/implementation/DefaultLocaleProvider.kt
@@ -1,6 +1,6 @@
 package com.thomaskioko.tvmaniac.locale.implementation
 
-import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
+import com.thomaskioko.tvmaniac.locale.api.LanguagePreference
 import com.thomaskioko.tvmaniac.locale.api.LocaleProvider
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
@@ -11,13 +11,13 @@ import kotlinx.coroutines.flow.Flow
 @ContributesBinding(AppScope::class)
 public class DefaultLocaleProvider(
     private val platformLocaleProvider: PlatformLocaleProvider,
-    private val datastoreRepository: DatastoreRepository,
+    private val languagePreference: LanguagePreference,
 ) : LocaleProvider {
 
-    override val currentLocale: Flow<String> = datastoreRepository.observeLanguage()
+    override val currentLocale: Flow<String> = languagePreference.observeLanguage()
 
     override suspend fun setLocale(languageCode: String) {
-        datastoreRepository.saveLanguage(languageCode)
+        languagePreference.saveLanguage(languageCode)
     }
 
     override fun getPreferredLocales(): Flow<List<String>> {

--- a/core/locale/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/locale/testing/FakeLanguagePreference.kt
+++ b/core/locale/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/locale/testing/FakeLanguagePreference.kt
@@ -1,0 +1,20 @@
+package com.thomaskioko.tvmaniac.locale.testing
+
+import com.thomaskioko.tvmaniac.locale.api.LanguagePreference
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+public class FakeLanguagePreference : LanguagePreference {
+    private val languageFlow = MutableStateFlow("en")
+
+    public fun setLanguageNow(languageCode: String) {
+        languageFlow.value = languageCode
+    }
+
+    override fun observeLanguage(): Flow<String> = languageFlow.asStateFlow()
+
+    override suspend fun saveLanguage(languageCode: String) {
+        languageFlow.value = languageCode
+    }
+}

--- a/core/logger/api/build.gradle.kts
+++ b/core/logger/api/build.gradle.kts
@@ -1,3 +1,13 @@
 plugins {
     alias(libs.plugins.app.kmp)
 }
+
+kotlin {
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(libs.coroutines.core)
+            }
+        }
+    }
+}

--- a/core/logger/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/CrashReportingPreference.kt
+++ b/core/logger/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/CrashReportingPreference.kt
@@ -1,0 +1,7 @@
+package com.thomaskioko.tvmaniac.core.logger
+
+import kotlinx.coroutines.flow.Flow
+
+public interface CrashReportingPreference {
+    public fun observeCrashReportingEnabled(): Flow<Boolean>
+}

--- a/core/logger/implementation/build.gradle.kts
+++ b/core/logger/implementation/build.gradle.kts
@@ -20,7 +20,6 @@ kotlin {
             api(projects.core.appconfig.api)
             api(projects.core.base)
             api(projects.core.logger.api)
-            api(projects.data.datastore.api)
             implementation(libs.kermit)
         }
     }

--- a/core/logger/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/LoggingInitializer.kt
+++ b/core/logger/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/LoggingInitializer.kt
@@ -4,7 +4,6 @@ import com.thomaskioko.tvmaniac.appconfig.DebugConfig
 import com.thomaskioko.tvmaniac.core.base.Initializer
 import com.thomaskioko.tvmaniac.core.base.Initializers
 import com.thomaskioko.tvmaniac.core.base.IoCoroutineScope
-import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Inject
@@ -17,7 +16,7 @@ import kotlinx.coroutines.launch
 public class LoggingInitializer(
     private val debugConfig: DebugConfig,
     private val crashReporter: CrashReporter,
-    private val datastoreRepository: DatastoreRepository,
+    private val crashReportingPreference: CrashReportingPreference,
     private val logger: Logger,
     @IoCoroutineScope private val scope: CoroutineScope,
 ) {
@@ -26,7 +25,7 @@ public class LoggingInitializer(
         logger.setup(debugConfig.isDebug)
 
         scope.launch {
-            datastoreRepository.observeCrashReportingEnabled()
+            crashReportingPreference.observeCrashReportingEnabled()
                 .collect {
                     crashReporter.setCollectionEnabled(it)
                 }

--- a/core/logger/testing/build.gradle.kts
+++ b/core/logger/testing/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
+            api(libs.coroutines.core)
             api(projects.core.logger.api)
         }
     }

--- a/core/logger/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/fixture/FakeCrashReportingPreference.kt
+++ b/core/logger/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/logger/fixture/FakeCrashReportingPreference.kt
@@ -1,0 +1,16 @@
+package com.thomaskioko.tvmaniac.core.logger.fixture
+
+import com.thomaskioko.tvmaniac.core.logger.CrashReportingPreference
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+public class FakeCrashReportingPreference : CrashReportingPreference {
+    private val enabledFlow = MutableStateFlow(true)
+
+    public fun setCrashReportingEnabled(enabled: Boolean) {
+        enabledFlow.value = enabled
+    }
+
+    override fun observeCrashReportingEnabled(): Flow<Boolean> = enabledFlow.asStateFlow()
+}

--- a/data/datastore/implementation/build.gradle.kts
+++ b/data/datastore/implementation/build.gradle.kts
@@ -23,10 +23,10 @@ kotlin {
         commonMain {
             dependencies {
                 api(projects.data.datastore.api)
+                api(projects.core.locale.api)
+                api(projects.core.logger.api)
+                api(projects.core.imageloading.api)
                 implementation(projects.core.base)
-                implementation(projects.core.locale.api)
-                implementation(projects.core.logger.api)
-                implementation(projects.core.imageloading.api)
 
                 api(libs.androidx.datastore.preference)
             }

--- a/data/datastore/implementation/build.gradle.kts
+++ b/data/datastore/implementation/build.gradle.kts
@@ -24,6 +24,9 @@ kotlin {
             dependencies {
                 api(projects.data.datastore.api)
                 implementation(projects.core.base)
+                implementation(projects.core.locale.api)
+                implementation(projects.core.logger.api)
+                implementation(projects.core.imageloading.api)
 
                 api(libs.androidx.datastore.preference)
             }

--- a/data/datastore/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/datastore/implementation/DatastoreCrashReportingPreference.kt
+++ b/data/datastore/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/datastore/implementation/DatastoreCrashReportingPreference.kt
@@ -1,0 +1,17 @@
+package com.thomaskioko.tvmaniac.datastore.implementation
+
+import com.thomaskioko.tvmaniac.core.logger.CrashReportingPreference
+import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.Flow
+
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+public class DatastoreCrashReportingPreference(
+    private val datastoreRepository: DatastoreRepository,
+) : CrashReportingPreference {
+    override fun observeCrashReportingEnabled(): Flow<Boolean> =
+        datastoreRepository.observeCrashReportingEnabled()
+}

--- a/data/datastore/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/datastore/implementation/DatastoreImageQualityPreference.kt
+++ b/data/datastore/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/datastore/implementation/DatastoreImageQualityPreference.kt
@@ -1,0 +1,18 @@
+package com.thomaskioko.tvmaniac.datastore.implementation
+
+import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
+import com.thomaskioko.tvmaniac.imageloading.api.ImageQualityPreference
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+public class DatastoreImageQualityPreference(
+    private val datastoreRepository: DatastoreRepository,
+) : ImageQualityPreference {
+    override fun observeImageQuality(): Flow<String> =
+        datastoreRepository.observeImageQuality().map { it.name }
+}

--- a/data/datastore/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/datastore/implementation/DatastoreLanguagePreference.kt
+++ b/data/datastore/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/datastore/implementation/DatastoreLanguagePreference.kt
@@ -1,0 +1,20 @@
+package com.thomaskioko.tvmaniac.datastore.implementation
+
+import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
+import com.thomaskioko.tvmaniac.locale.api.LanguagePreference
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.Flow
+
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+public class DatastoreLanguagePreference(
+    private val datastoreRepository: DatastoreRepository,
+) : LanguagePreference {
+    override fun observeLanguage(): Flow<String> = datastoreRepository.observeLanguage()
+
+    override suspend fun saveLanguage(languageCode: String) {
+        datastoreRepository.saveLanguage(languageCode)
+    }
+}


### PR DESCRIPTION
## Description

This PR removes the direct dependency from `core/imageloading`, `core/locale`, and `core/logger` on `DatastoreRepository`. Each module now declares a narrow preference interface in its own api package (`ImageQualityPreference`, `LanguagePreference`, `CrashReportingPreference`), and `data/datastore/implementation` provides the datastore-backed implementations. Consumers depend only on the small interface they need rather than the full datastore repository.