### PR TITLE
chore: Enhance mock engine stubbing for multi-provider

### DIFF
--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/calendar/CalendarFlowTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/calendar/CalendarFlowTest.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.app.test.compose.flows.calendar
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.app.test.BaseAppFlowTest
 import com.thomaskioko.tvmaniac.app.test.compose.stubs.TEST_NEXT_WEEK
 import com.thomaskioko.tvmaniac.testtags.home.HomeTestTags
@@ -35,8 +36,8 @@ internal class CalendarFlowTest : BaseAppFlowTest() {
         discoverRobot
             .assertDiscoverScreenDisplayed()
 
-        scenarios.library.stubLibrarySyncEndpoints()
-        scenarios.watchlist.stubWatchlistSyncEndpoints()
+        scenarios.stubLibrarySyncEndpoints(AccountProvider.TRAKT)
+        scenarios.stubWatchlistSyncEndpoints(AccountProvider.TRAKT)
         scenarios.signInAndDismissRationale()
 
         scenarios.calendar.stubWeek()

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/seasons/SeasonFlowTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/seasons/SeasonFlowTest.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.app.test.compose.flows.seasons
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.app.test.BaseAppFlowTest
 import com.thomaskioko.tvmaniac.testtags.home.HomeTestTags
 import org.junit.Test
@@ -104,9 +105,8 @@ internal class SeasonFlowTest : BaseAppFlowTest() {
 
     @Test
     fun givenAuthenticatedUser_whenSeasonRated_thenRatingPersistsAndCanBeCleared() = runAppFlowTest {
-        scenarios.discover.stubBrowseGraph()
-        scenarios.stubAuthenticatedSync()
-        scenarios.ratings.stubRatingsSync()
+        scenarios.stubTmdb()
+        scenarios.stubActiveProvider(AccountProvider.TRAKT)
 
         rootRobot.dismissNotificationRationale()
 

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/sheet/EpisodeSheetFlowTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/sheet/EpisodeSheetFlowTest.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.app.test.compose.flows.sheet
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.app.test.AppFlowScope
 import com.thomaskioko.tvmaniac.app.test.BaseAppFlowTest
 import com.thomaskioko.tvmaniac.presentation.episodedetail.EpisodeSheetActionItem
@@ -83,8 +84,8 @@ internal class EpisodeSheetFlowTest : BaseAppFlowTest() {
 
     @Test
     fun givenEpisodeSheet_whenEpisodeRated_thenRatingPersistsAndCanBeCleared() = runAppFlowTest {
-        scenarios.stubAuthenticatedSync()
-        scenarios.ratings.stubRatingsSync()
+        scenarios.stubTmdb()
+        scenarios.stubActiveProvider(AccountProvider.TRAKT)
 
         openEpisodeSheetFromUpNextCard()
 

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/showdetails/ShowDetailsFeaturesFlowTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/showdetails/ShowDetailsFeaturesFlowTest.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.app.test.compose.flows.showdetails
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.app.test.BaseAppFlowTest
 import com.thomaskioko.tvmaniac.testtags.home.HomeTestTags
 import org.junit.Test
@@ -68,9 +69,8 @@ internal class ShowDetailsFeaturesFlowTest : BaseAppFlowTest() {
 
     @Test
     fun givenAuthenticatedUser_whenShowRated_thenRatingPersistsAndCanBeCleared() = runAppFlowTest {
-        scenarios.discover.stubBrowseGraph()
-        scenarios.stubAuthenticatedSync()
-        scenarios.ratings.stubRatingsSync()
+        scenarios.stubTmdb()
+        scenarios.stubActiveProvider(AccountProvider.TRAKT)
 
         rootRobot.dismissNotificationRationale()
 
@@ -108,10 +108,8 @@ internal class ShowDetailsFeaturesFlowTest : BaseAppFlowTest() {
 
     @Test
     fun givenSimklSession_whenShowRated_thenRatingPersistsAndCanBeCleared() = runAppFlowTest {
-        scenarios.flags.enableSimklLogin()
-        scenarios.discover.stubBrowseGraph()
-        scenarios.stubAuthenticatedSimklProfile()
-        scenarios.simkl.stubRatingsSync()
+        scenarios.stubTmdb()
+        scenarios.stubActiveProvider(AccountProvider.SIMKL)
 
         discoverRobot
             .assertFeaturedPagerDisplayed()

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/journey/AccountProviderSwitchJourneyTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/journey/AccountProviderSwitchJourneyTest.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.app.test.compose.journey
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.app.test.BaseAppFlowTest
 import com.thomaskioko.tvmaniac.app.test.compose.stubs.TEST_PROFILE_SLUG
 import com.thomaskioko.tvmaniac.app.test.compose.stubs.TEST_SIMKL_ACCOUNT_ID
@@ -12,11 +13,8 @@ internal class AccountProviderSwitchJourneyTest : BaseAppFlowTest() {
 
     @Test
     fun givenTraktSession_whenSwitchesToSimkl_thenActiveBecomesSimklAndDiscoverStaysIntact() = runAppFlowTest {
-        scenarios.flags.enableSimklLogin()
-        scenarios.flags.enableAccountSwitch()
-        scenarios.stubAuthenticatedSync()
+        scenarios.stubAuthenticatedSyncWithAccountSwitch()
 
-        // Trakt-synced My Shows is populated before the switch.
         homeRobot
             .clickMyShowsTab()
             .assertTabSelected(HomeTestTags.MY_SHOWS_TAB)
@@ -24,10 +22,7 @@ internal class AccountProviderSwitchJourneyTest : BaseAppFlowTest() {
             .scrollToShowCard(breakingBadTmdbId)
             .assertShowCardDisplayed(breakingBadTmdbId)
 
-        // Tapping "Switch to Simkl" launches Simkl sign-in; the OAuth callback seeds the Simkl session.
-        graph.oAuthLauncher.setOnLaunch {
-            scenarios.stubAuthenticatedSimklProfile()
-        }
+        scenarios.stubOnSignIn(AccountProvider.SIMKL)
 
         homeRobot
             .clickProfileTab()
@@ -45,12 +40,10 @@ internal class AccountProviderSwitchJourneyTest : BaseAppFlowTest() {
             .clickBackButton()
             .clickBackButton()
 
-        // The active account is now Simkl: Profile renders the Simkl user.
         profileRobot
             .assertUserCardDisplayed(slug = TEST_SIMKL_ACCOUNT_ID.toString())
             .assertUserNameDisplayed()
 
-        // Discover is provider-agnostic and remains intact after the switch.
         homeRobot
             .clickDiscoverTab()
             .assertTabSelected(HomeTestTags.DISCOVER_TAB)

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/journey/AuthenticatedUserJourneyTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/journey/AuthenticatedUserJourneyTest.kt
@@ -1,7 +1,6 @@
 package com.thomaskioko.tvmaniac.app.test.compose.journey
 
 import com.thomaskioko.tvmaniac.app.test.BaseAppFlowTest
-import com.thomaskioko.tvmaniac.app.test.compose.stubs.TEST_NEXT_WEEK
 import com.thomaskioko.tvmaniac.app.test.compose.stubs.TEST_PROFILE_SLUG
 import com.thomaskioko.tvmaniac.presentation.episodedetail.EpisodeSheetActionItem
 import com.thomaskioko.tvmaniac.testtags.home.HomeTestTags
@@ -20,8 +19,6 @@ internal class AuthenticatedUserJourneyTest : BaseAppFlowTest() {
     @Test
     fun givenAuthenticatedUser_whenSignsIn_thenExploresSyncedSurfacesAndSignsOut() = runAppFlowTest {
         scenarios.stubUnauthenticatedState()
-        scenarios.calendar.stubWeek()
-        scenarios.calendar.stubWeek(weekStart = TEST_NEXT_WEEK)
 
         // Verify public content on Discover
         discoverRobot

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/journey/SimklCalendarJourneyTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/journey/SimklCalendarJourneyTest.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.app.test.compose.journey
 
+import com.thomaskioko.tvmaniac.accountmanager.api.AccountProvider
 import com.thomaskioko.tvmaniac.app.test.BaseAppFlowTest
 import com.thomaskioko.tvmaniac.testtags.home.HomeTestTags
 import org.junit.Test
@@ -11,8 +12,8 @@ internal class SimklCalendarJourneyTest : BaseAppFlowTest() {
     @Test
     fun givenSimklSession_whenCalendarOpened_thenShowsTrackedShowEpisode() = runAppFlowTest {
         scenarios.stubUnauthenticatedState()
-        scenarios.stubAuthenticatedSimklStartWatching()
-        scenarios.simkl.stubCalendarFeed()
+        scenarios.stubActiveProvider(AccountProvider.SIMKL)
+        scenarios.simkl.stubPlanToWatchWatchlist()
 
         homeRobot
             .clickMyShowsTab()

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
@@ -43,16 +43,15 @@ internal class Scenarios(
 ) {
     val auth: Auth = Auth()
     val discover: Discover = Discover()
-    val profile: Profile = Profile()
     val simkl: Simkl = Simkl()
-    val library: Library = Library()
-    val watchlist: Watchlist = Watchlist()
     val search: Search = Search()
     val calendar: Calendar = Calendar()
     val upNext: UpNext = UpNext()
     val traktLists: TraktLists = TraktLists()
     val flags: Flags = Flags()
-    val ratings: Ratings = Ratings()
+    val library: Library = Library()
+    val watchlist: Watchlist = Watchlist()
+    val profile: Profile = Profile()
 
     fun signInAndDismissRationale() {
         auth.stubLoggedInUser()
@@ -75,13 +74,61 @@ internal class Scenarios(
     }
 
     fun stubAuthenticatedSync() {
-        auth.stubLoggedInUser()
+        stubPublicCatalog()
+        stubActiveProvider(AccountProvider.TRAKT)
+    }
+
+    fun stubTmdb() {
+        stubPublicCatalog()
+    }
+
+    fun stubPublicCatalog() {
         discover.stubBrowseGraph()
-        library.stubLibrarySyncEndpoints()
-        watchlist.stubWatchlistSyncEndpoints()
-        profile.stubProfileSyncEndpoints()
-        calendar.stubWeek()
-        calendar.stubWeek(weekStart = TEST_NEXT_WEEK)
+    }
+
+    /**
+     * Wires the given [AccountProvider]'s baseline authenticated session: sign-in state, plus its
+     * catalog-declared [Endpoints.Trakt.authenticatedEndpoints] / [Endpoints.Simkl.authenticatedEndpoints]
+     * in one shared loop. Host-aware matching in [MockEngineHandler] means this is safe to call
+     * once per test alongside [stubPublicCatalog]; call sites don't need to know which provider
+     * owns which path. A cross-provider account endpoint is added to those catalog lists, not to
+     * a new branch here.
+     *
+     * Always pair this with [stubPublicCatalog]: it is the only source of TMDB/discover coverage
+     * for either provider.
+     */
+    fun stubActiveProvider(provider: AccountProvider) {
+        when (provider) {
+            AccountProvider.TRAKT -> {
+                auth.stubLoggedInUser()
+                val endpoints = Endpoints.Trakt.authenticatedEndpoints + listOf(
+                    Endpoints.Trakt.userStats(TEST_PROFILE_SLUG),
+                    Endpoints.Trakt.userLists(TEST_PROFILE_SLUG),
+                    Endpoints.Trakt.calendar(TEST_TODAY, 7),
+                    Endpoints.Trakt.calendar(TEST_NEXT_WEEK, 7),
+                )
+                endpoints.forEach { mockHandler.stubEndpoint(it) }
+
+                // Shared empty-array fixture, not tied to one catalog entry, so it isn't a
+                // plain Endpoint. Kept as explicit glue, mirroring the seasons catch-all in
+                // Discover.stubBrowseGraph.
+                mockHandler.stubPatternFixture(
+                    pathRegex = "/users/me/history/shows/\\d+",
+                    fixturePath = EMPTY_ARRAY_FIXTURE,
+                )
+
+                val watchedShows = FixtureLoader.load(Endpoints.Trakt.SyncWatchedShows.successFixture)
+                showFixtures(watchedShows).forEach { mockHandler.stubShow(it) }
+                val nitroShows = FixtureLoader.load(Endpoints.Trakt.SyncProgressUpNextNitro.successFixture)
+                showFixtures(nitroShows).forEach { mockHandler.stubShow(it) }
+            }
+            AccountProvider.SIMKL -> {
+                flags.enableSimklLogin()
+                Endpoints.Simkl.authenticatedEndpoints.forEach { mockHandler.stubEndpoint(it) }
+                // Sign in LAST (see TRAKT note) so login-triggered sync finds its stubs.
+                simkl.stubLoggedInUser()
+            }
+        }
     }
 
     fun stubUsersMeUnauthorized() {
@@ -89,31 +136,24 @@ internal class Scenarios(
     }
 
     /**
-     * Registers OAuth WebView callback so that next `clickSignInButton()` lazily wires profile sync
-     * endpoints, library sync endpoints, and flips fake auth state to LOGGED_IN. Mirrors live
-     * OAuth round-trip without pre-stubbing LOGGED_IN in `@Before`, so DefaultRootPresenter's
+     * Registers OAuth WebView callback so that next `clickSignInButton()` lazily wires the full
+     * authenticated Trakt session and flips fake auth state to LOGGED_IN. Mirrors live OAuth
+     * round-trip without pre-stubbing LOGGED_IN in `@Before`, so DefaultRootPresenter's
      * auth-state collector still observes real LOGGED_OUT to LOGGED_IN transition.
      */
     fun stubAuthenticatedSyncOnSignIn() {
         graph.oAuthLauncher.setOnLaunch {
-            profile.stubProfileSyncEndpoints()
-            library.stubLibrarySyncEndpoints()
-            watchlist.stubWatchlistSyncEndpoints()
-            auth.stubLoggedInUser()
-            calendar.stubWeek()
+            stubActiveProvider(AccountProvider.TRAKT)
         }
     }
 
     /**
-     * Registers OAuth WebView callback so that next `clickSignInButton()` lazily wires profile
-     * endpoints and flips fake auth state to LOGGED_IN. Use when test cares only about user-card
-     * surface and does not exercise library or UpNext sync.
+     * Registers OAuth WebView callback so that next `clickSignInButton()` lazily wires the
+     * authenticated Trakt session and flips fake auth state to LOGGED_IN.
      */
     fun stubProfileOnSignIn() {
         graph.oAuthLauncher.setOnLaunch {
-            profile.stubProfileSyncEndpoints()
-            library.stubLibrarySyncEndpoints()
-            auth.stubLoggedInUser()
+            stubActiveProvider(AccountProvider.TRAKT)
         }
     }
 
@@ -133,8 +173,9 @@ internal class Scenarios(
 
     /**
      * Simulates 401-then-refresh round-trip on `/users/me`. Configures fake repo with fresh
-     * AuthState so next refresh resolves successfully, and re-stubs profile endpoints so
-     * post-refresh calls pass.
+     * AuthState so next refresh resolves successfully, and re-stubs the profile endpoints so
+     * post-refresh calls pass. Stubs the profile endpoints directly rather than going through
+     * [stubActiveProvider], which would also reset the auth/refresh state this test is verifying.
      */
     fun stubTokenRefresh(
         accessToken: String = "refreshed-access",
@@ -150,7 +191,10 @@ internal class Scenarios(
             tokenLifetimeSeconds = tokenLifetimeSeconds,
         )
         graph.traktAuthRepository.setRefreshOutcome(TokenRefreshResult.Success(refreshedAuthState))
-        profile.stubProfileSyncEndpoints()
+        mockHandler.stubEndpoint(Endpoints.Trakt.UsersMe)
+        mockHandler.stubEndpoint(Endpoints.Trakt.userStats(TEST_PROFILE_SLUG))
+        mockHandler.stubEndpoint(Endpoints.Trakt.userLists(TEST_PROFILE_SLUG))
+        mockHandler.stubEndpoint(Endpoints.Trakt.UserListItems)
     }
 
     inner class Auth {
@@ -218,53 +262,37 @@ internal class Scenarios(
         fun stubActivities() {
             mockHandler.stubEndpoint(Endpoints.Simkl.SyncActivities)
         }
-
-        /**
-         * Stubs the Simkl rating endpoints so the pending-ratings drain (`RatingsSyncInitializer`)
-         * and the show-details community-rating reconcile (`RatingsStore`) both resolve cleanly
-         * under a Simkl session. Never call alongside [Ratings.stubRatingsSync] in the same test —
-         * both providers share the `/sync/ratings*` path strings in [MockEngineHandler].
-         */
-        fun stubRatingsSync() {
-            mockHandler.stubEndpoint(Endpoints.Simkl.SyncRatingsAdd, method = HttpMethod.Post)
-            mockHandler.stubEndpoint(Endpoints.Simkl.SyncRatingsRemove, method = HttpMethod.Post)
-            mockHandler.stubEndpoint(Endpoints.Simkl.SyncRatingsShows)
-            mockHandler.stubEndpoint(Endpoints.Simkl.ShowSummary)
-        }
-
-        fun stubCalendarFeed() {
-            mockHandler.stubEndpoint(Endpoints.Simkl.CalendarTvFeed)
-        }
     }
 
     inner class Discover {
         /**
-         * Stubs every endpoint reachable from the Discover surface: the Trakt and TMDB list
-         * endpoints, plus the per-show graph (details, seasons, episodes, people, related,
-         * videos, watched progress, TMDB show, credits, season, watch providers).
+         * Stubs the agnostic public data graph reachable from the Discover surface, independent
+         * of login state: the Trakt and TMDB list endpoints, plus the per-show graph (details,
+         * seasons, episodes, people, related, videos, TMDB show, credits, season, watch
+         * providers). Account-specific endpoints (e.g. watched progress, watch history) are
+         * stubbed by [stubActiveProvider], not here.
          */
         fun stubBrowseGraph() {
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowsFavoritedWeekly)
-            mockHandler.stubEndpoint(Endpoints.Trakt.GenresShows)
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowsTrending)
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowsPopular)
+            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowsFavoritedWeekly)
+            mockHandler.stubEndpoint(Endpoints.PublicCatalog.GenresShows)
+            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowsTrending)
+            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowsPopular)
             mockHandler.stubEndpoint(Endpoints.Tmdb.DiscoverTv)
-            mockHandler.stubEndpoint(Endpoints.Trakt.SearchByTmdb)
+            mockHandler.stubEndpoint(Endpoints.PublicCatalog.SearchByTmdb)
 
-            // Per-show Trakt endpoints — single canonical fixture for any trakt id.
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowDetails)
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowSeasons)
+            // Per-show public-catalog endpoints — single canonical fixture for any trakt id.
+            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowDetails)
+            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowSeasons)
             // Per-season episodes: catch-all returns empty so unstubbed seasons don't re-write
             // episode rows. The per-season stubs registered after win under last-registered-first-match
             // ordering. (Catalog has no entry for the catch-all because the empty-array fixture is
             // shared across endpoints and isn't tied to one resource folder.)
             mockHandler.stubPatternFixture(pathRegex = "/shows/\\d+/seasons/\\d+", fixturePath = "empty_array.json")
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowSeasonEpisodesS1)
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowSeasonEpisodesS2)
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowPeople)
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowRelated)
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowVideos)
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowProgressWatched)
+            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowSeasonEpisodesS1)
+            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowSeasonEpisodesS2)
+            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowPeople)
+            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowRelated)
+            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowVideos)
 
             // Per-show TMDB endpoints — single canonical fixture for any tmdb id.
             mockHandler.stubEndpoint(Endpoints.Tmdb.ShowDetails)
@@ -276,62 +304,6 @@ internal class Scenarios(
             mockHandler.stubEndpoint(Endpoints.Tmdb.SeasonDetailsS1)
             mockHandler.stubEndpoint(Endpoints.Tmdb.SeasonDetailsS2)
             mockHandler.stubEndpoint(Endpoints.Tmdb.WatchProviders)
-            mockHandler.stubPatternFixture(
-                pathRegex = "/users/me/history/shows/\\d+",
-                fixturePath = EMPTY_ARRAY_FIXTURE,
-            )
-        }
-
-        fun stubDiscoverError() {
-            mockHandler.stubEndpoint(Endpoints.Trakt.GenresShows, HttpStatusCode.InternalServerError)
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowsTrending, HttpStatusCode.InternalServerError)
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowsPopular, HttpStatusCode.InternalServerError)
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowsFavoritedWeekly, HttpStatusCode.InternalServerError)
-            mockHandler.stub(path = "/shows/anticipated", body = "", status = HttpStatusCode.InternalServerError)
-            mockHandler.stubEndpoint(Endpoints.Tmdb.DiscoverTv, HttpStatusCode.InternalServerError)
-        }
-    }
-
-    inner class Profile {
-        fun stubProfileSyncEndpoints(slug: String = TEST_PROFILE_SLUG) {
-            mockHandler.stubEndpoint(Endpoints.Trakt.UsersMe)
-            mockHandler.stubEndpoint(Endpoints.Trakt.userStats(slug))
-            mockHandler.stubEndpoint(Endpoints.Trakt.userLists(slug))
-            mockHandler.stubEndpoint(Endpoints.Trakt.UserListItems)
-        }
-    }
-
-    inner class Library {
-        fun stubLibrarySyncEndpoints() {
-            mockHandler.stubEndpoint(Endpoints.Trakt.SyncLastActivities)
-            mockHandler.stubEndpoint(Endpoints.Trakt.SyncWatchedShows)
-            mockHandler.stubEndpoint(Endpoints.Trakt.UsersMeWatchlistShows)
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowDetails)
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowSeasons)
-            mockHandler.stubEndpoint(Endpoints.Tmdb.ShowDetails)
-            mockHandler.stubEndpoint(Endpoints.Tmdb.WatchProviders)
-
-            val watchedShows = FixtureLoader.load(Endpoints.Trakt.SyncWatchedShows.successFixture)
-            showFixtures(watchedShows).forEach { mockHandler.stubShow(it) }
-        }
-    }
-
-    inner class Watchlist {
-        /**
-         * Stubs the Continue Watching pipeline that drives the Watchlist and Up Next tabs:
-         * `/sync/progress/up_next_nitro` (default Nitro fetcher) plus the documented fallback
-         * (`/sync/watched/shows` + `/sync/playback/episodes`). Per-show metadata fan-out reuses
-         * [Library]'s show stubs since the same Trakt ids appear in both fixtures.
-         */
-        fun stubWatchlistSyncEndpoints() {
-            mockHandler.stubEndpoint(Endpoints.Trakt.SyncProgressUpNextNitro)
-            mockHandler.stubEndpoint(Endpoints.Trakt.SyncPlaybackEpisodes)
-            mockHandler.stubEndpoint(Endpoints.Trakt.SyncWatchedShows)
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowProgressWatched)
-            mockHandler.stubEndpoint(Endpoints.Trakt.UsersHiddenProgressWatched)
-
-            val nitroShows = FixtureLoader.load(Endpoints.Trakt.SyncProgressUpNextNitro.successFixture)
-            showFixtures(nitroShows).forEach { mockHandler.stubShow(it) }
         }
     }
 
