### PR TITLE
chore: Commit the baseline profile the scheduled job creates

### DIFF
--- a/.github/workflows/baseline-profile.yml
+++ b/.github/workflows/baseline-profile.yml
@@ -43,7 +43,7 @@ jobs:
         uses: android-actions/setup-android@v4
 
       - name: Accept licenses
-        run: yes | sdkmanager --licenses || trueMovr
+        run: yes | sdkmanager --licenses || true
 
       - name: Build app and benchmark
         run: ./gradlew assembleNonMinifiedRelease -Papp.debugOnly=false

--- a/.github/workflows/baseline-profile.yml
+++ b/.github/workflows/baseline-profile.yml
@@ -3,6 +3,7 @@ name: Weekly Baseline Profile Generation
 on:
   schedule:
     - cron: '30 0 * * 0,3,5' #Every Sunday, Wednesday, and Friday at 12:30AM
+  workflow_dispatch:
 
 env:
   TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}

--- a/.github/workflows/baseline-profile.yml
+++ b/.github/workflows/baseline-profile.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Open a pull request with the new profile
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.GH_COMMIT_PAT }}
           add-paths: app/src/main/generated/baselineProfiles
           branch: baseline-profile-update
           delete-branch: true

--- a/.github/workflows/baseline-profile.yml
+++ b/.github/workflows/baseline-profile.yml
@@ -21,6 +21,7 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: write
 
     timeout-minutes: 60
 
@@ -59,4 +60,18 @@ jobs:
           -Pandroid.experimental.androidTest.numManagedDeviceShards=1
           --no-configuration-cache
 
-      ## ToDo: Commit baseline profile changes to main.
+      - name: Open a pull request with the new profile
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          add-paths: app/src/main/generated/baselineProfiles
+          branch: baseline-profile-update
+          delete-branch: true
+          commit-message: Update the generated baseline profile
+          title: 'chore: Update the generated baseline profile'
+          body: |
+            ## Description
+            This PR brings in the baseline profile that the scheduled job just generated.
+
+            ## Changes
+            - Update the baseline profile files under `app/src/main/generated/baselineProfiles`


### PR DESCRIPTION
## Description
This PR makes the scheduled baseline profile job open a pull request with the profile it creates. The job already builds the app and creates a new profile on a schedule, but nothing saved the result, so the app kept shipping with the profile that someone last checked in by hand. The job now commits the new files and opens a pull request for review.

## Changes
- Add a step that commits the generated baseline profile and opens a pull request against main
- Allow the job to be started by hand from the Actions tab

## Bug Fixes
- Correct the step that accepts the Android licenses so a failure there no longer stops the whole job
