### PR TITLE
chore: Migrate Swift packages to swift-tools-version 6.0

### DIFF
--- a/ios/Packages/Calendar/Package.swift
+++ b/ios/Packages/Calendar/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -44,5 +44,6 @@ let package = Package(
             ],
             exclude: ["__Snapshots__"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/Components/Package.swift
+++ b/ios/Packages/Components/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -45,5 +45,6 @@ let package = Package(
             ],
             exclude: ["__Snapshots__"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/CoreKit/Package.swift
+++ b/ios/Packages/CoreKit/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -28,5 +28,6 @@ let package = Package(
                 .product(name: "Nuke", package: "Nuke"),
             ]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/Debug/Package.swift
+++ b/ios/Packages/Debug/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -44,5 +44,6 @@ let package = Package(
             ],
             exclude: ["__Snapshots__"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/DesignSystem/Package.swift
+++ b/ios/Packages/DesignSystem/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -22,5 +22,6 @@ let package = Package(
                 .process("Resources/Assets.xcassets"),
             ]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/Discover/Package.swift
+++ b/ios/Packages/Discover/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -45,5 +45,6 @@ let package = Package(
             ],
             exclude: ["__Snapshots__"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/EpisodeDetail/Package.swift
+++ b/ios/Packages/EpisodeDetail/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -38,5 +38,6 @@ let package = Package(
             ],
             exclude: ["__Snapshots__"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/FeatureFlags/Package.swift
+++ b/ios/Packages/FeatureFlags/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -44,5 +44,6 @@ let package = Package(
             ],
             exclude: ["__Snapshots__"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/Home/Package.swift
+++ b/ios/Packages/Home/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -44,5 +44,6 @@ let package = Package(
                 .product(name: "TvManiac", package: "TvManiacFramework"),
             ]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/Library/Package.swift
+++ b/ios/Packages/Library/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -44,5 +44,6 @@ let package = Package(
             ],
             exclude: ["__Snapshots__"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/Models/Package.swift
+++ b/ios/Packages/Models/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -18,5 +18,6 @@ let package = Package(
         .target(
             name: "Models"
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/MoreShows/Package.swift
+++ b/ios/Packages/MoreShows/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -44,5 +44,6 @@ let package = Package(
             ],
             exclude: ["__Snapshots__"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/MyShows/Package.swift
+++ b/ios/Packages/MyShows/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -47,5 +47,6 @@ let package = Package(
             ],
             exclude: ["__Snapshots__"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/Profile/Package.swift
+++ b/ios/Packages/Profile/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -47,5 +47,6 @@ let package = Package(
             ],
             exclude: ["__Snapshots__"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/Progress/Package.swift
+++ b/ios/Packages/Progress/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -40,5 +40,6 @@ let package = Package(
             ],
             exclude: ["__Snapshots__"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/RatingSheet/Package.swift
+++ b/ios/Packages/RatingSheet/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -38,5 +38,6 @@ let package = Package(
             ],
             exclude: ["__Snapshots__"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/Root/Package.swift
+++ b/ios/Packages/Root/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -52,5 +52,6 @@ let package = Package(
                 .product(name: "TvManiac", package: "TvManiacFramework"),
             ]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/Search/Package.swift
+++ b/ios/Packages/Search/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -44,5 +44,6 @@ let package = Package(
             ],
             exclude: ["__Snapshots__"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/SeasonDetails/Package.swift
+++ b/ios/Packages/SeasonDetails/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -42,5 +42,6 @@ let package = Package(
             ],
             exclude: ["__Snapshots__"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/Settings/Package.swift
+++ b/ios/Packages/Settings/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -47,5 +47,6 @@ let package = Package(
             ],
             exclude: ["__Snapshots__"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/ShowDetails/Package.swift
+++ b/ios/Packages/ShowDetails/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -45,5 +45,6 @@ let package = Package(
             ],
             exclude: ["__Snapshots__"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/ShowList/Package.swift
+++ b/ios/Packages/ShowList/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -30,5 +30,6 @@ let package = Package(
                 "TvManiacKit",
             ]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/SnapshotTestingLib/Package.swift
+++ b/ios/Packages/SnapshotTestingLib/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -26,5 +26,6 @@ let package = Package(
                 "DesignSystem",
             ]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/TraktAuthKit/Package.swift
+++ b/ios/Packages/TraktAuthKit/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(
@@ -26,5 +26,6 @@ let package = Package(
             ],
             path: "Sources/TraktAuthKit"
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/TvManiacFramework/Package.swift
+++ b/ios/Packages/TvManiacFramework/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import Foundation
 import PackageDescription

--- a/ios/Packages/TvManiacKit/Package.swift
+++ b/ios/Packages/TvManiacKit/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -36,5 +36,6 @@ let package = Package(
                 .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
             ]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/ios/Packages/UpNext/Package.swift
+++ b/ios/Packages/UpNext/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -40,5 +40,6 @@ let package = Package(
             ],
             exclude: ["__Snapshots__"]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )


### PR DESCRIPTION
## Description
This PR moves all Swift packages in `ios/Packages/` to Swift tools version 6.0. Starting with this version, packages build in Swift 6 language mode by default, which enforces strict concurrency checks the codebase is not ready for yet. To keep everything building exactly as before, every package stays on the Swift 5 language mode through `swiftLanguageModes: [.v5]`, and no Swift source files change. When we are ready to adopt Swift 6, we can remove the pin from one package at a time and fix what the compiler reports.

## Changes
- Update `swift-tools-version` to 6.0 in all 27 package manifests
- Pin `swiftLanguageModes: [.v5]` in the 26 packages that build Swift code
- Update `TvManiacFramework` with the tools version only, since its single binary target builds no Swift code
