### PR TITLE
fix: Reduce idle CPU usage on the Discover screen

### DIFF
--- a/ios/Packages/Components/Sources/Components/CarouselView.swift
+++ b/ios/Packages/Components/Sources/Components/CarouselView.swift
@@ -102,7 +102,7 @@ public struct CarouselView<T, Content: View>: View {
     }
 
     private func setupAutoScroll() {
-        guard !items.isEmpty else { return }
+        guard items.count > 1 else { return }
         stopAutoScroll()
         let itemCount = items.count
         timerCancellable = Timer.publish(every: 5, on: .main, in: .common)

--- a/ios/Packages/Components/Sources/Components/CircularIndicator.swift
+++ b/ios/Packages/Components/Sources/Components/CircularIndicator.swift
@@ -48,7 +48,6 @@ public struct CircularIndicator: View {
                 }
             }
         }
-        .drawingGroup()
         .animation(nil, value: indicatorProgress)
         .animation(nil, value: currentIndex)
         .onChange(of: currentIndex) { _, newIndex in
@@ -158,22 +157,19 @@ public struct CircularIndicator: View {
     }
 
     private func resetAndStartProgress() {
+        guard totalItems > 1 else { return }
         progressTimer?.invalidate()
         progressTimer = nil
 
-        withAnimation(nil) {
-            indicatorProgress = 0
-        }
+        indicatorProgress = 0
 
         scheduleDelayedWork(delay: 0.05) {
             let startTime = Date()
-            progressTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { timer in
+            progressTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { timer in
                 let elapsed = Date().timeIntervalSince(startTime)
                 let progress = min(elapsed / 5.0, 1.0)
 
-                withAnimation(nil) {
-                    indicatorProgress = CGFloat(progress)
-                }
+                indicatorProgress = CGFloat(progress)
 
                 if progress >= 1.0 {
                     timer.invalidate()

--- a/ios/Packages/Components/Sources/Components/SyncProgressBar.swift
+++ b/ios/Packages/Components/Sources/Components/SyncProgressBar.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// through to the toolbar beneath it.
 public struct SyncProgressBar: View {
     @Environment(\.appTheme) private var theme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var animating = false
 
     private let height: CGFloat = 4
@@ -27,7 +28,7 @@ public struct SyncProgressBar: View {
                     .frame(width: segment)
                     .offset(x: animating ? width : -segment)
                     .animation(
-                        .easeInOut(duration: 1.1).repeatForever(autoreverses: false),
+                        reduceMotion ? nil : .easeInOut(duration: 1.1).repeatForever(autoreverses: false),
                         value: animating
                     )
             }

--- a/ios/Packages/CoreKit/Sources/CoreKit/ImageCacheManager.swift
+++ b/ios/Packages/CoreKit/Sources/CoreKit/ImageCacheManager.swift
@@ -15,9 +15,8 @@ import UIKit
 ///
 /// | Setting | Standard | Low Memory |
 /// |---|---|---|
-/// | Memory cache cost limit | 50 MB | 30 MB |
+/// | Memory cache cost limit | 100 MB | 50 MB |
 /// | Memory cache count limit | 50 | 30 |
-/// | Memory cache TTL | 120 s | 60 s |
 /// | Concurrent loads | 4 | 3 |
 /// | URL cache (memory) | 5 MB | 2 MB |
 public enum ImageCacheManager {
@@ -33,9 +32,8 @@ public enum ImageCacheManager {
 
         let imageCache = ImageCache()
         let isLowMem = SystemMemory.isLowMemoryDevice
-        imageCache.costLimit = isLowMem ? 30 * 1024 * 1024 : 50 * 1024 * 1024
+        imageCache.costLimit = isLowMem ? 50 * 1024 * 1024 : 100 * 1024 * 1024
         imageCache.countLimit = isLowMem ? 30 : 50
-        imageCache.ttl = isLowMem ? 60 : 120
         config.imageCache = imageCache
 
         config.isStoringPreviewsInMemoryCache = false

--- a/ios/Packages/Discover/Sources/Discover/DiscoverScreen.swift
+++ b/ios/Packages/Discover/Sources/Discover/DiscoverScreen.swift
@@ -100,13 +100,13 @@ public struct DiscoverScreen: View {
             .frame(height: 150)
             .allowsHitTesting(false)
 
-            if #available(iOS 18.0, *) {
+            if #available(iOS 18.0, *), pullOffset > 0 {
                 let progress = min(pullOffset / RefreshConstants.threshold, 1.0)
 
                 ProgressView()
                     .progressViewStyle(CircularProgressViewStyle(tint: appTheme.colors.onSurface))
                     .scaleEffect(2.0)
-                    .opacity(pullOffset > 0 ? max(0.6, Double(progress)) : 0)
+                    .opacity(max(0.6, Double(progress)))
                     .padding(.top, RefreshConstants.indicatorTopPadding)
                     .allowsHitTesting(false)
             }


### PR DESCRIPTION
## Description
This PR reduces the background work the Discover screen does while it sits idle. The image cache was too small to hold the featured header images, so the app loaded them again on every carousel turn, and the page indicator under the header redrew itself more often than the animation needed.

## Changes
- Increase the image cache size so the featured header images stay cached instead of reloading on every carousel turn.
- Update the page indicator to redraw less often and skip its progress timer when there is only one page.
- Stop the carousel auto-scroll when it has only one show.
- Show the pull-to-refresh spinner only while pulling. It used to stay in the screen invisibly and keep animating.
- Keep the sync progress bar still when Reduce Motion is turned on.