### PR TITLE
chore: Raise the iOS minimum deployment target to iOS 18

### DIFF
--- a/ios/Packages/Calendar/Package.swift
+++ b/ios/Packages/Calendar/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "Calendar",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/Components/Package.swift
+++ b/ios/Packages/Components/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "Components",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/CoreKit/Package.swift
+++ b/ios/Packages/CoreKit/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "CoreKit",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/Debug/Package.swift
+++ b/ios/Packages/Debug/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "Debug",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/DesignSystem/Package.swift
+++ b/ios/Packages/DesignSystem/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "DesignSystem",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/DesignSystem/Sources/DesignSystem/Styles/AppColorStyle.swift
+++ b/ios/Packages/DesignSystem/Sources/DesignSystem/Styles/AppColorStyle.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 public struct AppColorStyle: ShapeStyle {
-    private let keyPath: KeyPath<TvManiacColorScheme, Color>
+    private let keyPath: KeyPath<TvManiacColorScheme, Color> & Sendable
 
-    public init(_ keyPath: KeyPath<TvManiacColorScheme, Color>) {
+    public init(_ keyPath: KeyPath<TvManiacColorScheme, Color> & Sendable) {
         self.keyPath = keyPath
     }
 

--- a/ios/Packages/Discover/Package.swift
+++ b/ios/Packages/Discover/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "Discover",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/Discover/Sources/Discover/DiscoverScreen.swift
+++ b/ios/Packages/Discover/Sources/Discover/DiscoverScreen.swift
@@ -100,7 +100,7 @@ public struct DiscoverScreen: View {
             .frame(height: 150)
             .allowsHitTesting(false)
 
-            if #available(iOS 18.0, *), pullOffset > 0 {
+            if pullOffset > 0 {
                 let progress = min(pullOffset / RefreshConstants.threshold, 1.0)
 
                 ProgressView()
@@ -140,30 +140,25 @@ public struct DiscoverScreen: View {
         .toastView(toast: $toast)
     }
 
-    @ViewBuilder
     private var discoverScrollView: some View {
-        if #available(iOS 18.0, *) {
-            scrollViewContent
-                .onScrollGeometryChange(for: CGFloat.self) { geometry in
-                    geometry.contentOffset.y
-                } action: { _, newValue in
-                    if !isRefreshingLocal, isScrollInteracting {
-                        pullOffset = max(0, -newValue)
-                    }
+        scrollViewContent
+            .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                geometry.contentOffset.y
+            } action: { _, newValue in
+                if !isRefreshingLocal, isScrollInteracting {
+                    pullOffset = max(0, -newValue)
                 }
-                .onScrollPhaseChange { oldPhase, newPhase in
-                    isScrollInteracting = newPhase == .interacting
-                    if oldPhase == .interacting {
-                        if !isRefreshingLocal, pullOffset >= RefreshConstants.threshold {
-                            isRefreshingLocal = true
-                            onRefresh()
-                        }
-                        pullOffset = 0
+            }
+            .onScrollPhaseChange { oldPhase, newPhase in
+                isScrollInteracting = newPhase == .interacting
+                if oldPhase == .interacting {
+                    if !isRefreshingLocal, pullOffset >= RefreshConstants.threshold {
+                        isRefreshingLocal = true
+                        onRefresh()
                     }
+                    pullOffset = 0
                 }
-        } else {
-            scrollViewContent
-        }
+            }
     }
 
     private var scrollViewContent: some View {

--- a/ios/Packages/EpisodeDetail/Package.swift
+++ b/ios/Packages/EpisodeDetail/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "EpisodeDetail",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/FeatureFlags/Package.swift
+++ b/ios/Packages/FeatureFlags/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "FeatureFlags",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/Home/Package.swift
+++ b/ios/Packages/Home/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "Home",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/Home/Sources/Home/TabContentView.swift
+++ b/ios/Packages/Home/Sources/Home/TabContentView.swift
@@ -24,7 +24,7 @@ public struct TabContentView<Content: View>: View {
     public var body: some View {
         ZStack {
             if let child {
-                NavigationView {
+                NavigationStack {
                     content(child)
                         .id(ObjectIdentifier(child))
                 }

--- a/ios/Packages/Library/Package.swift
+++ b/ios/Packages/Library/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "Library",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/Models/Package.swift
+++ b/ios/Packages/Models/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "Models",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/MoreShows/Package.swift
+++ b/ios/Packages/MoreShows/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "MoreShows",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/MyShows/Package.swift
+++ b/ios/Packages/MyShows/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "MyShows",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/MyShows/Sources/MyShows/MyShowsTab.swift
+++ b/ios/Packages/MyShows/Sources/MyShows/MyShowsTab.swift
@@ -275,7 +275,7 @@ private extension ContinueWatchingState {
             staleGridItems: Array(staleItems).map {
                 MyShowsGridItem(
                     showId: $0.showId,
-                    title: $0.title ?? "",
+                    title: $0.title,
                     posterImageUrl: $0.posterImageUrl,
                     watchProgress: $0.watchProgress
                 )

--- a/ios/Packages/Profile/Package.swift
+++ b/ios/Packages/Profile/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "Profile",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/Progress/Package.swift
+++ b/ios/Packages/Progress/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "Progress",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/RatingSheet/Package.swift
+++ b/ios/Packages/RatingSheet/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "RatingSheet",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/Root/Package.swift
+++ b/ios/Packages/Root/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "Root",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/Search/Package.swift
+++ b/ios/Packages/Search/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "Search",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/SeasonDetails/Package.swift
+++ b/ios/Packages/SeasonDetails/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "SeasonDetails",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/Settings/Package.swift
+++ b/ios/Packages/Settings/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "Settings",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/Settings/Sources/Settings/SettingsView.swift
+++ b/ios/Packages/Settings/Sources/Settings/SettingsView.swift
@@ -519,7 +519,7 @@ public struct SettingsView: View {
             loginLabel: uiState.labels.login,
             providerName: providerDisplayName(uiState.activeProvider),
             providerLogoName: uiState.activeProvider?.name == "SIMKL" ? "SimklMono" : "TraktMono",
-            authProviders: uiState.authProviders.compactMap { $0 as? AuthProviderOption }.map { option in
+            authProviders: uiState.authProviders.map { option in
                 SwiftAuthProvider(
                     id: option.provider.name,
                     label: option.label,

--- a/ios/Packages/ShowDetails/Package.swift
+++ b/ios/Packages/ShowDetails/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "ShowDetails",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/ShowList/Package.swift
+++ b/ios/Packages/ShowList/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "ShowList",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/ShowList/Sources/ShowList/ShowListSheetView.swift
+++ b/ios/Packages/ShowList/Sources/ShowList/ShowListSheetView.swift
@@ -198,7 +198,7 @@ public struct ShowListSheetView: View {
             ProviderSignInCard(
                 title: state.labels.loginRequiredTitle,
                 description: state.labels.loginRequiredMessage,
-                providers: state.authProviders.compactMap { $0 as? AuthProviderOption }.map { option in
+                providers: state.authProviders.map { option in
                     SwiftAuthProvider(
                         id: option.provider.name,
                         label: option.label,

--- a/ios/Packages/SnapshotTestingLib/Package.swift
+++ b/ios/Packages/SnapshotTestingLib/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "SnapshotTestingLib",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/TraktAuthKit/Package.swift
+++ b/ios/Packages/TraktAuthKit/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "TraktAuthKit",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/TvManiacFramework/Package.swift
+++ b/ios/Packages/TvManiacFramework/Package.swift
@@ -35,7 +35,7 @@ guard FileManager.default.fileExists(atPath: frameworkPath) else {
 let package = Package(
     name: "TvManiacFramework",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/TvManiacKit/Package.swift
+++ b/ios/Packages/TvManiacKit/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "TvManiacKit",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/Packages/UpNext/Package.swift
+++ b/ios/Packages/UpNext/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "UpNext",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v18),
     ],
     products: [
         .library(

--- a/ios/tv-maniac.xcodeproj/project.pbxproj
+++ b/ios/tv-maniac.xcodeproj/project.pbxproj
@@ -347,7 +347,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -415,7 +415,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -450,7 +450,7 @@
 				INFOPLIST_FILE = ios/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = TvManiac;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -491,7 +491,7 @@
 				INFOPLIST_FILE = ios/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = TvManiac;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
## Description
This PR raises the minimum iOS version the app supports from iOS 17 to iOS 18. Both versions run on the same devices, so no phone loses support, and pull to refresh on the Discover screen now works for every user instead of only those on iOS 18.

## Changes
- Update the Xcode project and all Swift package manifests to require iOS 18
- Remove the iOS version checks on the Discover screen so pull to refresh and scroll tracking always run
- Replace the deprecated NavigationView with NavigationStack in the tab content view
- Fix a Swift 6 concurrency warning in the design system color style
- Remove redundant type casts in the Settings and show list screens