### PR TITLE
feat: Add Trakt and SIMKL ratings remote data sources

### DIFF
--- a/api/simkl/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/api/SimklRatingsRemoteDataSource.kt
+++ b/api/simkl/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/api/SimklRatingsRemoteDataSource.kt
@@ -1,0 +1,14 @@
+package com.thomaskioko.tvmaniac.simkl.api
+
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklAddRatingsResponse
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklRatingsRequest
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklRemoveRatingsRequest
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklRemoveRatingsResponse
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklUserRatingsResponse
+
+public interface SimklRatingsRemoteDataSource {
+    public suspend fun addRatings(request: SimklRatingsRequest): ApiResponse<SimklAddRatingsResponse>
+    public suspend fun removeRatings(request: SimklRemoveRatingsRequest): ApiResponse<SimklRemoveRatingsResponse>
+    public suspend fun getUserShowRatings(): ApiResponse<SimklUserRatingsResponse>
+}

--- a/api/simkl/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/api/model/SimklRatingsRequest.kt
+++ b/api/simkl/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/api/model/SimklRatingsRequest.kt
@@ -1,0 +1,26 @@
+package com.thomaskioko.tvmaniac.simkl.api.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class SimklRatingsRequest(
+    @SerialName("shows") val shows: List<SimklRatingItem>? = null,
+)
+
+@Serializable
+public data class SimklRatingItem(
+    @SerialName("rating") val rating: Int,
+    @SerialName("rated_at") val ratedAt: String? = null,
+    @SerialName("ids") val ids: SimklShowIds,
+)
+
+@Serializable
+public data class SimklRemoveRatingsRequest(
+    @SerialName("shows") val shows: List<SimklRatingIdItem>? = null,
+)
+
+@Serializable
+public data class SimklRatingIdItem(
+    @SerialName("ids") val ids: SimklShowIds,
+)

--- a/api/simkl/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/api/model/SimklRatingsResponse.kt
+++ b/api/simkl/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/api/model/SimklRatingsResponse.kt
@@ -1,0 +1,51 @@
+package com.thomaskioko.tvmaniac.simkl.api.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class SimklAddRatingsResponse(
+    @SerialName("added") val added: SimklRatingsCountBucket? = null,
+    @SerialName("not_found") val notFound: SimklRatingsNotFoundBucket? = null,
+)
+
+@Serializable
+public data class SimklRemoveRatingsResponse(
+    @SerialName("deleted") val deleted: SimklRatingsCountBucket? = null,
+    @SerialName("not_found") val notFound: SimklRatingsNotFoundBucket? = null,
+)
+
+@Serializable
+public data class SimklRatingsCountBucket(
+    @SerialName("movies") val movies: Int? = null,
+    @SerialName("shows") val shows: Int? = null,
+)
+
+@Serializable
+public data class SimklRatingsNotFoundBucket(
+    @SerialName("movies") val movies: List<SimklShowEntry> = emptyList(),
+    @SerialName("shows") val shows: List<SimklShowEntry> = emptyList(),
+)
+
+@Serializable
+public data class SimklRatings(
+    @SerialName("simkl") val simkl: SimklRatingValue? = null,
+)
+
+@Serializable
+public data class SimklRatingValue(
+    @SerialName("rating") val rating: Double? = null,
+    @SerialName("votes") val votes: Int? = null,
+)
+
+@Serializable
+public data class SimklUserRatingsResponse(
+    @SerialName("shows") val shows: List<SimklUserRatedShow> = emptyList(),
+)
+
+@Serializable
+public data class SimklUserRatedShow(
+    @SerialName("user_rating") val userRating: Int? = null,
+    @SerialName("rated_at") val ratedAt: String? = null,
+    @SerialName("show") val show: SimklShowEntry,
+)

--- a/api/simkl/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/api/model/SimklSyncResponse.kt
+++ b/api/simkl/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/api/model/SimklSyncResponse.kt
@@ -47,6 +47,7 @@ public data class SimklShowEntry(
     @SerialName("title") val title: String? = null,
     @SerialName("year") val year: Int? = null,
     @SerialName("ids") val ids: SimklShowIds,
+    @SerialName("ratings") val ratings: SimklRatings? = null,
 )
 
 @Serializable