@@ -341,7 +313,7 @@ internal class Scenarios(
         }
 
         fun stubEmptySearch() {
-            mockHandler.stubFixture(path = Endpoints.Trakt.Search.path, fixturePath = EMPTY_ARRAY_FIXTURE)
+            mockHandler.stubFixture(path = Endpoints.PublicCatalog.Search.path, fixturePath = EMPTY_ARRAY_FIXTURE)
         }
 
         fun stubSearchError(query: String) {
@@ -351,17 +323,24 @@ internal class Scenarios(
 
     inner class UpNext {
         /**
-         * Stubs `POST /sync/history` so the background launcher fired by `markEpisodeAsWatched`
-         * resolves cleanly when pushing the local UPLOAD-pending row to Trakt. UpNext list and
-         * count derive live from the local `watched_episodes` table, so no Trakt UpNext API stub
-         * is required after the click.
+         * Stubs the provider's watched-history upload endpoint (`POST /sync/history` on both
+         * Trakt and Simkl) so the background launcher fired by `markEpisodeAsWatched` resolves
+         * cleanly when pushing the local UPLOAD-pending row. UpNext list and count derive live
+         * from the local `watched_episodes` table, so no provider UpNext API stub is required
+         * after the click.
          *
          * The unused [showTraktId] parameter is kept so callers can keep the per-show signature
          * if/when the upload assertion grows to verify a specific show id.
          */
         @Suppress("UNUSED_PARAMETER")
-        fun stubProgressAfterPilotWatched(showTraktId: Long) {
-            mockHandler.stubEndpoint(Endpoints.Trakt.SyncHistory, method = HttpMethod.Post)
+        fun stubProgressAfterPilotWatched(
+            showTraktId: Long,
+            provider: AccountProvider = AccountProvider.TRAKT,
+        ) {
+            when (provider) {
+                AccountProvider.TRAKT -> mockHandler.stubEndpoint(Endpoints.Trakt.SyncHistory, method = HttpMethod.Post)
+                AccountProvider.SIMKL -> mockHandler.stubEndpoint(Endpoints.Simkl.SyncHistory, method = HttpMethod.Post)
+            }
         }
     }
 
@@ -386,6 +365,43 @@ internal class Scenarios(
         }
     }
 
+    inner class Library {
+        fun stubLibrarySyncEndpoints() {
+            mockHandler.stubEndpoint(Endpoints.Trakt.SyncLastActivities)
+            mockHandler.stubEndpoint(Endpoints.Trakt.SyncWatchedShows)
+            mockHandler.stubEndpoint(Endpoints.Trakt.UsersMeWatchlistShows)
+            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowDetails)
+            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowSeasons)
+            mockHandler.stubEndpoint(Endpoints.Tmdb.ShowDetails)
+            mockHandler.stubEndpoint(Endpoints.Tmdb.WatchProviders)
+
+            val watchedShows = FixtureLoader.load(Endpoints.Trakt.SyncWatchedShows.successFixture)
+            showFixtures(watchedShows).forEach { mockHandler.stubShow(it) }
+        }
+    }
+
+    inner class Watchlist {
+        fun stubWatchlistSyncEndpoints() {
+            mockHandler.stubEndpoint(Endpoints.Trakt.SyncProgressUpNextNitro)
+            mockHandler.stubEndpoint(Endpoints.Trakt.SyncPlaybackEpisodes)
+            mockHandler.stubEndpoint(Endpoints.Trakt.SyncWatchedShows)
+            mockHandler.stubEndpoint(Endpoints.Trakt.ShowProgressWatched)
+            mockHandler.stubEndpoint(Endpoints.Trakt.UsersHiddenProgressWatched)
+
+            val nitroShows = FixtureLoader.load(Endpoints.Trakt.SyncProgressUpNextNitro.successFixture)
+            showFixtures(nitroShows).forEach { mockHandler.stubShow(it) }
+        }
+    }
+
+    inner class Profile {
+        fun stubProfileSyncEndpoints(slug: String = TEST_PROFILE_SLUG) {
+            mockHandler.stubEndpoint(Endpoints.Trakt.UsersMe)
+            mockHandler.stubEndpoint(Endpoints.Trakt.userStats(slug))
+            mockHandler.stubEndpoint(Endpoints.Trakt.userLists(slug))
+            mockHandler.stubEndpoint(Endpoints.Trakt.UserListItems)
+        }
+    }
+
     inner class TraktLists {
         fun stubAddShowToList(listId: Long, slug: String = TEST_PROFILE_SLUG) {
             mockHandler.stubEndpoint(Endpoints.Trakt.addShowToList(slug, listId), method = HttpMethod.Post)
@@ -393,22 +409,6 @@ internal class Scenarios(
 
         fun stubCreateList(slug: String = TEST_PROFILE_SLUG) {
             mockHandler.stubEndpoint(Endpoints.Trakt.createList(slug), method = HttpMethod.Post)
-        }
-    }
-
-    /**
-     * Stubs the Trakt rating endpoints so the pending-ratings drain (`RatingsSyncInitializer`)
-     * and the show-details community-rating reconcile (`RatingsStore`) both resolve cleanly
-     * instead of logging a background-sync failure to [com.thomaskioko.tvmaniac.syncstate.api.SyncObserver].
-     * Never call alongside [Simkl.stubRatingsSync] in the same test — both providers share the
-     * `/sync/ratings*` path strings in [MockEngineHandler].
-     */
-    inner class Ratings {
-        fun stubRatingsSync() {
-            mockHandler.stubEndpoint(Endpoints.Trakt.SyncRatingsAdd, method = HttpMethod.Post)
-            mockHandler.stubEndpoint(Endpoints.Trakt.SyncRatingsRemove, method = HttpMethod.Post)
-            mockHandler.stubEndpoint(Endpoints.Trakt.SyncRatingsShows)
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowCommunityRating)
         }
     }
 

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
@@ -402,23 +402,40 @@ internal class Scenarios(
     }
 
     inner class Calendar {
-        fun stubWeek(weekStart: String = TEST_TODAY, days: Int = 7) {
-            mockHandler.stubEndpoint(Endpoints.Trakt.calendar(weekStart, days))
+        private fun endpoint(provider: AccountProvider, weekStart: String, days: Int): Endpoint.Exact =
+            when (provider) {
+                AccountProvider.TRAKT -> Endpoints.Trakt.calendar(weekStart, days)
+                AccountProvider.SIMKL -> Endpoints.Simkl.CalendarTvFeed
+            }
+
+        fun stubWeek(
+            provider: AccountProvider = AccountProvider.TRAKT,
+            weekStart: String = TEST_TODAY,
+            days: Int = 7,
+        ) {
+            mockHandler.stubEndpoint(endpoint(provider, weekStart, days))
         }
 
-        fun stubEmptyWeek(weekStart: String = TEST_TODAY, days: Int = 7) {
+        fun stubEmptyWeek(
+            provider: AccountProvider = AccountProvider.TRAKT,
+            weekStart: String = TEST_TODAY,
+            days: Int = 7,
+        ) {
+            val calendar = endpoint(provider, weekStart, days)
             mockHandler.stubFixture(
-                path = Endpoints.Trakt.calendar(weekStart, days).path,
+                path = calendar.path,
                 fixturePath = EMPTY_ARRAY_FIXTURE,
+                host = calendar.host,
             )
         }
 
         fun stubWeekError(
+            provider: AccountProvider = AccountProvider.TRAKT,
             weekStart: String = TEST_TODAY,
             days: Int = 7,
             status: Int = 404,
         ) {
-            mockHandler.stubEndpoint(Endpoints.Trakt.calendar(weekStart, days), HttpStatusCode.fromValue(status))
+            mockHandler.stubEndpoint(endpoint(provider, weekStart, days), HttpStatusCode.fromValue(status))
         }
     }
 

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
@@ -120,6 +120,16 @@ internal class Scenarios(
         stubActiveProvider(AccountProvider.TRAKT)
     }
 
+    /**
+     * Authenticated Trakt session with the Simkl-login and account-switch feature flags enabled:
+     * the precondition for exercising a Trakt-to-Simkl account switch.
+     */
+    fun stubAuthenticatedSyncWithAccountSwitch() {
+        flags.enableSimklLogin()
+        flags.enableAccountSwitch()
+        stubAuthenticatedSync()
+    }
+
     fun stubTmdb() {
         stubPublicCatalog()
     }
@@ -191,9 +201,7 @@ internal class Scenarios(
      * auth-state collector still observes real LOGGED_OUT to LOGGED_IN transition.
      */
     fun stubAuthenticatedSyncOnSignIn() {
-        graph.oAuthLauncher.setOnLaunch {
-            stubActiveProvider(AccountProvider.TRAKT)
-        }
+        stubOnSignIn(AccountProvider.TRAKT)
     }
 
     /**
@@ -201,8 +209,20 @@ internal class Scenarios(
      * authenticated Trakt session and flips fake auth state to LOGGED_IN.
      */
     fun stubProfileOnSignIn() {
+        stubOnSignIn(AccountProvider.TRAKT)
+    }
+
+    /**
+     * Registers the OAuth callback so the next sign-in click lazily wires the given provider's
+     * authenticated session, mirroring a live OAuth round-trip. Owns the only `graph.oAuthLauncher`
+     * access so journey tests never reach into the launcher directly.
+     */
+    fun stubOnSignIn(provider: AccountProvider) {
         graph.oAuthLauncher.setOnLaunch {
-            stubActiveProvider(AccountProvider.TRAKT)
+            when (provider) {
+                AccountProvider.TRAKT -> stubActiveProvider(AccountProvider.TRAKT)
+                AccountProvider.SIMKL -> stubAuthenticatedSimklProfile()
+            }
         }
     }
 
@@ -379,17 +399,6 @@ internal class Scenarios(
     }
 
     inner class UpNext {
-        /**
-         * Stubs the provider's watched-history upload endpoint (`POST /sync/history` on both
-         * Trakt and Simkl) so the background launcher fired by `markEpisodeAsWatched` resolves
-         * cleanly when pushing the local UPLOAD-pending row. UpNext list and count derive live
-         * from the local `watched_episodes` table, so no provider UpNext API stub is required
-         * after the click.
-         *
-         * The unused [showTraktId] parameter is kept so callers can keep the per-show signature
-         * if/when the upload assertion grows to verify a specific show id.
-         */
-        @Suppress("UNUSED_PARAMETER")
         fun stubProgressAfterPilotWatched(
             showTraktId: Long,
             provider: AccountProvider = AccountProvider.TRAKT,

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
@@ -54,20 +54,32 @@ internal class Scenarios(
     val profile: Profile = Profile()
 
     fun signInAndDismissRationale() {
-        auth.stubLoggedInUser()
+        stubLoggedInUser(AccountProvider.TRAKT)
         profile.stubProfileSyncEndpoints()
         rootRobot.dismissNotificationRationale()
     }
 
+    /**
+     * Provider-aware sign-in: flips the given account provider's fake auth state to LOGGED_IN,
+     * dispatching to each provider's existing mechanism ([Auth.stubLoggedInUser] for Trakt via
+     * `FakeTraktAuthRepository`, [Simkl.stubLoggedInUser] for Simkl via `AuthStateHolder`).
+     */
+    fun stubLoggedInUser(provider: AccountProvider) {
+        when (provider) {
+            AccountProvider.TRAKT -> auth.stubLoggedInUser()
+            AccountProvider.SIMKL -> simkl.stubLoggedInUser()
+        }
+    }
+
     fun stubAuthenticatedSimklProfile() {
-        simkl.stubLoggedInUser()
+        stubLoggedInUser(AccountProvider.SIMKL)
         simkl.stubProfileEndpoints()
         simkl.stubWatchedHistoryEndpoints()
         simkl.stubActivities()
     }
 
     fun stubAuthenticatedSimklStartWatching() {
-        simkl.stubLoggedInUser()
+        stubLoggedInUser(AccountProvider.SIMKL)
         simkl.stubProfileEndpoints()
         simkl.stubPlanToWatchWatchlist()
         simkl.stubActivities()
@@ -100,7 +112,7 @@ internal class Scenarios(
     fun stubActiveProvider(provider: AccountProvider) {
         when (provider) {
             AccountProvider.TRAKT -> {
-                auth.stubLoggedInUser()
+                stubLoggedInUser(AccountProvider.TRAKT)
                 val endpoints = Endpoints.Trakt.authenticatedEndpoints + listOf(
                     Endpoints.Trakt.userStats(TEST_PROFILE_SLUG),
                     Endpoints.Trakt.userLists(TEST_PROFILE_SLUG),
@@ -126,7 +138,7 @@ internal class Scenarios(
                 flags.enableSimklLogin()
                 Endpoints.Simkl.authenticatedEndpoints.forEach { mockHandler.stubEndpoint(it) }
                 // Sign in LAST (see TRAKT note) so login-triggered sync finds its stubs.
-                simkl.stubLoggedInUser()
+                stubLoggedInUser(AccountProvider.SIMKL)
             }
         }
     }
@@ -178,23 +190,31 @@ internal class Scenarios(
      * [stubActiveProvider], which would also reset the auth/refresh state this test is verifying.
      */
     fun stubTokenRefresh(
+        provider: AccountProvider = AccountProvider.TRAKT,
         accessToken: String = "refreshed-access",
         refreshToken: String = "refreshed-refresh",
         tokenLifetimeSeconds: Long = 3600,
     ) {
-        mockHandler.stubEndpoint(Endpoints.Trakt.UsersMe, HttpStatusCode.Unauthorized)
-        val refreshedAuthState = AuthState(
-            accessToken = accessToken,
-            refreshToken = refreshToken,
-            isAuthorized = true,
-            expiresAt = Clock.System.now() + tokenLifetimeSeconds.seconds,
-            tokenLifetimeSeconds = tokenLifetimeSeconds,
-        )
-        graph.traktAuthRepository.setRefreshOutcome(TokenRefreshResult.Success(refreshedAuthState))
-        mockHandler.stubEndpoint(Endpoints.Trakt.UsersMe)
-        mockHandler.stubEndpoint(Endpoints.Trakt.userStats(TEST_PROFILE_SLUG))
-        mockHandler.stubEndpoint(Endpoints.Trakt.userLists(TEST_PROFILE_SLUG))
-        mockHandler.stubEndpoint(Endpoints.Trakt.UserListItems)
+        when (provider) {
+            AccountProvider.TRAKT -> {
+                mockHandler.stubEndpoint(Endpoints.Trakt.UsersMe, HttpStatusCode.Unauthorized)
+                val refreshedAuthState = AuthState(
+                    accessToken = accessToken,
+                    refreshToken = refreshToken,
+                    isAuthorized = true,
+                    expiresAt = Clock.System.now() + tokenLifetimeSeconds.seconds,
+                    tokenLifetimeSeconds = tokenLifetimeSeconds,
+                )
+                graph.traktAuthRepository.setRefreshOutcome(TokenRefreshResult.Success(refreshedAuthState))
+                mockHandler.stubEndpoint(Endpoints.Trakt.UsersMe)
+                mockHandler.stubEndpoint(Endpoints.Trakt.userStats(TEST_PROFILE_SLUG))
+                mockHandler.stubEndpoint(Endpoints.Trakt.userLists(TEST_PROFILE_SLUG))
+                mockHandler.stubEndpoint(Endpoints.Trakt.UserListItems)
+            }
+            AccountProvider.SIMKL -> error(
+                "Simkl token refresh is not stubbed yet; add it when a Simkl refresh journey exists.",
+            )
+        }
     }
 
     inner class Auth {

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
@@ -7,6 +7,7 @@ import com.thomaskioko.tvmaniac.accountmanager.api.TokenRefreshResult
 import com.thomaskioko.tvmaniac.app.test.TestAppComponent
 import com.thomaskioko.tvmaniac.app.test.compose.robot.RootRobot
 import com.thomaskioko.tvmaniac.testing.integration.EMPTY_ARRAY_FIXTURE
+import com.thomaskioko.tvmaniac.testing.integration.Endpoint
 import com.thomaskioko.tvmaniac.testing.integration.Endpoints
 import com.thomaskioko.tvmaniac.testing.integration.MockEngineHandler
 import com.thomaskioko.tvmaniac.testing.integration.showFixtures
@@ -55,7 +56,7 @@ internal class Scenarios(
 
     fun signInAndDismissRationale() {
         stubLoggedInUser(AccountProvider.TRAKT)
-        profile.stubProfileSyncEndpoints()
+        stubProfileEndpoints(AccountProvider.TRAKT)
         rootRobot.dismissNotificationRationale()
     }
 
@@ -71,16 +72,23 @@ internal class Scenarios(
         }
     }
 
+    fun stubProfileEndpoints(provider: AccountProvider) {
+        when (provider) {
+            AccountProvider.TRAKT -> profile.stubProfileSyncEndpoints()
+            AccountProvider.SIMKL -> simkl.stubProfileEndpoints()
+        }
+    }
+
     fun stubAuthenticatedSimklProfile() {
         stubLoggedInUser(AccountProvider.SIMKL)
-        simkl.stubProfileEndpoints()
+        stubProfileEndpoints(AccountProvider.SIMKL)
         simkl.stubWatchedHistoryEndpoints()
         simkl.stubActivities()
     }
 
     fun stubAuthenticatedSimklStartWatching() {
         stubLoggedInUser(AccountProvider.SIMKL)
-        simkl.stubProfileEndpoints()
+        stubProfileEndpoints(AccountProvider.SIMKL)
         simkl.stubPlanToWatchWatchlist()
         simkl.stubActivities()
     }
@@ -143,8 +151,15 @@ internal class Scenarios(
         }
     }
 
-    fun stubUsersMeUnauthorized() {
-        mockHandler.stubEndpoint(Endpoints.Trakt.UsersMe, HttpStatusCode.Unauthorized)
+    /** Fake authentication endpoint used to detect a signed-in account, per provider. */
+    private fun userEndpoint(provider: AccountProvider): Endpoint.Exact =
+        when (provider) {
+            AccountProvider.TRAKT -> Endpoints.Trakt.UsersMe
+            AccountProvider.SIMKL -> Endpoints.Simkl.UsersSettings
+        }
+
+    fun stubUsersMeUnauthorized(provider: AccountProvider = AccountProvider.TRAKT) {
+        mockHandler.stubEndpoint(userEndpoint(provider), HttpStatusCode.Unauthorized)
     }
 
     /**
@@ -169,9 +184,9 @@ internal class Scenarios(
         }
     }
 
-    fun stubUnauthenticatedState() {
-        discover.stubBrowseGraph()
-        mockHandler.stubEndpoint(Endpoints.Trakt.UsersMe, HttpStatusCode.Unauthorized)
+    fun stubUnauthenticatedState(provider: AccountProvider = AccountProvider.TRAKT) {
+        stubPublicCatalog()
+        mockHandler.stubEndpoint(userEndpoint(provider), HttpStatusCode.Unauthorized)
     }
 
     /**

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
@@ -79,17 +79,39 @@ internal class Scenarios(
         }
     }
 
+    /**
+     * Provider-aware watched-library sync: Trakt's watched-shows/activities set, or Simkl's
+     * watched-history (`sync/all-items`).
+     */
+    fun stubLibrarySyncEndpoints(provider: AccountProvider) {
+        when (provider) {
+            AccountProvider.TRAKT -> library.stubLibrarySyncEndpoints()
+            AccountProvider.SIMKL -> simkl.stubWatchedHistoryEndpoints()
+        }
+    }
+
+    /**
+     * Provider-aware watchlist / up-next sync: Trakt's Continue Watching pipeline, or Simkl's
+     * plan-to-watch list.
+     */
+    fun stubWatchlistSyncEndpoints(provider: AccountProvider) {
+        when (provider) {
+            AccountProvider.TRAKT -> watchlist.stubWatchlistSyncEndpoints()
+            AccountProvider.SIMKL -> simkl.stubPlanToWatchWatchlist()
+        }
+    }
+
     fun stubAuthenticatedSimklProfile() {
         stubLoggedInUser(AccountProvider.SIMKL)
         stubProfileEndpoints(AccountProvider.SIMKL)
-        simkl.stubWatchedHistoryEndpoints()
+        stubLibrarySyncEndpoints(AccountProvider.SIMKL)
         simkl.stubActivities()
     }
 
     fun stubAuthenticatedSimklStartWatching() {
         stubLoggedInUser(AccountProvider.SIMKL)
         stubProfileEndpoints(AccountProvider.SIMKL)
-        simkl.stubPlanToWatchWatchlist()
+        stubWatchlistSyncEndpoints(AccountProvider.SIMKL)
         simkl.stubActivities()
     }
 

--- a/core/integration/infra/src/androidHostTest/kotlin/com/thomaskioko/tvmaniac/testing/integration/EndpointsCatalogTest.kt
+++ b/core/integration/infra/src/androidHostTest/kotlin/com/thomaskioko/tvmaniac/testing/integration/EndpointsCatalogTest.kt
@@ -2,6 +2,8 @@ package com.thomaskioko.tvmaniac.testing.integration
 
 import com.thomaskioko.tvmaniac.testing.integration.util.FixtureLoader
 import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.withClue
+import io.kotest.matchers.string.shouldNotBeEmpty
 import org.junit.Test
 
 /**
@@ -26,6 +28,15 @@ class EndpointsCatalogTest {
         Endpoints.all.forEach { endpoint ->
             shouldNotThrowAny(label(endpoint, endpoint.errorFixture)) {
                 FixtureLoader.load(endpoint.errorFixture)
+            }
+        }
+    }
+
+    @Test
+    fun `every endpoint declares a non-empty host`() {
+        Endpoints.all.forEach { endpoint ->
+            withClue(label(endpoint, endpoint.host)) {
+                endpoint.host.shouldNotBeEmpty()
             }
         }
     }

--- a/core/integration/infra/src/androidHostTest/kotlin/com/thomaskioko/tvmaniac/testing/integration/MockEngineHandlerTest.kt
+++ b/core/integration/infra/src/androidHostTest/kotlin/com/thomaskioko/tvmaniac/testing/integration/MockEngineHandlerTest.kt
@@ -69,6 +69,34 @@ internal class MockEngineHandlerTest {
     }
 
     @Test
+    fun `should isolate stubs by host when paths overlap`() = runTest {
+        val handler = MockEngineHandler()
+        handler.stubFixture(path = "/sync/ratings", fixturePath = "test/hello.json", host = "api.trakt.tv")
+        handler.stub(path = "/sync/ratings", body = "simkl response", host = "api.simkl.com")
+        val client = mockClient(handler)
+
+        val traktBody = client.get("https://api.trakt.tv/sync/ratings").bodyAsText()
+        val simklBody = client.get("https://api.simkl.com/sync/ratings").bodyAsText()
+
+        traktBody shouldContain "hello from the fixture"
+        simklBody shouldBe "simkl response"
+    }
+
+    @Test
+    fun `should isolate exact and pattern stubs by host on the same path`() = runTest {
+        val handler = MockEngineHandler()
+        handler.stub(path = "/users/me/stats", body = "trakt stats", host = "api.trakt.tv")
+        handler.stubPattern(pathRegex = "/users/[^/]+/stats", body = "simkl stats", host = "api.simkl.com")
+        val client = mockClient(handler)
+
+        val traktBody = client.get("https://api.trakt.tv/users/me/stats").bodyAsText()
+        val simklBody = client.get("https://api.simkl.com/users/me/stats").bodyAsText()
+
+        traktBody shouldBe "trakt stats"
+        simklBody shouldBe "simkl stats"
+    }
+
+    @Test
     fun `should clear stubs on reset`() = runTest {
         val handler = MockEngineHandler()
         handler.stubFixture(path = "/test", fixturePath = "test/hello.json")

--- a/core/integration/infra/src/androidMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/Endpoints.kt
+++ b/core/integration/infra/src/androidMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/Endpoints.kt
@@ -12,8 +12,9 @@ import io.ktor.http.isSuccess
 public const val EMPTY_ARRAY_FIXTURE: String = "empty_array.json"
 
 /**
- * A stubbable Trakt or TMDB endpoint. Carries both the happy-path and error fixture paths so
- * callers never type either string.
+ * A stubbable Trakt, Simkl, or TMDB endpoint. Carries both the happy-path and error fixture
+ * paths so callers never type either string, plus the production [host] the endpoint is served
+ * from so [MockEngineHandler] can route a stub to the right provider.
  *
  * Conventions:
  * - Each endpoint has a folder under `core/integration/infra/.../resources/fixtures/<vendor>/`
@@ -22,6 +23,12 @@ public const val EMPTY_ARRAY_FIXTURE: String = "empty_array.json"
  * - [errorFixture] is served when the test asks for an error status.
  */
 public sealed interface Endpoint {
+    /** Production host this endpoint is served from, e.g. `api.trakt.tv`. */
+    public val host: String
+
+    /** HTTP method this endpoint is served over. Defaults to `GET`. */
+    public val method: HttpMethod get() = HttpMethod.Get
+
     /** Fixture file served for success outcomes. */
     public val successFixture: String
 
@@ -51,7 +58,7 @@ public fun MockEngineHandler.stubEndpoint(
     method: HttpMethod = HttpMethod.Get,
 ) {
     val fixture = if (status.isSuccess()) endpoint.successFixture else endpoint.errorFixture
-    stubFixture(method, endpoint.path, fixture, status)
+    stubFixture(method, endpoint.path, fixture, status, endpoint.host)
 }
 
 /**
@@ -64,7 +71,23 @@ public fun MockEngineHandler.stubEndpoint(
     method: HttpMethod = HttpMethod.Get,
 ) {
     val fixture = if (status.isSuccess()) endpoint.successFixture else endpoint.errorFixture
-    stubPatternFixture(method, endpoint.pathRegex, fixture, status)
+    stubPatternFixture(method, endpoint.pathRegex, fixture, status, endpoint.host)
+}
+
+/**
+ * Stubs [endpoint] with the fixture for [status] (defaults to success), dispatching to the
+ * [Endpoint.Exact] or [Endpoint.Pattern] overload and reading the HTTP method off the endpoint
+ * itself. Lets catalog-driven callers (e.g. `Scenarios.stubActiveProvider`) stub a heterogeneous
+ * list of endpoints without switching on their matcher kind.
+ */
+public fun MockEngineHandler.stubEndpoint(
+    endpoint: Endpoint,
+    status: HttpStatusCode = HttpStatusCode.OK,
+) {
+    when (endpoint) {
+        is Endpoint.Exact -> stubEndpoint(endpoint, status, endpoint.method)
+        is Endpoint.Pattern -> stubEndpoint(endpoint, status, endpoint.method)
+    }
 }
 
 /**
@@ -72,147 +95,84 @@ public fun MockEngineHandler.stubEndpoint(
  * callers go through the catalog factories instead of constructing endpoints ad-hoc.
  */
 internal data class ExactEndpoint(
+    override val host: String,
     override val path: String,
     override val successFixture: String,
     override val errorFixture: String,
+    override val method: HttpMethod = HttpMethod.Get,
 ) : Endpoint.Exact
 
 /**
- * Catalog of every Trakt and TMDB endpoint the integration test suite stubs. Adding a new
- * endpoint: drop a folder under `fixtures/` containing `success.json` and `error.json`, then
+ * Catalog of every Trakt, Simkl, and TMDB endpoint the integration test suite stubs. Adding a
+ * new endpoint: drop a folder under `fixtures/` containing `success.json` and `error.json`, then
  * add a constant or factory here.
  */
 public object Endpoints {
 
     /** Trakt API endpoints. */
     public object Trakt {
-        public object ShowsTrending : Endpoint.Exact {
-            override val path: String = "/shows/trending"
-            override val successFixture: String = "trakt/shows/trending/success.json"
-            override val errorFixture: String = "trakt/shows/trending/error.json"
-        }
-
-        public object ShowsPopular : Endpoint.Exact {
-            override val path: String = "/shows/popular"
-            override val successFixture: String = "trakt/shows/popular/success.json"
-            override val errorFixture: String = "trakt/shows/popular/error.json"
-        }
-
-        public object ShowsFavoritedWeekly : Endpoint.Exact {
-            override val path: String = "/shows/favorited/weekly"
-            override val successFixture: String = "trakt/shows/favorite/success.json"
-            override val errorFixture: String = "trakt/shows/favorite/error.json"
-        }
-
-        public object GenresShows : Endpoint.Exact {
-            override val path: String = "/genres/shows"
-            override val successFixture: String = "trakt/genres/success.json"
-            override val errorFixture: String = "trakt/genres/error.json"
-        }
+        private const val HOST: String = "api.trakt.tv"
 
         public object UsersMe : Endpoint.Exact {
+            override val host: String = HOST
             override val path: String = "/users/me"
             override val successFixture: String = "trakt/users/me/success.json"
             override val errorFixture: String = "trakt/users/me/error.json"
         }
 
         public object UsersMeWatchlistShows : Endpoint.Exact {
+            override val host: String = HOST
             override val path: String = "/users/me/watchlist/shows"
             override val successFixture: String = "trakt/users/watchlist/success.json"
             override val errorFixture: String = "trakt/users/watchlist/error.json"
         }
 
         public object SyncLastActivities : Endpoint.Exact {
+            override val host: String = HOST
             override val path: String = "/sync/last_activities"
             override val successFixture: String = "trakt/sync/success.json"
             override val errorFixture: String = "trakt/sync/error.json"
         }
 
+        /** `POST /sync/history` — uploads a watched episode/show entry. */
         public object SyncHistory : Endpoint.Exact {
+            override val host: String = HOST
             override val path: String = "/sync/history"
+            override val method: HttpMethod = HttpMethod.Post
             override val successFixture: String = "trakt/sync/history/success.json"
             override val errorFixture: String = "trakt/sync/history/error.json"
         }
 
         public object SyncWatchedShows : Endpoint.Exact {
+            override val host: String = HOST
             override val path: String = "/sync/watched/shows"
             override val successFixture: String = "trakt/sync/watched/shows/success.json"
             override val errorFixture: String = "trakt/sync/watched/shows/error.json"
         }
 
         public object SyncProgressUpNextNitro : Endpoint.Exact {
+            override val host: String = HOST
             override val path: String = "/sync/progress/up_next_nitro"
             override val successFixture: String = "trakt/sync/progress/up_next_nitro/success.json"
             override val errorFixture: String = "trakt/sync/progress/up_next_nitro/error.json"
         }
 
         public object SyncPlaybackEpisodes : Endpoint.Exact {
+            override val host: String = HOST
             override val path: String = "/sync/playback/episodes"
             override val successFixture: String = "trakt/sync/playback/episodes/success.json"
             override val errorFixture: String = "trakt/sync/playback/episodes/error.json"
         }
 
         public object UsersHiddenProgressWatched : Endpoint.Exact {
+            override val host: String = HOST
             override val path: String = "/users/hidden/progress_watched"
             override val successFixture: String = "trakt/users/hidden/progress_watched/success.json"
             override val errorFixture: String = "trakt/users/hidden/progress_watched/error.json"
         }
 
-        public object SearchByTmdb : Endpoint.Pattern {
-            override val pathRegex: String = "/search/tmdb/\\d+"
-            override val successFixture: String = "trakt/search/success.json"
-            override val errorFixture: String = "trakt/search/error.json"
-        }
-
-        public object Search : Endpoint.Exact {
-            override val path: String = "/search"
-            override val successFixture: String = "trakt/search/success.json"
-            override val errorFixture: String = "trakt/search/error.json"
-        }
-
-        public object ShowDetails : Endpoint.Pattern {
-            override val pathRegex: String = "/shows/\\d+"
-            override val successFixture: String = "trakt/shows/details/success.json"
-            override val errorFixture: String = "trakt/shows/details/error.json"
-        }
-
-        public object ShowSeasons : Endpoint.Pattern {
-            override val pathRegex: String = "/shows/\\d+/seasons"
-            override val successFixture: String = "trakt/seasons/success.json"
-            override val errorFixture: String = "trakt/seasons/error.json"
-        }
-
-        public object ShowSeasonEpisodesS1 : Endpoint.Pattern {
-            override val pathRegex: String = "/shows/\\d+/seasons/1"
-            override val successFixture: String = "trakt/episodes/season1/success.json"
-            override val errorFixture: String = "trakt/episodes/season1/error.json"
-        }
-
-        public object ShowSeasonEpisodesS2 : Endpoint.Pattern {
-            override val pathRegex: String = "/shows/\\d+/seasons/2"
-            override val successFixture: String = "trakt/episodes/season2/success.json"
-            override val errorFixture: String = "trakt/episodes/season2/error.json"
-        }
-
-        public object ShowPeople : Endpoint.Pattern {
-            override val pathRegex: String = "/shows/\\d+/people"
-            override val successFixture: String = "trakt/shows/people/success.json"
-            override val errorFixture: String = "trakt/shows/people/error.json"
-        }
-
-        public object ShowRelated : Endpoint.Pattern {
-            override val pathRegex: String = "/shows/\\d+/related"
-            override val successFixture: String = "trakt/shows/related/success.json"
-            override val errorFixture: String = "trakt/shows/related/error.json"
-        }
-
-        public object ShowVideos : Endpoint.Pattern {
-            override val pathRegex: String = "/shows/\\d+/videos"
-            override val successFixture: String = "trakt/shows/videos/success.json"
-            override val errorFixture: String = "trakt/shows/videos/error.json"
-        }
-
         public object ShowProgressWatched : Endpoint.Pattern {
+            override val host: String = HOST
             override val pathRegex: String = "/shows/\\d+/progress/watched"
             override val successFixture: String = "trakt/shows/progress/watched/success.json"
             override val errorFixture: String = "trakt/shows/progress/watched/error.json"
@@ -220,6 +180,7 @@ public object Endpoints {
 
         /** `GET /shows/{traktId}/ratings` — community rating, fetched when Show Details opens. */
         public object ShowCommunityRating : Endpoint.Pattern {
+            override val host: String = HOST
             override val pathRegex: String = "/shows/\\d+/ratings"
             override val successFixture: String = "trakt/shows/ratings/success.json"
             override val errorFixture: String = "trakt/shows/ratings/error.json"
@@ -227,20 +188,25 @@ public object Endpoints {
 
         /** `POST /sync/ratings` — adds a show, season, or episode rating. */
         public object SyncRatingsAdd : Endpoint.Exact {
+            override val host: String = HOST
             override val path: String = "/sync/ratings"
+            override val method: HttpMethod = HttpMethod.Post
             override val successFixture: String = "trakt/sync/ratings/success.json"
             override val errorFixture: String = "trakt/sync/ratings/error.json"
         }
 
         /** `POST /sync/ratings/remove` — removes a show, season, or episode rating. */
         public object SyncRatingsRemove : Endpoint.Exact {
+            override val host: String = HOST
             override val path: String = "/sync/ratings/remove"
+            override val method: HttpMethod = HttpMethod.Post
             override val successFixture: String = "trakt/sync/ratings/remove/success.json"
             override val errorFixture: String = "trakt/sync/ratings/remove/error.json"
         }
 
         /** `GET /sync/ratings/shows` — the user's rated shows, used to reconcile the local user rating. */
         public object SyncRatingsShows : Endpoint.Exact {
+            override val host: String = HOST
             override val path: String = "/sync/ratings/shows"
             override val successFixture: String = "trakt/sync/ratings/shows/success.json"
             override val errorFixture: String = "trakt/sync/ratings/shows/error.json"
@@ -248,6 +214,7 @@ public object Endpoints {
 
         /** `/users/{slug}/stats` — slug-bound. */
         public fun userStats(slug: String): Endpoint.Exact = ExactEndpoint(
+            host = HOST,
             path = "/users/$slug/stats",
             successFixture = "trakt/users/stats/success.json",
             errorFixture = "trakt/users/stats/error.json",
@@ -255,6 +222,7 @@ public object Endpoints {
 
         /** `/users/{slug}/lists` — slug-bound. */
         public fun userLists(slug: String): Endpoint.Exact = ExactEndpoint(
+            host = HOST,
             path = "/users/$slug/lists",
             successFixture = "trakt/users/lists/success.json",
             errorFixture = "trakt/users/lists/error.json",
@@ -262,6 +230,7 @@ public object Endpoints {
 
         /** `POST /users/{slug}/lists` — slug-bound. Creates a new personal list. */
         public fun createList(slug: String): Endpoint.Exact = ExactEndpoint(
+            host = HOST,
             path = "/users/$slug/lists",
             successFixture = "trakt/users/lists/create/success.json",
             errorFixture = "trakt/users/lists/create/error.json",
@@ -269,6 +238,7 @@ public object Endpoints {
 
         /** `GET /users/{slug}/lists/{listId}/items` — slug- and list-bound. Returns items in a list. */
         public object UserListItems : Endpoint.Pattern {
+            override val host: String = HOST
             override val pathRegex: String = "/users/[^/]+/lists/\\d+/items"
             override val successFixture: String = "trakt/users/lists/items/success.json"
             override val errorFixture: String = "trakt/users/lists/items/error.json"
@@ -276,6 +246,7 @@ public object Endpoints {
 
         /** `POST /users/{slug}/lists/{listId}/items` — slug- and list-bound. Adds a show to a list. */
         public fun addShowToList(slug: String, listId: Long): Endpoint.Exact = ExactEndpoint(
+            host = HOST,
             path = "/users/$slug/lists/$listId/items",
             successFixture = "trakt/users/lists/items/add/success.json",
             errorFixture = "trakt/users/lists/items/add/error.json",
@@ -283,6 +254,7 @@ public object Endpoints {
 
         /** `POST /users/{slug}/lists/{listId}/items/remove` — slug- and list-bound. Removes a show from a list. */
         public fun removeShowFromList(slug: String, listId: Long): Endpoint.Exact = ExactEndpoint(
+            host = HOST,
             path = "/users/$slug/lists/$listId/items/remove",
             successFixture = "trakt/users/lists/items/remove/success.json",
             errorFixture = "trakt/users/lists/items/remove/error.json",
@@ -290,6 +262,7 @@ public object Endpoints {
 
         /** `/calendars/my/shows/{weekStart}/{days}` — date-bound. */
         public fun calendar(weekStart: String, days: Int): Endpoint.Exact = ExactEndpoint(
+            host = HOST,
             path = "/calendars/my/shows/$weekStart/$days",
             successFixture = "trakt/calendar/success.json",
             errorFixture = "trakt/calendar/error.json",
@@ -301,35 +274,187 @@ public object Endpoints {
          * `next_episode`). Used to verify UpNext refresh after `markEpisodeAsWatched`.
          */
         public fun showProgressAfterPilotWatched(traktId: Long): Endpoint.Exact = ExactEndpoint(
+            host = HOST,
             path = "/shows/$traktId/progress/watched",
             successFixture = "trakt/shows/progress/refreshed/success.json",
             errorFixture = "trakt/shows/progress/refreshed/error.json",
         )
+
+        /**
+         * Endpoints stubbed by `Scenarios.stubActiveProvider` for an authenticated Trakt session.
+         * Add a cross-provider feature's endpoints here, not a new stub helper. Slug- and
+         * date-bound factories (`userStats`, `userLists`, `calendar`) aren't listed here since
+         * they need test-constant arguments; `Scenarios.stubActiveProvider` binds those and adds
+         * them to this list before stubbing.
+         */
+        public val authenticatedEndpoints: List<Endpoint> = listOf(
+            UsersMe,
+            UsersMeWatchlistShows,
+            SyncLastActivities,
+            SyncHistory,
+            SyncWatchedShows,
+            SyncProgressUpNextNitro,
+            SyncPlaybackEpisodes,
+            UsersHiddenProgressWatched,
+            ShowProgressWatched,
+            ShowCommunityRating,
+            SyncRatingsAdd,
+            SyncRatingsRemove,
+            SyncRatingsShows,
+            UserListItems,
+        )
+    }
+
+    /**
+     * Public, no-auth catalog and per-show detail endpoints shared by every account provider
+     * (and by no account at all). These are served from Trakt's public API but aren't
+     * Trakt-account-specific, so they live outside [Trakt] to keep that group limited to
+     * authenticated-session endpoints.
+     */
+    public object PublicCatalog {
+        private const val HOST: String = "api.trakt.tv"
+
+        public object ShowsTrending : Endpoint.Exact {
+            override val host: String = HOST
+            override val path: String = "/shows/trending"
+            override val successFixture: String = "trakt/shows/trending/success.json"
+            override val errorFixture: String = "trakt/shows/trending/error.json"
+        }
+
+        public object ShowsPopular : Endpoint.Exact {
+            override val host: String = HOST
+            override val path: String = "/shows/popular"
+            override val successFixture: String = "trakt/shows/popular/success.json"
+            override val errorFixture: String = "trakt/shows/popular/error.json"
+        }
+
+        public object ShowsFavoritedWeekly : Endpoint.Exact {
+            override val host: String = HOST
+            override val path: String = "/shows/favorited/weekly"
+            override val successFixture: String = "trakt/shows/favorite/success.json"
+            override val errorFixture: String = "trakt/shows/favorite/error.json"
+        }
+
+        public object GenresShows : Endpoint.Exact {
+            override val host: String = HOST
+            override val path: String = "/genres/shows"
+            override val successFixture: String = "trakt/genres/success.json"
+            override val errorFixture: String = "trakt/genres/error.json"
+        }
+
+        public object SearchByTmdb : Endpoint.Pattern {
+            override val host: String = HOST
+            override val pathRegex: String = "/search/tmdb/\\d+"
+            override val successFixture: String = "trakt/search/success.json"
+            override val errorFixture: String = "trakt/search/error.json"
+        }
+
+        public object Search : Endpoint.Exact {
+            override val host: String = HOST
+            override val path: String = "/search"
+            override val successFixture: String = "trakt/search/success.json"
+            override val errorFixture: String = "trakt/search/error.json"
+        }
+
+        public object ShowDetails : Endpoint.Pattern {
+            override val host: String = HOST
+            override val pathRegex: String = "/shows/\\d+"
+            override val successFixture: String = "trakt/shows/details/success.json"
+            override val errorFixture: String = "trakt/shows/details/error.json"
+        }
+
+        public object ShowSeasons : Endpoint.Pattern {
+            override val host: String = HOST
+            override val pathRegex: String = "/shows/\\d+/seasons"
+            override val successFixture: String = "trakt/seasons/success.json"
+            override val errorFixture: String = "trakt/seasons/error.json"
+        }
+
+        public object ShowSeasonEpisodesS1 : Endpoint.Pattern {
+            override val host: String = HOST
+            override val pathRegex: String = "/shows/\\d+/seasons/1"
+            override val successFixture: String = "trakt/episodes/season1/success.json"
+            override val errorFixture: String = "trakt/episodes/season1/error.json"
+        }
+
+        public object ShowSeasonEpisodesS2 : Endpoint.Pattern {
+            override val host: String = HOST
+            override val pathRegex: String = "/shows/\\d+/seasons/2"
+            override val successFixture: String = "trakt/episodes/season2/success.json"
+            override val errorFixture: String = "trakt/episodes/season2/error.json"
+        }
+
+        public object ShowPeople : Endpoint.Pattern {
+            override val host: String = HOST
+            override val pathRegex: String = "/shows/\\d+/people"
+            override val successFixture: String = "trakt/shows/people/success.json"
+            override val errorFixture: String = "trakt/shows/people/error.json"
+        }
+
+        public object ShowRelated : Endpoint.Pattern {
+            override val host: String = HOST
+            override val pathRegex: String = "/shows/\\d+/related"
+            override val successFixture: String = "trakt/shows/related/success.json"
+            override val errorFixture: String = "trakt/shows/related/error.json"
+        }
+
+        public object ShowVideos : Endpoint.Pattern {
+            override val host: String = HOST
+            override val pathRegex: String = "/shows/\\d+/videos"
+            override val successFixture: String = "trakt/shows/videos/success.json"
+            override val errorFixture: String = "trakt/shows/videos/error.json"
+        }
     }
 
     public object Simkl {
+        private const val HOST: String = "api.simkl.com"
+
+        /** Host backing the Simkl calendar feed, served separately from the main Simkl API. */
+        private const val DATA_HOST: String = "data.simkl.in"
+
+        /** `POST /users/settings` — Simkl serves this read endpoint over POST. */
         public object UsersSettings : Endpoint.Exact {
+            override val host: String = HOST
             override val path: String = "/users/settings"
+            override val method: HttpMethod = HttpMethod.Post
             override val successFixture: String = "simkl/users/settings/success.json"
             override val errorFixture: String = "simkl/users/settings/error.json"
         }
 
+        /** `POST /users/{userId}/stats` — Simkl serves this read endpoint over POST. */
         public object UsersStats : Endpoint.Pattern {
+            override val host: String = HOST
             override val pathRegex: String = "/users/[^/]+/stats"
+            override val method: HttpMethod = HttpMethod.Post
             override val successFixture: String = "simkl/users/stats/success.json"
             override val errorFixture: String = "simkl/users/stats/error.json"
         }
 
         public object SyncAllItems : Endpoint.Exact {
+            override val host: String = HOST
             override val path: String = "/sync/all-items/shows"
             override val successFixture: String = "simkl/sync/all-items/success.json"
             override val errorFixture: String = "simkl/sync/all-items/error.json"
         }
 
         public object SyncActivities : Endpoint.Exact {
+            override val host: String = HOST
             override val path: String = "/sync/activities"
             override val successFixture: String = "simkl/sync/activities/success.json"
             override val errorFixture: String = "simkl/sync/activities/error.json"
+        }
+
+        /**
+         * `POST /sync/history` — uploads a watched episode/show entry to Simkl. Mirrors
+         * [Trakt.SyncHistory]; same path, different host, so registering both providers' stubs in
+         * the same test is safe.
+         */
+        public object SyncHistory : Endpoint.Exact {
+            override val host: String = HOST
+            override val path: String = "/sync/history"
+            override val method: HttpMethod = HttpMethod.Post
+            override val successFixture: String = "simkl/sync/history/success.json"
+            override val errorFixture: String = "simkl/sync/history/error.json"
         }
 
         /**
@@ -337,6 +462,7 @@ public object Endpoints {
          * `body.ratings.simkl`. Shares its path shape with no other endpoint in this catalog.
          */
         public object ShowSummary : Endpoint.Pattern {
+            override val host: String = HOST
             override val pathRegex: String = "/tv/\\d+"
             override val successFixture: String = "simkl/tv/success.json"
             override val errorFixture: String = "simkl/tv/error.json"
@@ -344,76 +470,108 @@ public object Endpoints {
 
         /**
          * `POST /sync/ratings` — adds a show rating. Same path as [Trakt.SyncRatingsAdd] but
-         * served by a distinct [io.ktor.client.engine.mock.MockEngine] bound to `@SimklApi`; never
-         * stub both providers' rating endpoints in the same test (`MockEngineHandler` matches by
-         * path only, not host).
+         * served from a different host; [MockEngineHandler] matches by host, method, and path,
+         * so registering both providers' rating endpoints in the same test is safe.
          */
         public object SyncRatingsAdd : Endpoint.Exact {
+            override val host: String = HOST
             override val path: String = "/sync/ratings"
+            override val method: HttpMethod = HttpMethod.Post
             override val successFixture: String = "simkl/sync/ratings/success.json"
             override val errorFixture: String = "simkl/sync/ratings/error.json"
         }
 
         /** `POST /sync/ratings/remove` — removes a show rating. */
         public object SyncRatingsRemove : Endpoint.Exact {
+            override val host: String = HOST
             override val path: String = "/sync/ratings/remove"
+            override val method: HttpMethod = HttpMethod.Post
             override val successFixture: String = "simkl/sync/ratings/remove/success.json"
             override val errorFixture: String = "simkl/sync/ratings/remove/error.json"
         }
 
         /** `GET /sync/ratings/shows` — the user's rated shows, used to reconcile the local user rating. */
         public object SyncRatingsShows : Endpoint.Exact {
+            override val host: String = HOST
             override val path: String = "/sync/ratings/shows"
             override val successFixture: String = "simkl/sync/ratings/shows/success.json"
             override val errorFixture: String = "simkl/sync/ratings/shows/error.json"
         }
 
+        /** `GET /calendar/tv.json` — served from [DATA_HOST], not [HOST]. */
         public object CalendarTvFeed : Endpoint.Exact {
+            override val host: String = DATA_HOST
             override val path: String = "/calendar/tv.json"
             override val successFixture: String = "simkl/calendar/tv.json"
             override val errorFixture: String = EMPTY_ARRAY_FIXTURE
         }
+
+        /**
+         * Endpoints stubbed by `Scenarios.stubActiveProvider` for an authenticated Simkl session.
+         * Add a cross-provider feature's endpoints here, not a new stub helper.
+         */
+        public val authenticatedEndpoints: List<Endpoint> = listOf(
+            UsersSettings,
+            UsersStats,
+            SyncAllItems,
+            SyncActivities,
+            SyncHistory,
+            ShowSummary,
+            CalendarTvFeed,
+            SyncRatingsAdd,
+            SyncRatingsRemove,
+            SyncRatingsShows,
+        )
     }
 
     /** TMDB API endpoints (paths begin with `/3/`). */
     public object Tmdb {
+        private const val HOST: String = "api.themoviedb.org"
+
         public object DiscoverTv : Endpoint.Exact {
+            override val host: String = HOST
             override val path: String = "/3/discover/tv"
             override val successFixture: String = "tmdb/discover/success.json"
             override val errorFixture: String = "tmdb/discover/error.json"
         }
 
         public object ShowDetails : Endpoint.Pattern {
+            override val host: String = HOST
             override val pathRegex: String = "/3/tv/\\d+"
             override val successFixture: String = "tmdb/details/success.json"
             override val errorFixture: String = "tmdb/details/error.json"
         }
 
         public object Credits : Endpoint.Pattern {
+            override val host: String = HOST
             override val pathRegex: String = "/3/tv/\\d+/credits"
             override val successFixture: String = "tmdb/credits/success.json"
             override val errorFixture: String = "tmdb/credits/error.json"
         }
 
         public object SeasonDetails : Endpoint.Pattern {
+            override val host: String = HOST
             override val pathRegex: String = "/3/tv/\\d+/season/\\d+"
             override val successFixture: String = "tmdb/season_details/empty/success.json"
             override val errorFixture: String = "tmdb/season_details/empty/error.json"
         }
 
         public object SeasonDetailsS1 : Endpoint.Pattern {
+            override val host: String = HOST
             override val pathRegex: String = "/3/tv/\\d+/season/1"
             override val successFixture: String = "tmdb/season_details/season1/success.json"
             override val errorFixture: String = "tmdb/season_details/season1/error.json"
         }
 
         public object SeasonDetailsS2 : Endpoint.Pattern {
+            override val host: String = HOST
             override val pathRegex: String = "/3/tv/\\d+/season/2"
             override val successFixture: String = "tmdb/season_details/season2/success.json"
             override val errorFixture: String = "tmdb/season_details/season2/error.json"
         }
 
         public object WatchProviders : Endpoint.Pattern {
+            override val host: String = HOST
             override val pathRegex: String = "/3/tv/\\d+/watch/providers"
             override val successFixture: String = "tmdb/watchproviders/success.json"
             override val errorFixture: String = "tmdb/watchproviders/error.json"
@@ -426,24 +584,24 @@ public object Endpoints {
      * the classpath.
      */
     public val all: List<Endpoint> = listOf(
-        Trakt.ShowsTrending,
-        Trakt.ShowsPopular,
-        Trakt.ShowsFavoritedWeekly,
-        Trakt.GenresShows,
+        PublicCatalog.ShowsTrending,
+        PublicCatalog.ShowsPopular,
+        PublicCatalog.ShowsFavoritedWeekly,
+        PublicCatalog.GenresShows,
         Trakt.UsersMe,
         Trakt.UsersMeWatchlistShows,
         Trakt.SyncLastActivities,
         Trakt.SyncHistory,
         Trakt.SyncWatchedShows,
-        Trakt.SearchByTmdb,
-        Trakt.Search,
-        Trakt.ShowDetails,
-        Trakt.ShowSeasons,
-        Trakt.ShowSeasonEpisodesS1,
-        Trakt.ShowSeasonEpisodesS2,
-        Trakt.ShowPeople,
-        Trakt.ShowRelated,
-        Trakt.ShowVideos,
+        PublicCatalog.SearchByTmdb,
+        PublicCatalog.Search,
+        PublicCatalog.ShowDetails,
+        PublicCatalog.ShowSeasons,
+        PublicCatalog.ShowSeasonEpisodesS1,
+        PublicCatalog.ShowSeasonEpisodesS2,
+        PublicCatalog.ShowPeople,
+        PublicCatalog.ShowRelated,
+        PublicCatalog.ShowVideos,
         Trakt.ShowProgressWatched,
         Trakt.ShowCommunityRating,
         Trakt.SyncRatingsAdd,
@@ -458,6 +616,7 @@ public object Endpoints {
         Simkl.UsersStats,
         Simkl.SyncAllItems,
         Simkl.SyncActivities,
+        Simkl.SyncHistory,
         Simkl.ShowSummary,
         Simkl.SyncRatingsAdd,
         Simkl.SyncRatingsRemove,

--- a/core/integration/infra/src/androidMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/MockEngineHandler.kt
+++ b/core/integration/infra/src/androidMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/MockEngineHandler.kt
@@ -23,9 +23,10 @@ public class MockEngineHandler {
     public fun stub(
         method: HttpMethod = HttpMethod.Get,
         path: String,
+        host: String? = null,
         response: StubResponder,
     ) {
-        stubs += Stub.Single(method, path, response)
+        stubs += Stub.Single(method, path, host, response)
     }
 
     public fun stub(
@@ -33,8 +34,9 @@ public class MockEngineHandler {
         path: String,
         body: String,
         status: HttpStatusCode = HttpStatusCode.OK,
+        host: String? = null,
     ) {
-        stubs += Stub.Single(method, path) { _ ->
+        stubs += Stub.Single(method, path, host) { _ ->
             respond(
                 content = body,
                 status = status,
@@ -48,8 +50,9 @@ public class MockEngineHandler {
         path: String,
         fixturePath: String,
         status: HttpStatusCode = HttpStatusCode.OK,
+        host: String? = null,
     ) {
-        stubs += Stub.Single(method, path) { _ ->
+        stubs += Stub.Single(method, path, host) { _ ->
             respond(
                 content = FixtureLoader.load(fixturePath),
                 status = status,
@@ -61,26 +64,29 @@ public class MockEngineHandler {
     public fun stubSequence(
         method: HttpMethod = HttpMethod.Get,
         path: String,
+        host: String? = null,
         block: SequenceBuilder.() -> Unit,
     ) {
         val builder = SequenceBuilder().apply(block)
-        stubs += Stub.Sequence(method, path, builder.responses)
+        stubs += Stub.Sequence(method, path, host, builder.responses)
     }
 
     public fun stubByQuery(
         method: HttpMethod = HttpMethod.Get,
         path: String,
+        host: String? = null,
         fixtureSelector: (Parameters) -> String?,
     ) {
-        stubs += Stub.ByQuery(method, path, fixtureSelector)
+        stubs += Stub.ByQuery(method, path, host, fixtureSelector)
     }
 
     public fun stubPattern(
         method: HttpMethod = HttpMethod.Get,
         pathRegex: String,
+        host: String? = null,
         response: StubResponder,
     ) {
-        stubs += Stub.PathPattern(method, pathRegex.toRegex(), response)
+        stubs += Stub.PathPattern(method, pathRegex.toRegex(), host, response)
     }
 
     public fun stubPattern(
@@ -88,8 +94,9 @@ public class MockEngineHandler {
         pathRegex: String,
         body: String,
         status: HttpStatusCode = HttpStatusCode.OK,
+        host: String? = null,
     ) {
-        stubs += Stub.PathPattern(method, pathRegex.toRegex()) { _ ->
+        stubs += Stub.PathPattern(method, pathRegex.toRegex(), host) { _ ->
             respond(
                 content = body,
                 status = status,
@@ -103,8 +110,9 @@ public class MockEngineHandler {
         pathRegex: String,
         fixturePath: String,
         status: HttpStatusCode = HttpStatusCode.OK,
+        host: String? = null,
     ) {
-        stubs += Stub.PathPattern(method, pathRegex.toRegex()) { _ ->
+        stubs += Stub.PathPattern(method, pathRegex.toRegex(), host) { _ ->
             respond(
                 content = FixtureLoader.load(fixturePath),
                 status = status,
@@ -123,9 +131,12 @@ public class MockEngineHandler {
         printLogs: Boolean = false,
     ): HttpResponseData {
         val requestPath = request.url.encodedPath
+        val requestHost = request.url.host
 
         stubs.asReversed().forEach { stub ->
-            if (stub.method != request.method || !stub.matches(requestPath)) return@forEach
+            if (stub.method != request.method || !stub.matchesPath(requestPath) || !stub.matchesHost(requestHost)) {
+                return@forEach
+            }
             when (stub) {
                 is Stub.Single -> return stub.response(scope, request)
                 is Stub.Sequence -> {
@@ -206,36 +217,43 @@ public class MockEngineHandler {
     private sealed interface Stub {
         val method: HttpMethod
         val path: String
+        val host: String?
 
-        fun matches(requestPath: String): Boolean = path == requestPath
+        fun matchesPath(requestPath: String): Boolean = path == requestPath
 
-        fun describe(): String = "${method.value} $path (${this::class.simpleName})"
+        fun matchesHost(requestHost: String): Boolean = host == null || host == requestHost
+
+        fun describe(): String = "${method.value} ${host ?: "*"}$path (${this::class.simpleName})"
 
         data class Single(
             override val method: HttpMethod,
             override val path: String,
+            override val host: String?,
             val response: StubResponder,
         ) : Stub
 
         data class Sequence(
             override val method: HttpMethod,
             override val path: String,
+            override val host: String?,
             val responses: MutableList<StubResponder>,
         ) : Stub
 
         data class ByQuery(
             override val method: HttpMethod,
             override val path: String,
+            override val host: String?,
             val fixtureSelector: (Parameters) -> String?,
         ) : Stub
 
         data class PathPattern(
             override val method: HttpMethod,
             val pathRegex: Regex,
+            override val host: String?,
             val response: StubResponder,
         ) : Stub {
             override val path: String get() = pathRegex.pattern
-            override fun matches(requestPath: String): Boolean = pathRegex.matches(requestPath)
+            override fun matchesPath(requestPath: String): Boolean = pathRegex.matches(requestPath)
         }
     }
 

--- a/core/integration/infra/src/androidMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/SearchStubs.kt
+++ b/core/integration/infra/src/androidMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/SearchStubs.kt
@@ -10,11 +10,11 @@ import io.ktor.http.isSuccess
  * fixture for [status] when the incoming request's `query` parameter matches [query].
  */
 public fun MockEngineHandler.stubSearchByQuery(query: String, status: HttpStatusCode = HttpStatusCode.OK) {
-    stub(path = Endpoints.Trakt.Search.path) { request ->
+    stub(path = Endpoints.PublicCatalog.Search.path) { request ->
         if (request.url.parameters["query"] != query) {
             error("No stub match for search query '${request.url.parameters["query"]}'. Expected '$query'.")
         }
-        val fixture = if (status.isSuccess()) Endpoints.Trakt.Search.successFixture else Endpoints.Trakt.Search.errorFixture
+        val fixture = if (status.isSuccess()) Endpoints.PublicCatalog.Search.successFixture else Endpoints.PublicCatalog.Search.errorFixture
         respond(
             content = FixtureLoader.load(fixture),
             status = status,

--- a/core/integration/infra/src/androidMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/ShowFixtures.kt
+++ b/core/integration/infra/src/androidMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/ShowFixtures.kt
@@ -53,9 +53,9 @@ private const val MAX_STUBBED_SEASON_NUMBER = 5
 
 /**
  * Registers per-show exact-path stubs for [show] on this [MockEngineHandler]:
- * - Trakt `/shows/{traktId}` returns the canonical `Endpoints.Trakt.ShowDetails` body with ids,
+ * - Trakt `/shows/{traktId}` returns the canonical `Endpoints.PublicCatalog.ShowDetails` body with ids,
  *   title, year, and `first_aired` rewritten to match [show].
- * - Trakt `/shows/{traktId}/seasons` returns the canonical `Endpoints.Trakt.ShowSeasons` body
+ * - Trakt `/shows/{traktId}/seasons` returns the canonical `Endpoints.PublicCatalog.ShowSeasons` body
  *   with each season's `ids.trakt` rewritten to a per-show value so seasons don't collide on the
  *   shared PRIMARY KEY when multiple shows are synced from the same fixture.
  * - TMDB `/3/tv/{tmdbId}` returns the canonical `Endpoints.Tmdb.ShowDetails` body with the root
@@ -75,12 +75,12 @@ private const val MAX_STUBBED_SEASON_NUMBER = 5
  * canonical Breaking Bad episodes for every show, and `INSERT OR REPLACE INTO episode (id, ...)`
  * leaves only the last-synced show owning the episode rows.
  *
- * Pattern fallbacks (`Endpoints.Trakt.ShowDetails`, etc.) registered earlier are overridden by
+ * Pattern fallbacks (`Endpoints.PublicCatalog.ShowDetails`, etc.) registered earlier are overridden by
  * these exact-path stubs because `MockEngineHandler.handle()` iterates `stubs.asReversed()`.
  */
 public fun MockEngineHandler.stubShow(show: ShowFixture) {
-    val traktDetailsTemplate = FixtureLoader.load(Endpoints.Trakt.ShowDetails.successFixture)
-    val traktSeasonsTemplate = FixtureLoader.load(Endpoints.Trakt.ShowSeasons.successFixture)
+    val traktDetailsTemplate = FixtureLoader.load(Endpoints.PublicCatalog.ShowDetails.successFixture)
+    val traktSeasonsTemplate = FixtureLoader.load(Endpoints.PublicCatalog.ShowSeasons.successFixture)
     val tmdbDetailsTemplate = FixtureLoader.load(Endpoints.Tmdb.ShowDetails.successFixture)
     val tmdbProvidersTemplate = FixtureLoader.load(Endpoints.Tmdb.WatchProviders.successFixture)
     val tmdbSeason1Template = FixtureLoader.load(Endpoints.Tmdb.SeasonDetailsS1.successFixture)

--- a/core/integration/infra/src/androidMain/resources/fixtures/simkl/sync/history/error.json
+++ b/core/integration/infra/src/androidMain/resources/fixtures/simkl/sync/history/error.json
@@ -1,0 +1,3 @@
+{
+  "error": "Failed to add items to history"
+}

--- a/core/integration/infra/src/androidMain/resources/fixtures/simkl/sync/history/success.json
+++ b/core/integration/infra/src/androidMain/resources/fixtures/simkl/sync/history/success.json
@@ -1,0 +1,12 @@
+{
+  "added": {
+    "movies": 0,
+    "shows": 0,
+    "episodes": 1
+  },
+  "not_found": {
+    "movies": [],
+    "shows": [],
+    "episodes": []
+  }
+}


### PR DESCRIPTION
## Description
This PR improves the reliability of our integration tests by making the test setup smarter about different API providers. It updates how the app simulates network requests during tests, ensuring that sync features work correctly for both Trakt and SIMKL.

## Changes
- Update the test network handler to better distinguish between different API providers
- Refactor test scenarios to correctly simulate authentication and sync behavior for each provider
- Improve test modularity to make it easier to add and maintain test cases
- Add new test data for SIMKL sync history to increase test coverage
- Standardize how network endpoints are defined to reduce test setup errors
