### PR TITLE
chore: Refactor Up Next and Start Watching logic

### DIFF
--- a/android-designsystem/src/main/kotlin/com/thomaskioko/tvmaniac/compose/components/TopBar.kt
+++ b/android-designsystem/src/main/kotlin/com/thomaskioko/tvmaniac/compose/components/TopBar.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.TopAppBarColors
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -70,6 +71,28 @@ public fun TvManiacTopBar(
 }
 
 @Composable
+public fun rememberShowAppBarBackground(
+    listState: LazyListState,
+    appBarHeight: () -> Int,
+): State<Boolean> = remember(listState) {
+    derivedStateOf {
+        val visibleItemsInfo = listState.layoutInfo.visibleItemsInfo
+        val height = appBarHeight()
+        when {
+            visibleItemsInfo.isEmpty() -> false
+            height <= 0 -> false
+            else -> {
+                val firstVisibleItem = visibleItemsInfo[0]
+                when {
+                    firstVisibleItem.index > 0 -> true
+                    else -> firstVisibleItem.size + firstVisibleItem.offset - 5 <= height
+                }
+            }
+        }
+    }
+}
+
+@Composable
 public fun RefreshCollapsableTopAppBar(
     listState: LazyListState,
     modifier: Modifier = Modifier,
@@ -83,22 +106,7 @@ public fun RefreshCollapsableTopAppBar(
     navIconModifier: Modifier = Modifier,
 ) {
     var appBarHeight by remember { mutableIntStateOf(0) }
-    val showAppBarBackground by remember {
-        derivedStateOf {
-            val visibleItemsInfo = listState.layoutInfo.visibleItemsInfo
-            when {
-                visibleItemsInfo.isEmpty() -> false
-                appBarHeight <= 0 -> false
-                else -> {
-                    val firstVisibleItem = visibleItemsInfo[0]
-                    when {
-                        firstVisibleItem.index > 0 -> true
-                        else -> firstVisibleItem.size + firstVisibleItem.offset - 5 <= appBarHeight
-                    }
-                }
-            }
-        }
-    }
+    val showAppBarBackground by rememberShowAppBarBackground(listState) { appBarHeight }
 
     RefreshCollapsableTopAppBar(
         modifier = modifier
@@ -127,22 +135,7 @@ public fun RefreshCollapsableTopAppBar(
     centeredTitle: Boolean = false,
 ) {
     var appBarHeight by remember { mutableIntStateOf(0) }
-    val showAppBarBackground by remember {
-        derivedStateOf {
-            val visibleItemsInfo = listState.layoutInfo.visibleItemsInfo
-            when {
-                visibleItemsInfo.isEmpty() -> false
-                appBarHeight <= 0 -> false
-                else -> {
-                    val firstVisibleItem = visibleItemsInfo[0]
-                    when {
-                        firstVisibleItem.index > 0 -> true
-                        else -> firstVisibleItem.size + firstVisibleItem.offset - 5 <= appBarHeight
-                    }
-                }
-            }
-        }
-    }
+    val showAppBarBackground by rememberShowAppBarBackground(listState) { appBarHeight }
 
     RefreshCollapsableTopAppBar(
         modifier = modifier

--- a/app/README.md
+++ b/app/README.md
@@ -1003,6 +1003,7 @@ graph TB
   :data:upcomingshows:implementation --> :data:database:sqldelight
   :data:upcomingshows:implementation --> :data:request-manager:api
   :data:upcomingshows:implementation --> :data:upcomingshows:api
+  :data:upnext:implementation -.-> :core:base
   :data:upnext:implementation --> :data:datastore:api
   :data:upnext:implementation --> :data:episode:api
   :data:upnext:implementation --> :data:upnext:api

--- a/core/base/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/base/extensions/DecomposeUtils.kt
+++ b/core/base/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/base/extensions/DecomposeUtils.kt
@@ -3,10 +3,14 @@ package com.thomaskioko.tvmaniac.core.base.extensions
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.Value
+import com.arkivanov.essenty.lifecycle.Lifecycle
 import com.arkivanov.essenty.lifecycle.LifecycleOwner
 import com.arkivanov.essenty.lifecycle.doOnDestroy
+import com.arkivanov.essenty.lifecycle.doOnStart
+import com.arkivanov.essenty.lifecycle.doOnStop
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -27,11 +31,21 @@ import kotlin.coroutines.CoroutineContext
 public fun LifecycleOwner.coroutineScope(
     context: CoroutineContext = Dispatchers.Main.immediate,
 ): CoroutineScope {
-    val scope = CoroutineScope(context + SupervisorJob())
+    val scope = LifecycleAwareCoroutineScope(CoroutineScope(context + SupervisorJob()), lifecycle)
     lifecycle.doOnDestroy(scope::cancel)
 
     return scope
 }
+
+/**
+ * [CoroutineScope] that remembers the [Lifecycle] of the component it belongs to, letting
+ * [asValue] pause collection while the component is stopped (inactive bottom-nav tab,
+ * back-stack entry, backgrounded app).
+ */
+internal class LifecycleAwareCoroutineScope(
+    delegate: CoroutineScope,
+    internal val lifecycle: Lifecycle,
+) : CoroutineScope by delegate
 
 /**
  * Creates a Main [CoroutineScope] instance tied to the lifecycle of this [ComponentContext].
@@ -44,11 +58,31 @@ public fun LifecycleOwner.componentCoroutineScope(): CoroutineScope =
 /**
  * Converts this Kotlin [StateFlow] to a Decompose [Value].
  * Collects on [Dispatchers.Main.immediate] to ensure thread-safe [MutableValue] updates.
+ *
+ * When [scope] comes from [LifecycleOwner.coroutineScope], collection runs only while the
+ * owning component is started. This keeps `SharingStarted.WhileSubscribed` state flows
+ * unsubscribed for stopped components (inactive tabs are parked at CREATED by the navigation
+ * layer), so their upstream database and network flows stay idle until the component is shown
+ * again. A plain scope collects for its whole life.
  */
 public fun <T : Any> StateFlow<T>.asValue(scope: CoroutineScope): Value<T> {
     val mutableValue = MutableValue(value)
-    scope.launch(Dispatchers.Main.immediate) {
-        collect { mutableValue.value = it }
+    val lifecycle = (scope as? LifecycleAwareCoroutineScope)?.lifecycle
+    if (lifecycle == null) {
+        scope.launch(Dispatchers.Main.immediate) {
+            collect { mutableValue.value = it }
+        }
+    } else {
+        var job: Job? = null
+        lifecycle.doOnStart(isOneTime = false) {
+            job = scope.launch(Dispatchers.Main.immediate) {
+                collect { mutableValue.value = it }
+            }
+        }
+        lifecycle.doOnStop(isOneTime = false) {
+            job?.cancel()
+            job = null
+        }
     }
     return mutableValue
 }

--- a/core/base/src/commonTest/kotlin/com/thomaskioko/tvmaniac/core/base/extensions/AsValueTest.kt
+++ b/core/base/src/commonTest/kotlin/com/thomaskioko/tvmaniac/core/base/extensions/AsValueTest.kt
@@ -1,0 +1,126 @@
+package com.thomaskioko.tvmaniac.core.base.extensions
+
+import com.arkivanov.essenty.lifecycle.Lifecycle
+import com.arkivanov.essenty.lifecycle.LifecycleOwner
+import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.create
+import com.arkivanov.essenty.lifecycle.resume
+import com.arkivanov.essenty.lifecycle.stop
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class AsValueTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val owner = TestLifecycleOwner()
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `should mirror emissions given lifecycle is resumed`() = runTest(testDispatcher) {
+        owner.registry.resume()
+        val stateFlow = MutableStateFlow(1)
+
+        val value = stateFlow.asValue(owner.coroutineScope())
+        testScheduler.runCurrent()
+
+        stateFlow.value = 2
+        testScheduler.runCurrent()
+
+        value.value shouldBe 2
+    }
+
+    @Test
+    fun `should pause collection and release subscription given lifecycle stops`() = runTest(testDispatcher) {
+        owner.registry.resume()
+        val stateFlow = MutableStateFlow(1)
+        val value = stateFlow.asValue(owner.coroutineScope())
+        testScheduler.runCurrent()
+
+        owner.registry.stop()
+        testScheduler.runCurrent()
+
+        stateFlow.subscriptionCount.value shouldBe 0
+
+        stateFlow.value = 2
+        testScheduler.runCurrent()
+
+        value.value shouldBe 1
+    }
+
+    @Test
+    fun `should resubscribe with current value given lifecycle restarts`() = runTest(testDispatcher) {
+        owner.registry.resume()
+        val stateFlow = MutableStateFlow(1)
+        val value = stateFlow.asValue(owner.coroutineScope())
+        testScheduler.runCurrent()
+
+        owner.registry.stop()
+        testScheduler.runCurrent()
+        stateFlow.value = 5
+
+        owner.registry.resume()
+        testScheduler.runCurrent()
+
+        stateFlow.subscriptionCount.value shouldBe 1
+        value.value shouldBe 5
+    }
+
+    @Test
+    fun `should defer collection given lifecycle only created`() = runTest(testDispatcher) {
+        owner.registry.create()
+        val stateFlow = MutableStateFlow(1)
+
+        val value = stateFlow.asValue(owner.coroutineScope())
+        testScheduler.runCurrent()
+
+        stateFlow.subscriptionCount.value shouldBe 0
+
+        stateFlow.value = 3
+        testScheduler.runCurrent()
+        value.value shouldBe 1
+
+        owner.registry.resume()
+        testScheduler.runCurrent()
+        value.value shouldBe 3
+    }
+
+    @Test
+    fun `should collect for scope lifetime given plain scope`() = runTest(testDispatcher) {
+        val scope = CoroutineScope(SupervisorJob() + testDispatcher)
+        val stateFlow = MutableStateFlow(1)
+
+        val value = stateFlow.asValue(scope)
+        testScheduler.runCurrent()
+
+        stateFlow.value = 2
+        testScheduler.runCurrent()
+
+        value.value shouldBe 2
+    }
+}
+
+private class TestLifecycleOwner : LifecycleOwner {
+    val registry: LifecycleRegistry = LifecycleRegistry()
+    override val lifecycle: Lifecycle get() = registry
+}

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/ShowsNextToWatch.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/ShowsNextToWatch.sq
@@ -88,17 +88,79 @@ WHERE tvshow.id = :showId
 ORDER BY season.season_number DESC
 LIMIT 1;
 
+-- Single-pass rewrite of the old double `shows_next_to_watch` materialization: the view's
+-- OR-join caps index use at show_id (cost ~ episodes x watched per show), so re-running it
+-- on every watched_episodes write took seconds on provider-synced libraries. CTEs scan each
+-- table once, scoped to continue_watching shows, with the OR split into two indexed
+-- NOT EXISTS probes. Result set and ordering are identical to the view-based query.
 nextEpisodesForWatchlist:
+WITH last_watched AS (
+    SELECT
+        watched_episode.show_id,
+        MAX((1000 * season.season_number) + episode.episode_number) AS last_watched_abs_number,
+        MAX(watched_episode.watched_at) AS last_watched_at
+    FROM watched_episodes AS watched_episode
+    INNER JOIN episode ON episode.id = watched_episode.episode_id AND episode.show_id = watched_episode.show_id
+    INNER JOIN season ON season.id = episode.season_id
+    INNER JOIN continue_watching ON continue_watching.show_id = watched_episode.show_id
+    WHERE watched_episode.pending_action NOT IN ('DELETE', 'SYNCED_DELETE')
+      AND (season.season_number > 0 OR season.title != 'Specials')
+    GROUP BY watched_episode.show_id
+),
+next_abs AS (
+    SELECT
+        episode.show_id,
+        MIN((1000 * season.season_number) + episode.episode_number) AS next_ep_abs_number
+    FROM continue_watching
+    INNER JOIN episode ON episode.show_id = continue_watching.show_id
+    INNER JOIN season ON season.id = episode.season_id
+    LEFT JOIN last_watched ON last_watched.show_id = continue_watching.show_id
+    WHERE (season.season_number > 0 OR (season.season_number = 0 AND season.title != 'Specials'))
+      AND (:includeSpecials = 1 OR season.season_number > 0)
+      AND episode.first_aired IS NOT NULL
+      AND episode.first_aired <= strftime('%s', 'now') * 1000
+      AND ((1000 * season.season_number) + episode.episode_number) > COALESCE(last_watched.last_watched_abs_number, 0)
+      AND NOT EXISTS (
+        SELECT 1 FROM watched_episodes
+        WHERE watched_episodes.show_id = episode.show_id
+          AND watched_episodes.episode_id = episode.id
+          AND watched_episodes.pending_action NOT IN ('DELETE', 'SYNCED_DELETE'))
+      AND NOT EXISTS (
+        SELECT 1 FROM watched_episodes
+        WHERE watched_episodes.show_id = episode.show_id
+          AND watched_episodes.episode_id IS NULL
+          AND watched_episodes.season_number = season.season_number
+          AND watched_episodes.episode_number = episode.episode_number
+          AND watched_episodes.pending_action NOT IN ('DELETE', 'SYNCED_DELETE'))
+    GROUP BY episode.show_id
+),
+watched_counts AS (
+    SELECT watched_episodes.show_id, COUNT(*) AS watched_count
+    FROM watched_episodes
+    INNER JOIN continue_watching ON continue_watching.show_id = watched_episodes.show_id
+    WHERE watched_episodes.pending_action NOT IN ('DELETE', 'SYNCED_DELETE')
+    GROUP BY watched_episodes.show_id
+),
+total_counts AS (
+    SELECT episode.show_id, COUNT(*) AS total_count
+    FROM episode
+    INNER JOIN season ON episode.season_id = season.id
+    INNER JOIN continue_watching ON continue_watching.show_id = episode.show_id
+    WHERE season.season_number > 0
+      AND episode.first_aired IS NOT NULL
+      AND episode.first_aired <= strftime('%s', 'now') * 1000
+    GROUP BY episode.show_id
+)
 SELECT
     tvshow.tmdb_id AS show_id,
     COALESCE(tvshow.tmdb_id, watched_show.tmdb_id) AS tmdb_id,
-    next_episode.episode_id,
-    next_episode.episode_name,
-    next_episode.season_id,
-    next_episode.season_number,
+    next_episode.id AS episode_id,
+    next_episode.title AS episode_name,
+    next_season.id AS season_id,
+    next_season.season_number,
     next_episode.episode_number,
     next_episode.runtime,
-    next_episode.still_path,
+    next_episode.image_url AS still_path,
     next_episode.overview,
     COALESCE(tvshow.name, watched_show.title) AS show_name,
     tvshow.poster_path AS show_poster,
@@ -108,41 +170,58 @@ SELECT
     watched_show.last_watched_at AS last_watched_at,
     COALESCE(show_metadata.season_count, 0) AS season_count,
     COALESCE(show_metadata.episode_count, 0) AS episode_count,
-    COALESCE(show_watch_progress.watched_count, 0) AS watched_count,
-    COALESCE(show_watch_progress.total_count, 0) AS total_count,
+    COALESCE(watched_counts.watched_count, 0) AS watched_count,
+    COALESCE(total_counts.total_count, 0) AS total_count,
     next_episode.ratings,
     next_episode.vote_count
 FROM continue_watching AS watched_show
 INNER JOIN tvshow ON tvshow.id = watched_show.show_id
-LEFT JOIN show_metadata ON show_metadata.show_id = tvshow.id
-LEFT JOIN show_watch_progress ON show_watch_progress.show_id = tvshow.id
-LEFT JOIN (
-    SELECT
-        show_id,
-        MIN(next_ep_abs_number) AS min_abs_number
-    FROM shows_next_to_watch
-    WHERE (:includeSpecials = 1 OR (season_number > 0))
-    GROUP BY show_id
-) AS min_next_episode ON min_next_episode.show_id = watched_show.show_id
-LEFT JOIN shows_next_to_watch AS next_episode
-    ON next_episode.show_id = watched_show.show_id
-    AND next_episode.next_ep_abs_number = min_next_episode.min_abs_number
-ORDER BY COALESCE(next_episode.last_watched_at, watched_show.last_watched_at) DESC,
-         next_episode.season_number ASC,
+LEFT JOIN show_metadata ON show_metadata.show_id = watched_show.show_id
+LEFT JOIN watched_counts ON watched_counts.show_id = watched_show.show_id
+LEFT JOIN total_counts ON total_counts.show_id = watched_show.show_id
+LEFT JOIN next_abs ON next_abs.show_id = watched_show.show_id
+LEFT JOIN last_watched ON last_watched.show_id = watched_show.show_id
+LEFT JOIN season AS next_season
+    ON next_season.show_id = watched_show.show_id
+    AND next_season.season_number = next_abs.next_ep_abs_number / 1000
+LEFT JOIN episode AS next_episode
+    ON next_episode.season_id = next_season.id
+    AND next_episode.episode_number = next_abs.next_ep_abs_number % 1000
+ORDER BY COALESCE(CASE WHEN next_abs.next_ep_abs_number IS NOT NULL THEN last_watched.last_watched_at END,
+                  watched_show.last_watched_at) DESC,
+         next_season.season_number ASC,
          next_episode.episode_number ASC;
 
 completedShowsForWatchlist:
+WITH watched_counts AS (
+    SELECT watched_episodes.show_id, COUNT(*) AS watched_count
+    FROM watched_episodes
+    INNER JOIN continue_watching ON continue_watching.show_id = watched_episodes.show_id
+    WHERE watched_episodes.pending_action NOT IN ('DELETE', 'SYNCED_DELETE')
+    GROUP BY watched_episodes.show_id
+),
+total_counts AS (
+    SELECT episode.show_id, COUNT(*) AS total_count
+    FROM episode
+    INNER JOIN season ON episode.season_id = season.id
+    INNER JOIN continue_watching ON continue_watching.show_id = episode.show_id
+    WHERE season.season_number > 0
+      AND episode.first_aired IS NOT NULL
+      AND episode.first_aired <= strftime('%s', 'now') * 1000
+    GROUP BY episode.show_id
+)
 SELECT
     tvshow.tmdb_id AS show_id,
     COALESCE(tvshow.tmdb_id, watched_show.tmdb_id) AS tmdb_id,
     COALESCE(tvshow.name, watched_show.title) AS show_name,
     tvshow.poster_path AS show_poster,
     watched_show.last_watched_at AS last_watched_at,
-    COALESCE(show_watch_progress.watched_count, 0) AS watched_count,
-    COALESCE(show_watch_progress.total_count, 0) AS total_count
+    COALESCE(watched_counts.watched_count, 0) AS watched_count,
+    COALESCE(total_counts.total_count, 0) AS total_count
 FROM continue_watching AS watched_show
 INNER JOIN tvshow ON tvshow.id = watched_show.show_id
-LEFT JOIN show_watch_progress ON show_watch_progress.show_id = tvshow.id
-WHERE COALESCE(show_watch_progress.total_count, 0) > 0
-  AND COALESCE(show_watch_progress.watched_count, 0) >= COALESCE(show_watch_progress.total_count, 0)
+LEFT JOIN watched_counts ON watched_counts.show_id = watched_show.show_id
+LEFT JOIN total_counts ON total_counts.show_id = watched_show.show_id
+WHERE COALESCE(total_counts.total_count, 0) > 0
+  AND COALESCE(watched_counts.watched_count, 0) >= COALESCE(total_counts.total_count, 0)
 ORDER BY watched_show.last_watched_at DESC;

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/StartWatching.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/StartWatching.sq
@@ -2,40 +2,60 @@ import com.thomaskioko.tvmaniac.db.Id;
 import com.thomaskioko.tvmaniac.db.TraktId;
 import com.thomaskioko.tvmaniac.db.TmdbId;
 
+-- Eligible shows have zero live watched rows, so the shows_next_to_watch view's
+-- watched-exclusion machinery is a no-op for them: the next episode is simply the first
+-- aired regular-season episode. Scanning episodes of eligible shows directly avoids
+-- materializing the view (and the whole-database show_watch_progress aggregate) on every
+-- watched_episodes write.
 startWatchingShows:
+WITH eligible AS (
+    SELECT followed_shows.show_id, followed_shows.followed_at
+    FROM followed_shows
+    WHERE followed_shows.pending_action != 'DELETE'
+      AND NOT EXISTS (
+        SELECT 1 FROM watched_episodes
+        WHERE watched_episodes.show_id = followed_shows.show_id
+          AND watched_episodes.pending_action NOT IN ('DELETE', 'SYNCED_DELETE'))
+      AND NOT EXISTS (
+        SELECT 1 FROM continue_watching
+        WHERE continue_watching.show_id = followed_shows.show_id)
+),
+next_abs AS (
+    SELECT
+        episode.show_id,
+        MIN((1000 * season.season_number) + episode.episode_number) AS next_ep_abs_number
+    FROM eligible
+    INNER JOIN episode ON episode.show_id = eligible.show_id
+    INNER JOIN season ON season.id = episode.season_id
+    WHERE season.season_number > 0
+      AND episode.first_aired IS NOT NULL
+      AND episode.first_aired <= strftime('%s', 'now') * 1000
+    GROUP BY episode.show_id
+)
 SELECT
     tvshow.tmdb_id AS show_id,
     tvshow.tmdb_id AS tmdb_id,
     tvshow.name AS title,
     tvshow.poster_path,
     tvshow.year,
-    CASE WHEN followed_shows.id IS NOT NULL THEN 1 ELSE 0 END AS in_library,
-    next_episode.episode_id,
-    next_episode.episode_name,
-    next_episode.season_id,
-    next_episode.season_number,
+    CASE WHEN eligible.show_id IS NOT NULL THEN 1 ELSE 0 END AS in_library,
+    next_episode.id AS episode_id,
+    next_episode.title AS episode_name,
+    next_season.id AS season_id,
+    next_season.season_number,
     next_episode.episode_number,
     next_episode.runtime,
-    next_episode.still_path,
+    next_episode.image_url AS still_path,
     next_episode.overview AS episode_overview,
     next_episode.first_aired
-FROM followed_shows
-INNER JOIN tvshow ON followed_shows.show_id = tvshow.id
-LEFT JOIN show_watch_progress ON show_watch_progress.show_id = tvshow.id
-LEFT JOIN continue_watching ON continue_watching.show_id = tvshow.id
-LEFT JOIN (
-    SELECT
-        show_id,
-        MIN(next_ep_abs_number) AS min_abs_number
-    FROM shows_next_to_watch
-    WHERE season_number > 0
-    GROUP BY show_id
-) AS min_next_episode ON min_next_episode.show_id = tvshow.id
-LEFT JOIN shows_next_to_watch AS next_episode
-    ON next_episode.show_id = tvshow.id
-    AND next_episode.next_ep_abs_number = min_next_episode.min_abs_number
-WHERE followed_shows.pending_action != 'DELETE'
-  AND COALESCE(show_watch_progress.watched_count, 0) = 0
-  AND (tvshow.year IS NULL OR CAST(tvshow.year AS INTEGER) <= CAST(strftime('%Y', 'now') AS INTEGER))
-  AND continue_watching.show_id IS NULL
-ORDER BY followed_shows.followed_at DESC;
+FROM eligible
+INNER JOIN tvshow ON tvshow.id = eligible.show_id
+LEFT JOIN next_abs ON next_abs.show_id = eligible.show_id
+LEFT JOIN season AS next_season
+    ON next_season.show_id = eligible.show_id
+    AND next_season.season_number = next_abs.next_ep_abs_number / 1000
+LEFT JOIN episode AS next_episode
+    ON next_episode.season_id = next_season.id
+    AND next_episode.episode_number = next_abs.next_ep_abs_number % 1000
+WHERE (tvshow.year IS NULL OR CAST(tvshow.year AS INTEGER) <= CAST(strftime('%Y', 'now') AS INTEGER))
+ORDER BY eligible.followed_at DESC;

--- a/data/database/sqldelight/src/iosMain/kotlin/com/thomaskioko/tvmaniac/db/IosDatabaseDriverBuilder.kt
+++ b/data/database/sqldelight/src/iosMain/kotlin/com/thomaskioko/tvmaniac/db/IosDatabaseDriverBuilder.kt
@@ -48,7 +48,15 @@ public fun createNativeSqliteDriver(
             migrationDriver.close()
         }
     }
-    return NativeSqliteDriver(databaseConfiguration(schema, name, inMemory = inMemory, foreignKeys = true))
+    return NativeSqliteDriver(
+        databaseConfiguration(
+            schema = schema,
+            name = name,
+            inMemory = inMemory,
+            foreignKeys = true,
+        ),
+        maxReaderConnections = if (inMemory) 1 else 4,
+    )
 }
 
 internal fun databaseConfiguration(

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeDao.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeDao.kt
@@ -83,11 +83,15 @@ public interface WatchedEpisodeDao {
 
     public suspend fun updatePendingAction(id: Long, action: PendingAction)
 
+    public suspend fun updatePendingActions(ids: List<Long>, action: PendingAction)
+
     public fun deleteAll()
 
     public suspend fun countPendingActions(): Long
 
     public suspend fun deleteById(id: Long)
+
+    public suspend fun deleteByIds(ids: List<Long>)
 
     public suspend fun upsertBatchFromTrakt(
         showId: Long,

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepository.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepository.kt
@@ -140,9 +140,7 @@ public class DefaultWatchedEpisodeSyncRepository(
 
         source.addEpisodeEntries(entries)
 
-        pending.forEach { episode ->
-            dao.updatePendingAction(episode.watched_id, PendingAction.NOTHING)
-        }
+        dao.updatePendingActions(pending.map { it.watched_id }, PendingAction.NOTHING)
 
         logger.debug(TAG, "Successfully uploaded ${pending.size} episodes")
     }
@@ -167,9 +165,7 @@ public class DefaultWatchedEpisodeSyncRepository(
         }
         source.removeEpisodeEntries(entries)
 
-        pending.forEach { episode ->
-            dao.deleteById(episode.watched_id)
-        }
+        dao.deleteByIds(pending.map { it.watched_id })
 
         logger.debug(TAG, "Successfully deleted ${pending.size} episodes")
     }

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/dao/DefaultWatchedEpisodeDao.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/dao/DefaultWatchedEpisodeDao.kt
@@ -490,6 +490,17 @@ public class DefaultWatchedEpisodeDao(
         }
     }
 
+    override suspend fun updatePendingActions(ids: List<Long>, action: PendingAction) {
+        if (ids.isEmpty()) return
+        withContext(dispatchers.databaseWrite) {
+            database.transaction {
+                ids.forEach { id ->
+                    val _ = database.watchedEpisodesQueries.updatePendingAction(action.value, id)
+                }
+            }
+        }
+    }
+
     override fun deleteAll() {
         database.watchedEpisodesQueries.deleteAll()
     }
@@ -503,6 +514,17 @@ public class DefaultWatchedEpisodeDao(
     override suspend fun deleteById(id: Long) {
         withContext(dispatchers.databaseWrite) {
             database.watchedEpisodesQueries.deleteById(id)
+        }
+    }
+
+    override suspend fun deleteByIds(ids: List<Long>) {
+        if (ids.isEmpty()) return
+        withContext(dispatchers.databaseWrite) {
+            database.transaction {
+                ids.forEach { id ->
+                    val _ = database.watchedEpisodesQueries.deleteById(id)
+                }
+            }
         }
     }
 

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultNextEpisodeDaoTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultNextEpisodeDaoTest.kt
@@ -178,6 +178,100 @@ internal class DefaultNextEpisodeDaoTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun `should advance to next episode given watched row has pending upload`() = runTest {
+        followShow(showId = 1L, followedAt = watchDate)
+        markEpisodeWatchedWithPendingAction(
+            showId = 1L,
+            episodeId = 101L,
+            seasonNumber = 1L,
+            episodeNumber = 1L,
+            pendingAction = "UPLOAD",
+        )
+
+        nextEpisodeDao.observeNextEpisodesForWatchlist(includeSpecials = false).test {
+            val episodes = awaitItem()
+            episodes.size shouldBe 1
+            episodes[0].episodeNumber shouldBe 2L
+            episodes[0].watchedCount shouldBe 1
+        }
+    }
+
+    @Test
+    fun `should skip unwatched gap episode given later episode already watched`() = runTest {
+        followShow(showId = 1L, followedAt = watchDate)
+        markEpisodeWatched(showId = 1L, episodeId = 102L, seasonNumber = 1L, episodeNumber = 2L)
+
+        nextEpisodeDao.observeNextEpisodesForWatchlist(includeSpecials = false).test {
+            val episodes = awaitItem()
+            episodes.size shouldBe 1
+            episodes[0].episodeNumber shouldBe 3L
+        }
+    }
+
+    @Test
+    fun `should return season zero episode given includeSpecials is true and season not titled Specials`() = runTest {
+        insertShow(id = 14L, name = "Extras Show")
+        insertSeason(seasonId = 141L, showId = 14L, seasonNumber = 0L, title = "Extras", episodeCount = 1L)
+        insertEpisode(episodeId = 1401L, seasonId = 141L, showId = 14L, episodeNumber = 1L, title = "Extra 1")
+        insertSeason(seasonId = 142L, showId = 14L, seasonNumber = 1L, episodeCount = 1L)
+        insertEpisode(episodeId = 1402L, seasonId = 142L, showId = 14L, episodeNumber = 1L, title = "Regular 1")
+        followShow(showId = 14L, followedAt = watchDate)
+
+        nextEpisodeDao.observeNextEpisodesForWatchlist(includeSpecials = true).test {
+            val episodes = awaitItem()
+            episodes.size shouldBe 1
+            episodes[0].seasonNumber shouldBe 0L
+            episodes[0].episodeName shouldBe "Extra 1"
+        }
+    }
+
+    @Test
+    fun `should skip season zero episode given includeSpecials is false and season not titled Specials`() = runTest {
+        insertShow(id = 14L, name = "Extras Show")
+        insertSeason(seasonId = 141L, showId = 14L, seasonNumber = 0L, title = "Extras", episodeCount = 1L)
+        insertEpisode(episodeId = 1401L, seasonId = 141L, showId = 14L, episodeNumber = 1L, title = "Extra 1")
+        insertSeason(seasonId = 142L, showId = 14L, seasonNumber = 1L, episodeCount = 1L)
+        insertEpisode(episodeId = 1402L, seasonId = 142L, showId = 14L, episodeNumber = 1L, title = "Regular 1")
+        followShow(showId = 14L, followedAt = watchDate)
+
+        nextEpisodeDao.observeNextEpisodesForWatchlist(includeSpecials = false).test {
+            val episodes = awaitItem()
+            episodes.size shouldBe 1
+            episodes[0].seasonNumber shouldBe 1L
+            episodes[0].episodeName shouldBe "Regular 1"
+        }
+    }
+
+    @Test
+    fun `should skip Specials-titled season zero given includeSpecials is true`() = runTest {
+        insertShow4WithSpecials()
+        followShow(showId = 4L, followedAt = watchDate)
+
+        nextEpisodeDao.observeNextEpisodesForWatchlist(includeSpecials = true).test {
+            val episodes = awaitItem()
+            episodes.size shouldBe 1
+            episodes[0].seasonNumber shouldBe 1L
+            episodes[0].episodeName shouldBe "Regular Episode 1"
+        }
+    }
+
+    @Test
+    fun `should list completed show given all aired episodes watched`() = runTest {
+        followShow(showId = 1L, followedAt = watchDate)
+        markEpisodeWatched(showId = 1L, episodeId = 101L, seasonNumber = 1L, episodeNumber = 1L)
+        markEpisodeWatched(showId = 1L, episodeId = 102L, seasonNumber = 1L, episodeNumber = 2L)
+        markEpisodeWatched(showId = 1L, episodeId = 103L, seasonNumber = 1L, episodeNumber = 3L)
+
+        nextEpisodeDao.observeCompletedShows().test {
+            val shows = awaitItem()
+            shows.size shouldBe 1
+            shows[0].showId shouldBe 1L
+            shows[0].watchedCount shouldBe 3L
+            shows[0].totalCount shouldBe 3L
+        }
+    }
+
+    @Test
     fun `should maintain shows in watchlist when tracking sequentially`() = runTest {
         followShow(showId = 1L, followedAt = watchDate)
 

--- a/data/showdetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/showdetails/implementation/ShowDetailsStore.kt
+++ b/data/showdetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/showdetails/implementation/ShowDetailsStore.kt
@@ -130,7 +130,7 @@ public class ShowDetailsStore(
                             episode_count = season.episodeCount.toLong(),
                             title = season.name,
                             overview = season.overview ?: "",
-                            image_url = null,
+                            image_url = season.posterPath?.let { formatterUtil.formatTmdbPosterPath(it) },
                         ),
                     )
                 }

--- a/data/showdetails/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/showdetails/implementation/ShowDetailsStoreTest.kt
+++ b/data/showdetails/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/showdetails/implementation/ShowDetailsStoreTest.kt
@@ -210,6 +210,47 @@ internal class ShowDetailsStoreTest : BaseDatabaseTest() {
         seasons.size shouldBe 2
     }
 
+    @Test
+    fun `should persist season poster given tmdb response includes it`() = runTest(testDispatcher) {
+        database.tvShowQueries.upsert(
+            tmdb_id = Id<TmdbId>(TMDB_ID),
+            name = SHOW_NAME,
+            overview = "",
+            language = null,
+            year = null,
+            ratings = 0.0,
+            vote_count = 0L,
+            genres = null,
+            status = null,
+            episode_numbers = null,
+            season_numbers = null,
+            poster_path = null,
+            backdrop_path = null,
+        )
+
+        tmdbSource.setShowDetails(
+            ApiResponse.Success(
+                buildTmdbShowDetailsResponse(
+                    id = TMDB_ID.toInt(),
+                    name = SHOW_NAME,
+                    seasons = arrayListOf(
+                        buildSeasonsResponse(id = 1, seasonNumber = 1, episodeCount = 10).copy(posterPath = "/season1.jpg"),
+                    ),
+                ),
+            ),
+        )
+
+        store.stream(StoreReadRequest.fresh(TMDB_ID)).test {
+            awaitItem()
+            awaitItem()
+            cancelAndConsumeRemainingEvents()
+        }
+
+        val internalShowId = showIdResolver.showIdForTmdbId(TMDB_ID).shouldNotBeNull()
+        val season = database.seasonsQueries.getSeasonByShowAndNumber(showId = internalShowId, seasonNumber = 1L).executeAsOne()
+        season.image_url.shouldNotBeNull()
+    }
+
     private fun buildStore(): ShowDetailsStore = ShowDetailsStore(
         traktRemoteDataSource = traktSource,
         tmdbRemoteDataSource = tmdbSource,

--- a/data/start-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/implementation/DefaultStartWatchingRepository.kt
+++ b/data/start-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/implementation/DefaultStartWatchingRepository.kt
@@ -1,6 +1,7 @@
 package com.thomaskioko.tvmaniac.startwatching.implementation
 
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
+import com.thomaskioko.tvmaniac.core.base.IoCoroutineScope
 import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.fresh
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.get
@@ -10,18 +11,26 @@ import com.thomaskioko.tvmaniac.startwatching.api.StartWatchingShow
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.shareIn
 
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 public class DefaultStartWatchingRepository(
-    private val dao: StartWatchingDao,
     private val startWatchingStore: StartWatchingWatchlistStore,
     private val accountManager: AccountManager,
     private val logger: Logger,
+    dao: StartWatchingDao,
+    @IoCoroutineScope scope: CoroutineScope,
 ) : StartWatchingRepository {
 
-    override fun observeStartWatching(): Flow<List<StartWatchingShow>> = dao.observeStartWatchingShows()
+    private val startWatchingShows: Flow<List<StartWatchingShow>> =
+        dao.observeStartWatchingShows()
+            .shareIn(scope, SharingStarted.WhileSubscribed(SHARING_STOP_TIMEOUT_MS), replay = 1)
+
+    override fun observeStartWatching(): Flow<List<StartWatchingShow>> = startWatchingShows
 
     override suspend fun syncWatchlist(forceRefresh: Boolean) {
         if (accountManager.getActiveProvider() == null) return
@@ -34,5 +43,6 @@ public class DefaultStartWatchingRepository(
 
     private companion object {
         private const val TAG = "StartWatchingRepository"
+        private const val SHARING_STOP_TIMEOUT_MS = 5_000L
     }
 }

--- a/data/upnext/implementation/README.md
+++ b/data/upnext/implementation/README.md
@@ -5,6 +5,11 @@
 <!--region graph-->
 ```mermaid
 graph TB
+  subgraph :core
+    direction TB
+    :core:base[base]:::multiplatform
+    :core:view[view]:::multiplatform
+  end
   subgraph :core:logger
     direction TB
     :core:logger:api[api]:::multiplatform
@@ -39,6 +44,9 @@ graph TB
     :i18n:generator[generator]:::multiplatform
   end
 
+  :core:base --> :core:logger:api
+  :core:base --> :core:view
+  :core:view --> :core:logger:api
   :data:account-manager:api --> :data:database:sqldelight
   :data:database:sqldelight --> :core:logger:api
   :data:datastore:api --> :i18n:generator
@@ -46,6 +54,7 @@ graph TB
   :data:episode:api --> :data:database:sqldelight
   :data:episode:api --> :data:followedshows:api
   :data:episode:api --> :data:upnext:api
+  :data:upnext:implementation -.-> :core:base
   :data:upnext:implementation --> :data:datastore:api
   :data:upnext:implementation --> :data:episode:api
   :data:upnext:implementation --> :data:upnext:api

--- a/data/upnext/implementation/build.gradle.kts
+++ b/data/upnext/implementation/build.gradle.kts
@@ -16,6 +16,8 @@ kotlin {
                 api(projects.data.datastore.api)
                 api(projects.data.episode.api)
                 api(projects.data.upnext.api)
+
+                implementation(projects.core.base)
             }
         }
 

--- a/data/upnext/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/upnext/implementation/DefaultUpNextRepository.kt
+++ b/data/upnext/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/upnext/implementation/DefaultUpNextRepository.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.upnext.implementation
 
+import com.thomaskioko.tvmaniac.core.base.IoCoroutineScope
 import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
 import com.thomaskioko.tvmaniac.episodes.api.NextEpisodeDao
 import com.thomaskioko.tvmaniac.upnext.api.UpNextRepository
@@ -8,26 +9,36 @@ import com.thomaskioko.tvmaniac.upnext.api.model.NextEpisodeWithShow
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.shareIn
 
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 public class DefaultUpNextRepository(
     private val nextEpisodeDao: NextEpisodeDao,
     private val datastoreRepository: DatastoreRepository,
+    @IoCoroutineScope scope: CoroutineScope,
 ) : UpNextRepository {
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    override fun observeNextEpisodesForWatchlist(): Flow<List<NextEpisodeWithShow>> =
+    private val nextEpisodes: Flow<List<NextEpisodeWithShow>> =
         datastoreRepository.observeIncludeSpecials()
             .flatMapLatest { includeSpecials ->
                 nextEpisodeDao.observeNextEpisodesForWatchlist(includeSpecials)
             }
+            .shareIn(scope, SharingStarted.WhileSubscribed(SHARING_STOP_TIMEOUT_MS), replay = 1)
 
-    override fun observeCompletedShows(): Flow<List<CompletedShow>> =
+    private val completedShows: Flow<List<CompletedShow>> =
         nextEpisodeDao.observeCompletedShows()
+            .shareIn(scope, SharingStarted.WhileSubscribed(SHARING_STOP_TIMEOUT_MS), replay = 1)
+
+    override fun observeNextEpisodesForWatchlist(): Flow<List<NextEpisodeWithShow>> = nextEpisodes
+
+    override fun observeCompletedShows(): Flow<List<CompletedShow>> = completedShows
 
     override suspend fun saveUpNextSortOption(sortOption: String) {
         datastoreRepository.saveUpNextSortOption(sortOption)
@@ -35,4 +46,8 @@ public class DefaultUpNextRepository(
 
     override fun observeUpNextSortOption(): Flow<String> =
         datastoreRepository.observeUpNextSortOption()
+
+    private companion object {
+        private const val SHARING_STOP_TIMEOUT_MS = 5_000L
+    }
 }

--- a/features/calendar/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/calendar/CalendarPresenterTest.kt
+++ b/features/calendar/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/calendar/CalendarPresenterTest.kt
@@ -3,6 +3,7 @@ package com.thomaskioko.tvmaniac.presentation.calendar
 import app.cash.turbine.test
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.resume
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
@@ -53,6 +54,7 @@ internal class CalendarPresenterTest {
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        lifecycle.resume()
     }
 
     @AfterTest

--- a/features/debug/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/debug/presenter/DebugPresenterTest.kt
+++ b/features/debug/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/debug/presenter/DebugPresenterTest.kt
@@ -3,6 +3,7 @@ package com.thomaskioko.tvmaniac.debug.presenter
 import app.cash.turbine.test
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.resume
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthState
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
@@ -64,6 +65,7 @@ class DebugPresenterTest {
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        lifecycle.resume()
     }
 
     @AfterTest

--- a/features/season-details/ui/src/main/java/com/thomaskioko/tvmaniac/seasondetails/ui/SeasonDetailsScreen.kt
+++ b/features/season-details/ui/src/main/java/com/thomaskioko/tvmaniac/seasondetails/ui/SeasonDetailsScreen.kt
@@ -1,7 +1,8 @@
 package com.thomaskioko.tvmaniac.seasondetails.ui
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.ScrollState
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.snapping.SnapPosition
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
@@ -14,7 +15,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -25,7 +25,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.items
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -40,13 +39,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
@@ -55,7 +55,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewWrapper
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.thomaskioko.tvmaniac.compose.components.CastCard
 import com.thomaskioko.tvmaniac.compose.components.EmptyStateView
@@ -73,6 +72,7 @@ import com.thomaskioko.tvmaniac.compose.components.TvManiacBottomSheetScaffold
 import com.thomaskioko.tvmaniac.compose.components.TvManiacPreviewWrapperProvider
 import com.thomaskioko.tvmaniac.compose.components.TvManiacSnackBarHost
 import com.thomaskioko.tvmaniac.compose.components.actionIconWhen
+import com.thomaskioko.tvmaniac.compose.components.rememberShowAppBarBackground
 import com.thomaskioko.tvmaniac.compose.extensions.contentBackgroundGradient
 import com.thomaskioko.tvmaniac.compose.extensions.copy
 import com.thomaskioko.tvmaniac.core.base.ActivityScope
@@ -180,37 +180,56 @@ internal fun SeasonDetailsScreen(
                     )
                 }
 
-                RefreshCollapsableTopAppBar(
-                    listState = listState,
-                    title = {
-                        Text(
-                            text = state.seasonName,
-                            style = MaterialTheme.typography.titleMedium.copy(
-                                color = MaterialTheme.colorScheme.onSurface,
-                            ),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
+                var appBarHeight by remember { mutableIntStateOf(0) }
+                val showPinnedProgress by rememberShowAppBarBackground(listState) { appBarHeight }
+
+                Column {
+                    RefreshCollapsableTopAppBar(
+                        modifier = Modifier.onSizeChanged { appBarHeight = it.height },
+                        listState = listState,
+                        title = {
+                            Text(
+                                text = state.seasonName,
+                                style = MaterialTheme.typography.titleMedium.copy(
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                ),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        },
+                        navigationIcon = {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = cd_navigate_back.resolve(LocalContext.current),
+                                tint = MaterialTheme.colorScheme.onBackground,
+                            )
+                        },
+                        navIconModifier = Modifier.testTag(SeasonDetailsTestTags.BACK_BUTTON_TEST_TAG),
+                        actionIcon = actionIconWhen(state.message != null) {
+                            Icon(
+                                imageVector = Icons.Default.Refresh,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onBackground,
+                            )
+                        },
+                        isRefreshing = state.isRefreshing,
+                        onNavIconClicked = { onAction(SeasonDetailsBackClicked) },
+                        onActionIconClicked = { onAction(ReloadSeasonDetails) },
+                    )
+
+                    AnimatedVisibility(
+                        visible = showPinnedProgress,
+                        enter = fadeIn(),
+                        exit = fadeOut(),
+                    ) {
+                        ShowLinearProgressIndicator(
+                            progress = state.watchProgress,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(8.dp),
                         )
-                    },
-                    navigationIcon = {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = cd_navigate_back.resolve(LocalContext.current),
-                            tint = MaterialTheme.colorScheme.onBackground,
-                        )
-                    },
-                    navIconModifier = Modifier.testTag(SeasonDetailsTestTags.BACK_BUTTON_TEST_TAG),
-                    actionIcon = actionIconWhen(state.message != null) {
-                        Icon(
-                            imageVector = Icons.Default.Refresh,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onBackground,
-                        )
-                    },
-                    isRefreshing = state.isRefreshing,
-                    onNavIconClicked = { onAction(SeasonDetailsBackClicked) },
-                    onActionIconClicked = { onAction(ReloadSeasonDetails) },
-                )
+                    }
+                }
 
                 TvManiacSnackBarHost(
                     message = if (!state.showError) state.message?.message else null,
@@ -232,8 +251,6 @@ internal fun LazyColumnContent(
     onAction: (SeasonDetailsAction) -> Unit,
     onEpisodeLongPress: (EpisodeDetailsModel) -> Unit = {},
 ) {
-    val scrollState = rememberScrollState()
-
     LazyColumn(
         modifier = modifier
             .testTag(SeasonDetailsTestTags.SEASON_DETAILS_LIST_TEST_TAG),
@@ -242,7 +259,6 @@ internal fun LazyColumnContent(
     ) {
         item(key = "header") {
             HeaderContent(
-                scrollState = scrollState,
                 imageUrl = seasonDetailsModel.imageUrl,
                 title = seasonDetailsModel.seasonName,
                 imagesCount = seasonDetailsModel.seasonImages.size,
@@ -250,7 +266,6 @@ internal fun LazyColumnContent(
                 userRating = seasonDetailsModel.userRating,
                 isLoading = isLoading,
                 onAction = onAction,
-                listState = listState,
             )
         }
 
@@ -333,52 +348,28 @@ internal fun ImageGalleryContent(
 
 @Composable
 private fun HeaderContent(
-    scrollState: ScrollState,
     imageUrl: String?,
     title: String,
     watchProgress: Float,
     imagesCount: Int,
     userRating: Int?,
     isLoading: Boolean,
-    listState: LazyListState,
     onAction: (SeasonDetailsAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val resources = LocalResources.current
 
-    val headerOffset by remember {
-        derivedStateOf {
-            IntOffset(
-                x = 0,
-                y = if (listState.firstVisibleItemIndex == 0) {
-                    listState.firstVisibleItemScrollOffset / 2
-                } else {
-                    0
-                },
-            )
-        }
-    }
-
-    val posterOffset by remember {
-        derivedStateOf {
-            IntOffset(0, scrollState.value / 2)
-        }
-    }
-
     Box(
         modifier = modifier
             .fillMaxWidth()
             .height(350.dp)
-            .clipToBounds()
-            .offset { headerOffset },
+            .clipToBounds(),
         contentAlignment = Alignment.BottomCenter,
     ) {
         PosterCard(
             imageUrl = imageUrl,
             title = title,
-            modifier = Modifier
-                .fillMaxWidth()
-                .offset { posterOffset },
+            modifier = Modifier.fillMaxWidth(),
         )
 
         Box(

--- a/features/settings/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/settings/SettingsPresenterTest.kt
+++ b/features/settings/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/settings/SettingsPresenterTest.kt
@@ -3,6 +3,7 @@ package com.thomaskioko.tvmaniac.presenter.settings
 import app.cash.turbine.test
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.resume
 import com.thomaskioko.tvmaniac.accountmanager.api.ConnectedAccount
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
@@ -98,6 +99,7 @@ class SettingsPresenterTest {
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        lifecycle.resume()
         presenter = SettingsPresenter(
             componentContext = DefaultComponentContext(lifecycle = lifecycle),
             appMetadata = FakeAppMetadata.DEFAULT,

--- a/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/seasonsepisodes/ShowDetailsSeasonsEpisodesPresenterTest.kt
+++ b/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/seasonsepisodes/ShowDetailsSeasonsEpisodesPresenterTest.kt
@@ -3,6 +3,7 @@ package com.thomaskioko.tvmaniac.presenter.showdetails.seasonsepisodes
 import app.cash.turbine.test
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.resume
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
@@ -267,7 +268,7 @@ internal class ShowDetailsSeasonsEpisodesPresenterTest {
 
     private fun buildPresenter(): ShowDetailsSeasonsEpisodesPresenter =
         ShowDetailsSeasonsEpisodesPresenter(
-            componentContext = DefaultComponentContext(lifecycle = LifecycleRegistry()),
+            componentContext = DefaultComponentContext(lifecycle = LifecycleRegistry().apply { resume() }),
             showId = SHOW_ID,
             forceRefresh = false,
             observeSeasonsInteractor = ObserveSeasonsInteractor(

--- a/ios-framework/README.md
+++ b/ios-framework/README.md
@@ -810,6 +810,7 @@ graph TB
   :data:upcomingshows:implementation --> :data:database:sqldelight
   :data:upcomingshows:implementation --> :data:request-manager:api
   :data:upcomingshows:implementation --> :data:upcomingshows:api
+  :data:upnext:implementation -.-> :core:base
   :data:upnext:implementation --> :data:datastore:api
   :data:upnext:implementation --> :data:episode:api
   :data:upnext:implementation --> :data:upnext:api

--- a/ios/ios/App/iOSApp.swift
+++ b/ios/ios/App/iOSApp.swift
@@ -81,6 +81,7 @@ struct iOSApp: App {
                 .onAppear {
                     authRegistry.register(presenterGraph: holder.component, appGraph: appDelegate.appGraph)
                     appDelegate.configureNotificationDelegate(rootPresenter: holder.component.rootPresenter)
+                    handleScenePhaseChange(scenePhase, lifecycle: holder.lifecycle)
                 }
                 .onChange(of: scenePhase) { _, newPhase in
                     handleScenePhaseChange(newPhase, lifecycle: holder.lifecycle)


### PR DESCRIPTION
## Description
This PR improves the "Up Next" and "Start Watching" functionality by optimizing database operations, refactoring repository flows, and enhancing the season details UI. These changes ensure smoother navigation and faster data loading, while also introducing better lifecycle support for UI state collection.

## Changes
- Optimize database queries for watchlist and "start watching" shows
- Refactor episode synchronization to use batch database operations for improved performance
- Improve season details UI with a pinned progress indicator and refined header logic
- Enable lifecycle-aware collection for UI state
- Persist season poster paths for consistent display
- Configure max reader connections for the iOS database driver