--- a/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/DefaultSimklRatingsRemoteDataSource.kt
+++ b/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/DefaultSimklRatingsRemoteDataSource.kt
@@ -1,0 +1,55 @@
+package com.thomaskioko.tvmaniac.simkl.implementation
+
+import com.thomaskioko.tvmaniac.core.base.SimklApi
+import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.authSafeRequest
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.simkl.api.SimklRatingsRemoteDataSource
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklAddRatingsResponse
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklRatingsRequest
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklRemoveRatingsRequest
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklRemoveRatingsResponse
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklUserRatingsResponse
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
+import io.ktor.client.HttpClient
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
+import io.ktor.http.contentType
+import io.ktor.http.path
+
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+public class DefaultSimklRatingsRemoteDataSource(
+    @SimklApi private val httpClient: HttpClient,
+) : SimklRatingsRemoteDataSource {
+
+    override suspend fun addRatings(request: SimklRatingsRequest): ApiResponse<SimklAddRatingsResponse> =
+        httpClient.authSafeRequest {
+            url {
+                method = HttpMethod.Post
+                path("sync/ratings")
+            }
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }
+
+    override suspend fun removeRatings(request: SimklRemoveRatingsRequest): ApiResponse<SimklRemoveRatingsResponse> =
+        httpClient.authSafeRequest {
+            url {
+                method = HttpMethod.Post
+                path("sync/ratings/remove")
+            }
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }
+
+    override suspend fun getUserShowRatings(): ApiResponse<SimklUserRatingsResponse> =
+        httpClient.authSafeRequest {
+            url {
+                method = HttpMethod.Get
+                path("sync/ratings/shows")
+            }
+        }
+}

