### PR TITLE
chore: Remove the compilation cache from the iOS snapshot test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,28 +332,8 @@ jobs:
                     restore-keys: |
                         ${{ runner.os }}-snapshot-derived-data-
 
-            -   name: 🗂️ Restore Compilation Cache
-                id: compilation-cache
-                uses: actions/cache/restore@v6
-                with:
-                    path: compilation_cache
-                    key: ${{ runner.os }}-xcode-cas-snapshot-${{ env.XCODE_VERSION }}-${{ github.sha }}
-                    restore-keys: |
-                        ${{ runner.os }}-xcode-cas-snapshot-${{ env.XCODE_VERSION }}-
-
             -   name: 📸 Run Snapshot Tests
                 run: bundle exec fastlane snapshot_tests
-
-            -   name: 📏 Compilation cache size
-                if: ${{ !cancelled() }}
-                run: du -sh compilation_cache || true
-
-            -   name: 🗂️ Save Compilation Cache
-                if: github.ref == 'refs/heads/main' && steps.compilation-cache.outputs.cache-hit != 'true'
-                uses: actions/cache/save@v6
-                with:
-                    path: compilation_cache
-                    key: ${{ runner.os }}-xcode-cas-snapshot-${{ env.XCODE_VERSION }}-${{ github.sha }}
 
             -   name: 🗂️ Save DerivedData
                 if: github.ref == 'refs/heads/main' && steps.derived-data.outputs.cache-hit != 'true'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -46,7 +46,7 @@ platform :ios do
       destination: TEST_DESTINATION,
       skip_detect_devices: true,
       build_for_testing: true,
-      xcargs: "COMPILATION_CACHE_CAS_PATH=#{COMPILATION_CACHE_PATH} COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS=YES -skipPackagePluginValidation",
+      xcargs: "-skipPackagePluginValidation",
       xcodebuild_formatter: "",
       derived_data_path: DERIVED_DATA_PATH
     )


### PR DESCRIPTION
## Description
This PR removes the compilation cache from the iOS snapshot test job. That job already restores a DerivedData cache, so its build stays incremental and the compilation cache never has anything to store. The iOS app build keeps its compilation cache, where it makes the build faster.

## Changes
- Remove the compilation cache restore, size, and save steps from the snapshot test job on CI
- Stop passing the compilation cache path to the snapshot test lane