--- a/api/simkl/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/DefaultSimklRatingsRemoteDataSourceTest.kt
+++ b/api/simkl/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/DefaultSimklRatingsRemoteDataSourceTest.kt
@@ -1,0 +1,335 @@
+package com.thomaskioko.tvmaniac.simkl.implementation
+
+import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.IsAuthenticated
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklAddRatingsResponse
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklRatingIdItem
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklRatingItem
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklRatingsRequest
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklRemoveRatingsRequest
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklRemoveRatingsResponse
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklShowIds
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklUserRatingsResponse
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+
+internal class DefaultSimklRatingsRemoteDataSourceTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        prettyPrint = true
+        encodeDefaults = true
+    }
+
+    private fun createDataSource(engine: MockEngine): DefaultSimklRatingsRemoteDataSource {
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(json = json) }
+        }
+        client.attributes.put(IsAuthenticated) { true }
+        return DefaultSimklRatingsRemoteDataSource(httpClient = client)
+    }
+
+    @Test
+    fun `should use POST method and correct path given addRatings is called`() = runTest {
+        var capturedMethod: HttpMethod? = null
+        var capturedPath: String? = null
+
+        val engine = MockEngine { request ->
+            capturedMethod = request.method
+            capturedPath = request.url.encodedPath
+            respond(
+                content = SIMKL_ADD_RATINGS_RESPONSE,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        dataSource.addRatings(
+            SimklRatingsRequest(
+                shows = listOf(
+                    SimklRatingItem(
+                        rating = 8,
+                        ratedAt = "2014-09-01T09:10:11.000Z",
+                        ids = SimklShowIds(simkl = 39687L, tmdb = "296", imdb = "tt0472954"),
+                    ),
+                ),
+            ),
+        )
+
+        capturedMethod shouldBe HttpMethod.Post
+        capturedPath shouldBe "/sync/ratings"
+    }
+
+    @Test
+    fun `should include rating and rated_at in body given addRatings is called`() = runTest {
+        var capturedBody: String? = null
+
+        val engine = MockEngine { request ->
+            capturedBody = request.body.toByteArray().decodeToString()
+            respond(
+                content = SIMKL_ADD_RATINGS_RESPONSE,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        dataSource.addRatings(
+            SimklRatingsRequest(
+                shows = listOf(
+                    SimklRatingItem(
+                        rating = 8,
+                        ratedAt = "2014-09-01T09:10:11.000Z",
+                        ids = SimklShowIds(simkl = 39687L, tmdb = "296", imdb = "tt0472954"),
+                    ),
+                ),
+            ),
+        )
+
+        capturedBody shouldContain "\"rating\": 8"
+        capturedBody shouldContain "\"rated_at\": \"2014-09-01T09:10:11.000Z\""
+        capturedBody shouldContain "\"simkl\": 39687"
+    }
+
+    @Test
+    fun `should deserialize added and not_found buckets given addRatings response is returned`() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = SIMKL_ADD_RATINGS_RESPONSE,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        val result = dataSource.addRatings(SimklRatingsRequest(shows = emptyList()))
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<SimklAddRatingsResponse>>()
+        success.body.added?.movies shouldBe 0
+        success.body.added?.shows shouldBe 1
+        success.body.notFound?.movies shouldBe emptyList()
+        success.body.notFound?.shows shouldBe emptyList()
+    }
+
+    @Test
+    fun `should use POST method and correct path given removeRatings is called`() = runTest {
+        var capturedMethod: HttpMethod? = null
+        var capturedPath: String? = null
+
+        val engine = MockEngine { request ->
+            capturedMethod = request.method
+            capturedPath = request.url.encodedPath
+            respond(
+                content = SIMKL_REMOVE_RATINGS_RESPONSE,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        dataSource.removeRatings(
+            SimklRemoveRatingsRequest(
+                shows = listOf(SimklRatingIdItem(ids = SimklShowIds(simkl = 17465L))),
+            ),
+        )
+
+        capturedMethod shouldBe HttpMethod.Post
+        capturedPath shouldBe "/sync/ratings/remove"
+    }
+
+    @Test
+    fun `should include only ids without rating in body given removeRatings is called`() = runTest {
+        var capturedBody: String? = null
+
+        val engine = MockEngine { request ->
+            capturedBody = request.body.toByteArray().decodeToString()
+            respond(
+                content = SIMKL_REMOVE_RATINGS_RESPONSE,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        dataSource.removeRatings(
+            SimklRemoveRatingsRequest(
+                shows = listOf(SimklRatingIdItem(ids = SimklShowIds(simkl = 17465L))),
+            ),
+        )
+
+        capturedBody shouldContain "\"simkl\": 17465"
+        (capturedBody?.contains("rating") ?: true) shouldBe false
+    }
+
+    @Test
+    fun `should deserialize deleted and not_found buckets given removeRatings response is returned`() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = SIMKL_REMOVE_RATINGS_RESPONSE,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        val result = dataSource.removeRatings(SimklRemoveRatingsRequest(shows = emptyList()))
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<SimklRemoveRatingsResponse>>()
+        success.body.deleted?.movies shouldBe 0
+        success.body.deleted?.shows shouldBe 1
+        success.body.notFound?.movies shouldBe emptyList()
+        success.body.notFound?.shows shouldBe emptyList()
+    }
+
+    @Test
+    fun `should use GET method and correct path given getUserShowRatings is called`() = runTest {
+        var capturedMethod: HttpMethod? = null
+        var capturedPath: String? = null
+
+        val engine = MockEngine { request ->
+            capturedMethod = request.method
+            capturedPath = request.url.encodedPath
+            respond(
+                content = SIMKL_USER_RATINGS_RESPONSE,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        dataSource.getUserShowRatings()
+
+        capturedMethod shouldBe HttpMethod.Get
+        capturedPath shouldBe "/sync/ratings/shows"
+    }
+
+    @Test
+    fun `should deserialize user_rating rated_at and show given getUserShowRatings returns ratings`() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = SIMKL_USER_RATINGS_RESPONSE,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        val result = dataSource.getUserShowRatings()
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<SimklUserRatingsResponse>>()
+        val ratedShow = success.body.shows.first()
+        ratedShow.userRating shouldBe 8
+        ratedShow.ratedAt shouldBe "2014-09-01T09:10:11Z"
+        ratedShow.show.title shouldBe "Breaking Bad"
+        ratedShow.show.ids.simkl shouldBe 39687L
+    }
+
+    @Test
+    fun `should deserialize simkl community rating and votes given show entry includes a ratings object`() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = SIMKL_USER_RATINGS_RESPONSE,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        val result = dataSource.getUserShowRatings()
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<SimklUserRatingsResponse>>()
+        val ratedShow = success.body.shows.first()
+        ratedShow.show.ratings?.simkl?.rating shouldBe 8.4
+        ratedShow.show.ratings?.simkl?.votes shouldBe 12345
+    }
+
+    @Test
+    fun `should return Unauthenticated given user is not authenticated and getUserShowRatings is called`() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = SIMKL_USER_RATINGS_RESPONSE,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(json = json) }
+            install(SimklAuthGuard) {
+                isAuthenticated = { false }
+            }
+        }
+        client.attributes.put(IsAuthenticated) { false }
+        val dataSource = DefaultSimklRatingsRemoteDataSource(httpClient = client)
+
+        val result = dataSource.getUserShowRatings()
+
+        result.shouldBeInstanceOf<ApiResponse.Unauthenticated>()
+    }
+}
+
+private val SIMKL_ADD_RATINGS_RESPONSE = """
+{
+  "added": {
+    "movies": 0,
+    "shows": 1
+  },
+  "not_found": {
+    "movies": [],
+    "shows": []
+  }
+}
+""".trimIndent()
+
+private val SIMKL_REMOVE_RATINGS_RESPONSE = """
+{
+  "deleted": {
+    "movies": 0,
+    "shows": 1
+  },
+  "not_found": {
+    "movies": [],
+    "shows": []
+  }
+}
+""".trimIndent()
+
+private val SIMKL_USER_RATINGS_RESPONSE = """
+{
+  "shows": [
+    {
+      "user_rating": 8,
+      "rated_at": "2014-09-01T09:10:11Z",
+      "show": {
+        "title": "Breaking Bad",
+        "year": 2008,
+        "ids": {
+          "simkl": 39687,
+          "tmdb": "1396",
+          "imdb": "tt0903747"
+        },
+        "ratings": {
+          "simkl": {
+            "rating": 8.4,
+            "votes": 12345
+          }
+        }
+      }
+    }
+  ]
+}
+""".trimIndent()

--- a/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/TraktRatingsRemoteDataSource.kt
+++ b/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/TraktRatingsRemoteDataSource.kt
@@ -1,0 +1,28 @@
+package com.thomaskioko.tvmaniac.trakt.api
+
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktAddRatingsResponse
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktRatingResponse
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktRatingsRequest
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktRemoveRatingsRequest
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktRemoveRatingsResponse
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktUserRatingItem
+
+public interface TraktRatingsRemoteDataSource {
+
+    public suspend fun addRatings(request: TraktRatingsRequest): ApiResponse<TraktAddRatingsResponse>
+
+    public suspend fun removeRatings(request: TraktRemoveRatingsRequest): ApiResponse<TraktRemoveRatingsResponse>
+
+    public suspend fun getUserShowRatings(): ApiResponse<List<TraktUserRatingItem>>
+
+    public suspend fun getShowCommunityRating(traktId: Long): ApiResponse<TraktRatingResponse>
+
+    public suspend fun getSeasonCommunityRating(traktId: Long, seasonNumber: Int): ApiResponse<TraktRatingResponse>
+
+    public suspend fun getEpisodeCommunityRating(
+        traktId: Long,
+        seasonNumber: Int,
+        episodeNumber: Int,
+    ): ApiResponse<TraktRatingResponse>
+}

--- a/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/model/TraktRatingsReadResponse.kt
+++ b/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/model/TraktRatingsReadResponse.kt
@@ -1,0 +1,19 @@
+package com.thomaskioko.tvmaniac.trakt.api.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class TraktRatingResponse(
+    @SerialName("rating") val rating: Double,
+    @SerialName("votes") val votes: Long,
+    @SerialName("distribution") val distribution: Map<String, Int>,
+)
+
+@Serializable
+public data class TraktUserRatingItem(
+    @SerialName("rated_at") val ratedAt: String,
+    @SerialName("rating") val rating: Int,
+    @SerialName("type") val type: String,
+    @SerialName("show") val show: TraktHistoryShow,
+)

--- a/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/model/TraktRatingsRequest.kt
+++ b/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/model/TraktRatingsRequest.kt
@@ -1,0 +1,57 @@
+package com.thomaskioko.tvmaniac.trakt.api.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class TraktRatingsRequest(
+    @SerialName("shows") val shows: List<TraktShowRatingItem>? = null,
+    @SerialName("seasons") val seasons: List<TraktSeasonRatingItem>? = null,
+    @SerialName("episodes") val episodes: List<TraktEpisodeRatingItem>? = null,
+)
+
+@Serializable
+public data class TraktShowRatingItem(
+    @SerialName("rating") val rating: Int,
+    @SerialName("ids") val ids: TraktShowIds,
+)
+
+@Serializable
+public data class TraktSeasonRatingItem(
+    @SerialName("rating") val rating: Int,
+    @SerialName("ids") val ids: TraktSeasonIds,
+)
+
+@Serializable
+public data class TraktEpisodeRatingItem(
+    @SerialName("rating") val rating: Int,
+    @SerialName("ids") val ids: TraktEpisodeIds,
+)
+
+@Serializable
+public data class TraktSeasonIds(
+    @SerialName("trakt") val traktId: Long? = null,
+    @SerialName("tmdb") val tmdbId: Long? = null,
+)
+
+@Serializable
+public data class TraktRemoveRatingsRequest(
+    @SerialName("shows") val shows: List<TraktShowRatingIdItem>? = null,
+    @SerialName("seasons") val seasons: List<TraktSeasonRatingIdItem>? = null,
+    @SerialName("episodes") val episodes: List<TraktEpisodeRatingIdItem>? = null,
+)
+
+@Serializable
+public data class TraktShowRatingIdItem(
+    @SerialName("ids") val ids: TraktShowIds,
+)
+
+@Serializable
+public data class TraktSeasonRatingIdItem(
+    @SerialName("ids") val ids: TraktSeasonIds,
+)
+
+@Serializable
+public data class TraktEpisodeRatingIdItem(
+    @SerialName("ids") val ids: TraktEpisodeIds,
+)

--- a/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/model/TraktRatingsResponse.kt
+++ b/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/model/TraktRatingsResponse.kt
@@ -1,0 +1,32 @@
+package com.thomaskioko.tvmaniac.trakt.api.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class TraktAddRatingsResponse(
+    @SerialName("added") val added: TraktRatingsCount,
+    @SerialName("not_found") val notFound: TraktRatingsNotFound,
+)
+
+@Serializable
+public data class TraktRemoveRatingsResponse(
+    @SerialName("deleted") val deleted: TraktRatingsCount,
+    @SerialName("not_found") val notFound: TraktRatingsNotFound,
+)
+
+@Serializable
+public data class TraktRatingsCount(
+    @SerialName("movies") val movies: Int? = null,
+    @SerialName("shows") val shows: Int? = null,
+    @SerialName("seasons") val seasons: Int? = null,
+    @SerialName("episodes") val episodes: Int? = null,
+)
+
+@Serializable
+public data class TraktRatingsNotFound(
+    @SerialName("movies") val movies: List<TraktShowRatingIdItem>? = null,
+    @SerialName("shows") val shows: List<TraktShowRatingIdItem>? = null,
+    @SerialName("seasons") val seasons: List<TraktSeasonRatingIdItem>? = null,
+    @SerialName("episodes") val episodes: List<TraktEpisodeRatingIdItem>? = null,
+)

--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktRatingsRemoteDataSource.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktRatingsRemoteDataSource.kt
@@ -1,0 +1,86 @@
+package com.thomaskioko.trakt.service.implementation.api
+
+import com.thomaskioko.tvmaniac.core.base.TraktApi
+import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.authSafeRequest
+import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.safeRequest
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.trakt.api.TraktRatingsRemoteDataSource
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktAddRatingsResponse
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktRatingResponse
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktRatingsRequest
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktRemoveRatingsRequest
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktRemoveRatingsResponse
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktUserRatingItem
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
+import io.ktor.client.HttpClient
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
+import io.ktor.http.contentType
+import io.ktor.http.path
+
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+public class DefaultTraktRatingsRemoteDataSource(
+    @TraktApi
+    private val httpClient: HttpClient,
+) : TraktRatingsRemoteDataSource {
+
+    override suspend fun addRatings(request: TraktRatingsRequest): ApiResponse<TraktAddRatingsResponse> =
+        httpClient.authSafeRequest {
+            url {
+                method = HttpMethod.Post
+                path("sync/ratings")
+            }
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }
+
+    override suspend fun removeRatings(request: TraktRemoveRatingsRequest): ApiResponse<TraktRemoveRatingsResponse> =
+        httpClient.authSafeRequest {
+            url {
+                method = HttpMethod.Post
+                path("sync/ratings/remove")
+            }
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }
+
+    override suspend fun getUserShowRatings(): ApiResponse<List<TraktUserRatingItem>> =
+        httpClient.authSafeRequest {
+            url {
+                method = HttpMethod.Get
+                path("sync/ratings/shows")
+            }
+        }
+
+    override suspend fun getShowCommunityRating(traktId: Long): ApiResponse<TraktRatingResponse> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Get
+                path("shows/$traktId/ratings")
+            }
+        }
+
+    override suspend fun getSeasonCommunityRating(traktId: Long, seasonNumber: Int): ApiResponse<TraktRatingResponse> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Get
+                path("shows/$traktId/seasons/$seasonNumber/ratings")
+            }
+        }
+
+    override suspend fun getEpisodeCommunityRating(
+        traktId: Long,
+        seasonNumber: Int,
+        episodeNumber: Int,
+    ): ApiResponse<TraktRatingResponse> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Get
+                path("shows/$traktId/seasons/$seasonNumber/episodes/$episodeNumber/ratings")
+            }
+        }
+}

--- a/api/trakt/implementation/src/jvmTest/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktRatingsRemoteDataSourceTest.kt
+++ b/api/trakt/implementation/src/jvmTest/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktRatingsRemoteDataSourceTest.kt
@@ -1,0 +1,385 @@
+package com.thomaskioko.trakt.service.implementation.api
+
+import com.thomaskioko.trakt.service.implementation.TraktAuthGuard
+import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.IsAuthenticated
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktAddRatingsResponse
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktEpisodeIds
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktEpisodeRatingIdItem
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktEpisodeRatingItem
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktRatingResponse
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktRatingsRequest
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktRemoveRatingsRequest
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktRemoveRatingsResponse
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktSeasonIds
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktSeasonRatingIdItem
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktSeasonRatingItem
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktShowIds
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktShowRatingIdItem
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktShowRatingItem
+import com.thomaskioko.tvmaniac.trakt.api.model.TraktUserRatingItem
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+
+class DefaultTraktRatingsRemoteDataSourceTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        prettyPrint = true
+        encodeDefaults = true
+    }
+
+    private fun createDataSource(engine: MockEngine): DefaultTraktRatingsRemoteDataSource {
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(json = json) }
+        }
+        client.attributes.put(IsAuthenticated) { true }
+        return DefaultTraktRatingsRemoteDataSource(httpClient = client)
+    }
+
+    @Test
+    fun `should use POST method and correct path given addRatings is called`() = runTest {
+        var capturedMethod: HttpMethod? = null
+        var capturedPath: String? = null
+
+        val engine = MockEngine { request ->
+            capturedMethod = request.method
+            capturedPath = request.url.encodedPath
+            respond(
+                content = """{"added":{"movies":0,"shows":1,"seasons":0,"episodes":0},""" +
+                    """"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[]}}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        dataSource.addRatings(
+            TraktRatingsRequest(shows = listOf(TraktShowRatingItem(rating = 8, ids = TraktShowIds(traktId = 1, tmdbId = 296)))),
+        )
+
+        capturedMethod shouldBe HttpMethod.Post
+        capturedPath shouldBe "/sync/ratings"
+    }
+
+    @Test
+    fun `should include rating and ids in request body given addRatings is called`() = runTest {
+        var capturedBody: String? = null
+
+        val engine = MockEngine { request ->
+            capturedBody = request.body.toByteArray().decodeToString()
+            respond(
+                content = """{"added":{"movies":0,"shows":1,"seasons":0,"episodes":0},""" +
+                    """"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[]}}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        dataSource.addRatings(
+            TraktRatingsRequest(
+                shows = listOf(TraktShowRatingItem(rating = 8, ids = TraktShowIds(traktId = 1, tmdbId = 296))),
+                seasons = listOf(TraktSeasonRatingItem(rating = 7, ids = TraktSeasonIds(traktId = 2, tmdbId = 297))),
+                episodes = listOf(TraktEpisodeRatingItem(rating = 6, ids = TraktEpisodeIds(traktId = 3, tmdbId = 298))),
+            ),
+        )
+
+        capturedBody shouldContain "\"rating\": 8"
+        capturedBody shouldContain "\"rating\": 7"
+        capturedBody shouldContain "\"rating\": 6"
+        capturedBody shouldContain "296"
+        capturedBody shouldContain "297"
+        capturedBody shouldContain "298"
+    }
+
+    @Test
+    fun `should return Success with added counts given addRatings succeeds`() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = """{"added":{"movies":0,"shows":1,"seasons":2,"episodes":3},""" +
+                    """"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[]}}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        val result = dataSource.addRatings(
+            TraktRatingsRequest(shows = listOf(TraktShowRatingItem(rating = 8, ids = TraktShowIds(traktId = 1, tmdbId = 296)))),
+        )
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<TraktAddRatingsResponse>>()
+        success.body.added.shows shouldBe 1
+        success.body.added.seasons shouldBe 2
+        success.body.added.episodes shouldBe 3
+    }
+
+    @Test
+    fun `should use POST method and correct path given removeRatings is called`() = runTest {
+        var capturedMethod: HttpMethod? = null
+        var capturedPath: String? = null
+
+        val engine = MockEngine { request ->
+            capturedMethod = request.method
+            capturedPath = request.url.encodedPath
+            respond(
+                content = """{"deleted":{"movies":0,"shows":1,"seasons":0,"episodes":0},""" +
+                    """"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[]}}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        dataSource.removeRatings(
+            TraktRemoveRatingsRequest(shows = listOf(TraktShowRatingIdItem(ids = TraktShowIds(traktId = 1, tmdbId = 296)))),
+        )
+
+        capturedMethod shouldBe HttpMethod.Post
+        capturedPath shouldBe "/sync/ratings/remove"
+    }
+
+    @Test
+    fun `should include ids without rating in request body given removeRatings is called`() = runTest {
+        var capturedBody: String? = null
+
+        val engine = MockEngine { request ->
+            capturedBody = request.body.toByteArray().decodeToString()
+            respond(
+                content = """{"deleted":{"movies":0,"shows":1,"seasons":1,"episodes":1},""" +
+                    """"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[]}}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        dataSource.removeRatings(
+            TraktRemoveRatingsRequest(
+                shows = listOf(TraktShowRatingIdItem(ids = TraktShowIds(traktId = 1, tmdbId = 296))),
+                seasons = listOf(TraktSeasonRatingIdItem(ids = TraktSeasonIds(traktId = 2, tmdbId = 297))),
+                episodes = listOf(TraktEpisodeRatingIdItem(ids = TraktEpisodeIds(traktId = 3, tmdbId = 298))),
+            ),
+        )
+
+        capturedBody shouldContain "296"
+        capturedBody shouldContain "297"
+        capturedBody shouldContain "298"
+        capturedBody shouldNotContain "\"rating\""
+    }
+
+    @Test
+    fun `should return Success with deleted counts given removeRatings succeeds`() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = """{"deleted":{"movies":0,"shows":1,"seasons":2,"episodes":3},""" +
+                    """"not_found":{"movies":[],"shows":[],"seasons":[],"episodes":[]}}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        val result = dataSource.removeRatings(
+            TraktRemoveRatingsRequest(shows = listOf(TraktShowRatingIdItem(ids = TraktShowIds(traktId = 1, tmdbId = 296)))),
+        )
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<TraktRemoveRatingsResponse>>()
+        success.body.deleted.shows shouldBe 1
+        success.body.deleted.seasons shouldBe 2
+        success.body.deleted.episodes shouldBe 3
+    }
+
+    @Test
+    fun `should use GET and correct path given getUserShowRatings is called`() = runTest {
+        var capturedMethod: HttpMethod? = null
+        var capturedPath: String? = null
+
+        val engine = MockEngine { request ->
+            capturedMethod = request.method
+            capturedPath = request.url.encodedPath
+            respond(
+                content = """[]""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        dataSource.getUserShowRatings()
+
+        capturedMethod shouldBe HttpMethod.Get
+        capturedPath shouldBe "/sync/ratings/shows"
+    }
+
+    @Test
+    fun `should return Success with parsed items given getUserShowRatings succeeds`() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = """[{"rated_at":"2014-09-01T09:10:11.000Z","rating":10,"type":"show",""" +
+                    """"show":{"title":"Breaking Bad","year":2008,""" +
+                    """"ids":{"trakt":1,"slug":"breaking-bad","tmdb":1396,"imdb":"tt0903747"}}}]""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        val result = dataSource.getUserShowRatings()
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<List<TraktUserRatingItem>>>()
+        success.body shouldHaveSize 1
+        success.body.first().rating shouldBe 10
+        success.body.first().show.title shouldBe "Breaking Bad"
+        success.body.first().show.ids.traktId shouldBe 1
+        success.body.first().show.ids.tmdbId shouldBe 1396
+    }
+
+    @Test
+    fun `should use GET and correct path given getShowCommunityRating is called`() = runTest {
+        var capturedMethod: HttpMethod? = null
+        var capturedPath: String? = null
+
+        val engine = MockEngine { request ->
+            capturedMethod = request.method
+            capturedPath = request.url.encodedPath
+            respond(
+                content = """{"rating":9.0,"votes":51065,"distribution":{"1":123,"10":3000}}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        dataSource.getShowCommunityRating(traktId = 1)
+
+        capturedMethod shouldBe HttpMethod.Get
+        capturedPath shouldBe "/shows/1/ratings"
+    }
+
+    @Test
+    fun `should return Success with rating votes and distribution given getShowCommunityRating succeeds`() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = """{"rating":9.0,"votes":51065,"distribution":{"1":123,"10":3000}}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        val result = dataSource.getShowCommunityRating(traktId = 1)
+
+        val success = result.shouldBeInstanceOf<ApiResponse.Success<TraktRatingResponse>>()
+        success.body.rating shouldBe 9.0
+        success.body.votes shouldBe 51065
+        success.body.distribution["10"] shouldBe 3000
+    }
+
+    @Test
+    fun `should use GET and correct path given getSeasonCommunityRating is called`() = runTest {
+        var capturedMethod: HttpMethod? = null
+        var capturedPath: String? = null
+
+        val engine = MockEngine { request ->
+            capturedMethod = request.method
+            capturedPath = request.url.encodedPath
+            respond(
+                content = """{"rating":8.5,"votes":200,"distribution":{"1":1,"10":100}}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        dataSource.getSeasonCommunityRating(traktId = 1, seasonNumber = 2)
+
+        capturedMethod shouldBe HttpMethod.Get
+        capturedPath shouldBe "/shows/1/seasons/2/ratings"
+    }
+
+    @Test
+    fun `should use GET and correct path given getEpisodeCommunityRating is called`() = runTest {
+        var capturedMethod: HttpMethod? = null
+        var capturedPath: String? = null
+
+        val engine = MockEngine { request ->
+            capturedMethod = request.method
+            capturedPath = request.url.encodedPath
+            respond(
+                content = """{"rating":8.9,"votes":50,"distribution":{"1":1,"10":30}}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        dataSource.getEpisodeCommunityRating(traktId = 1, seasonNumber = 2, episodeNumber = 3)
+
+        capturedMethod shouldBe HttpMethod.Get
+        capturedPath shouldBe "/shows/1/seasons/2/episodes/3/ratings"
+    }
+
+    @Test
+    fun `should return Success given getShowCommunityRating is called without authentication`() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = """{"rating":9.0,"votes":51065,"distribution":{"1":123,"10":3000}}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(json = json) }
+            install(TraktAuthGuard) {
+                isAuthenticated = { false }
+            }
+        }
+        client.attributes.put(IsAuthenticated) { false }
+        val dataSource = DefaultTraktRatingsRemoteDataSource(httpClient = client)
+
+        val result = dataSource.getShowCommunityRating(traktId = 1)
+
+        result.shouldBeInstanceOf<ApiResponse.Success<TraktRatingResponse>>()
+    }
+
+    @Test
+    fun `should return Unauthenticated given getUserShowRatings is called without authentication`() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = """[]""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(json = json) }
+            install(TraktAuthGuard) {
+                isAuthenticated = { false }
+            }
+        }
+        client.attributes.put(IsAuthenticated) { false }
+        val dataSource = DefaultTraktRatingsRemoteDataSource(httpClient = client)
+
+        val result = dataSource.getUserShowRatings()
+
+        result.shouldBeInstanceOf<ApiResponse.Unauthenticated>()
+    }
+}


### PR DESCRIPTION
## Description
This PR introduces remote data sources for Trakt and SIMKL ratings, enabling fetching and submitting user show ratings. It adds the necessary API models and service implementations to support integrated rating functionality.

## Changes
- Create `TraktRatingsRemoteDataSource` and `SimklRatingsRemoteDataSource` interfaces for rating operations
- Implement rating data sources for Trakt and SIMKL services
- Add API models for requesting and parsing Trakt and SIMKL ratings
- Add comprehensive unit tests for Trakt and SIMKL remote data source implementations
