### PR TITLE
refactor: Share every test stub registration across platforms

### DIFF
--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/calendar/CalendarFlowTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/calendar/CalendarFlowTest.kt
@@ -2,7 +2,7 @@ package com.thomaskioko.tvmaniac.app.test.compose.flows.calendar
 
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.app.test.BaseAppFlowTest
-import com.thomaskioko.tvmaniac.app.test.compose.stubs.TEST_NEXT_WEEK
+import com.thomaskioko.tvmaniac.testing.integration.TEST_NEXT_WEEK
 import com.thomaskioko.tvmaniac.testtags.home.HomeTestTags
 import com.thomaskioko.tvmaniac.util.testing.FlakyTests
 import org.junit.Test

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/userlists/UserListFlowTests.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/userlists/UserListFlowTests.kt
@@ -2,8 +2,8 @@ package com.thomaskioko.tvmaniac.app.test.compose.flows.userlists
 
 import com.thomaskioko.tvmaniac.app.test.AppFlowScope
 import com.thomaskioko.tvmaniac.app.test.BaseAppFlowTest
-import com.thomaskioko.tvmaniac.app.test.compose.stubs.TEST_CREATED_LIST_NAME
-import com.thomaskioko.tvmaniac.app.test.compose.stubs.TEST_CREATED_LIST_TRAKT_ID
+import com.thomaskioko.tvmaniac.testing.integration.TEST_CREATED_LIST_NAME
+import com.thomaskioko.tvmaniac.testing.integration.TEST_CREATED_LIST_TRAKT_ID
 import com.thomaskioko.tvmaniac.testtags.home.HomeTestTags
 import org.junit.Test
 

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/journey/AuthenticatedUserJourneyTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/journey/AuthenticatedUserJourneyTest.kt
@@ -1,8 +1,8 @@
 package com.thomaskioko.tvmaniac.app.test.compose.journey
 
 import com.thomaskioko.tvmaniac.app.test.BaseAppFlowTest
-import com.thomaskioko.tvmaniac.app.test.compose.stubs.TEST_PROFILE_SLUG
 import com.thomaskioko.tvmaniac.presentation.episodedetail.EpisodeSheetActionItem
+import com.thomaskioko.tvmaniac.testing.integration.TEST_PROFILE_SLUG
 import com.thomaskioko.tvmaniac.testtags.home.HomeTestTags
 import com.thomaskioko.tvmaniac.testtags.notifications.NotificationRationaleTestTags
 import org.junit.Test

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/journey/SyncProviderSourceSwitchJourneyTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/journey/SyncProviderSourceSwitchJourneyTest.kt
@@ -2,8 +2,8 @@ package com.thomaskioko.tvmaniac.app.test.compose.journey
 
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.app.test.BaseAppFlowTest
-import com.thomaskioko.tvmaniac.app.test.compose.stubs.TEST_PROFILE_SLUG
 import com.thomaskioko.tvmaniac.app.test.compose.stubs.TEST_SIMKL_ACCOUNT_ID
+import com.thomaskioko.tvmaniac.testing.integration.TEST_PROFILE_SLUG
 import com.thomaskioko.tvmaniac.testtags.home.HomeTestTags
 import com.thomaskioko.tvmaniac.util.testing.FlakyTests
 import org.junit.Test

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
@@ -6,16 +6,10 @@ import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.accountmanager.api.TokenRefreshResult
 import com.thomaskioko.tvmaniac.app.test.TestAppComponent
 import com.thomaskioko.tvmaniac.app.test.compose.robot.RootRobot
-import com.thomaskioko.tvmaniac.testing.integration.EMPTY_ARRAY_FIXTURE
-import com.thomaskioko.tvmaniac.testing.integration.Endpoint
-import com.thomaskioko.tvmaniac.testing.integration.Endpoints
+import com.thomaskioko.tvmaniac.testing.integration.HttpScenarios
 import com.thomaskioko.tvmaniac.testing.integration.MockEngineHandler
-import com.thomaskioko.tvmaniac.testing.integration.showFixtures
-import com.thomaskioko.tvmaniac.testing.integration.stubEndpoint
-import com.thomaskioko.tvmaniac.testing.integration.stubSearchByQuery
-import com.thomaskioko.tvmaniac.testing.integration.stubShow
-import com.thomaskioko.tvmaniac.testing.integration.util.FixtureLoader
-import io.ktor.http.HttpMethod
+import com.thomaskioko.tvmaniac.testing.integration.TEST_PROFILE_SLUG
+import com.thomaskioko.tvmaniac.testing.integration.TEST_TODAY
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.runBlocking
 import kotlin.time.Clock
@@ -23,26 +17,24 @@ import kotlin.time.Duration.Companion.seconds
 
 internal const val TEST_ACCESS_TOKEN: String = "test-access"
 internal const val TEST_REFRESH_TOKEN: String = "test-refresh"
-internal const val TEST_PROFILE_SLUG: String = "integration-test-user"
-internal const val TEST_TODAY: String = "2026-04-19"
 internal const val TEST_SIMKL_USER_NAME: String = "simkl-test-user"
 internal const val TEST_SIMKL_ACCOUNT_ID: Long = 12345678L
-
-/** Trakt id of the list returned by `trakt/users/lists/create/success.json`. */
-internal const val TEST_CREATED_LIST_TRAKT_ID: Long = 99887766L
-
-/** Name of the list returned by `trakt/users/lists/create/success.json`. */
-internal const val TEST_CREATED_LIST_NAME: String = "Watch Later"
-internal const val TEST_NEXT_WEEK: String = "2026-04-26"
 internal const val SIMKL_LOGIN_FLAG_KEY: String = "simkl_login_enabled"
 internal const val ACCOUNT_SWITCH_FLAG_KEY: String = "enable_account_switch"
 internal const val ENABLE_PAYWALL_FLAG_KEY: String = "enable_paywall"
 
+/**
+ * Android's view of the test backend. Every purely HTTP registration lives in [HttpScenarios] so
+ * the JVM and iOS answer requests from the same saved responses; what stays here is the part
+ * XCUITest could never reach anyway, namely mutating graph fakes and driving the UI.
+ */
 internal class Scenarios(
-    private val mockHandler: MockEngineHandler,
+    mockHandler: MockEngineHandler,
     private val graph: TestAppComponent,
     private val rootRobot: RootRobot,
 ) {
+    private val http: HttpScenarios = HttpScenarios(mockHandler)
+
     val auth: Auth = Auth()
     val discover: Discover = Discover()
     val simkl: Simkl = Simkl()
@@ -140,12 +132,11 @@ internal class Scenarios(
     }
 
     /**
-     * Wires the given [SyncProviderSource]'s baseline authenticated session: sign-in state, plus its
-     * catalog-declared [Endpoints.Trakt.authenticatedEndpoints] / [Endpoints.Simkl.authenticatedEndpoints]
-     * in one shared loop. Host-aware matching in [MockEngineHandler] means this is safe to call
-     * once per test alongside [stubPublicCatalog]; call sites don't need to know which provider
-     * owns which path. A cross-provider account endpoint is added to those catalog lists, not to
-     * a new branch here.
+     * Wires the given [SyncProviderSource]'s baseline authenticated session: sign-in state, plus
+     * its catalog-declared endpoints. Host-aware matching in [MockEngineHandler] means this is
+     * safe to call once per test alongside [stubPublicCatalog]; call sites don't need to know
+     * which provider owns which path. A cross-provider account endpoint is added to the catalog
+     * lists in `Endpoints`, not to a new branch here.
      *
      * Always pair this with [stubPublicCatalog]: it is the only source of TMDB/discover coverage
      * for either provider.
@@ -154,45 +145,22 @@ internal class Scenarios(
         when (provider) {
             SyncProviderSource.TRAKT -> {
                 stubLoggedInUser(SyncProviderSource.TRAKT)
-                val endpoints = Endpoints.Trakt.authenticatedEndpoints + listOf(
-                    Endpoints.Trakt.userStats(TEST_PROFILE_SLUG),
-                    Endpoints.Trakt.userLists(TEST_PROFILE_SLUG),
-                    Endpoints.Trakt.calendar(TEST_TODAY, 7),
-                    Endpoints.Trakt.calendar(TEST_NEXT_WEEK, 7),
-                )
-                endpoints.forEach { mockHandler.stubEndpoint(it) }
-
-                // Shared empty-array fixture, not tied to one catalog entry, so it isn't a
-                // plain Endpoint. Kept as explicit glue, mirroring the seasons catch-all in
-                // Discover.stubBrowseGraph.
-                mockHandler.stubPatternFixture(
-                    pathRegex = "/users/me/history/shows/\\d+",
-                    fixturePath = EMPTY_ARRAY_FIXTURE,
-                )
-
-                val watchedShows = FixtureLoader.load(Endpoints.Trakt.SyncWatchedShows.successFixture)
-                showFixtures(watchedShows).forEach { mockHandler.stubShow(it) }
-                val nitroShows = FixtureLoader.load(Endpoints.Trakt.SyncProgressUpNextNitro.successFixture)
-                showFixtures(nitroShows).forEach { mockHandler.stubShow(it) }
+                http.stubTraktAuthenticatedEndpoints()
             }
             SyncProviderSource.SIMKL -> {
                 flags.enableSimklLogin()
-                Endpoints.Simkl.authenticatedEndpoints.forEach { mockHandler.stubEndpoint(it) }
+                http.stubSimklAuthenticatedEndpoints()
                 // Sign in LAST (see TRAKT note) so login-triggered sync finds its stubs.
                 stubLoggedInUser(SyncProviderSource.SIMKL)
             }
         }
     }
 
-    /** Fake authentication endpoint used to detect a signed-in account, per provider. */
-    private fun userEndpoint(provider: SyncProviderSource): Endpoint.Exact =
-        when (provider) {
-            SyncProviderSource.TRAKT -> Endpoints.Trakt.UsersMe
-            SyncProviderSource.SIMKL -> Endpoints.Simkl.UsersSettings
-        }
-
     fun stubUsersMeUnauthorized(provider: SyncProviderSource = SyncProviderSource.TRAKT) {
-        mockHandler.stubEndpoint(userEndpoint(provider), HttpStatusCode.Unauthorized)
+        when (provider) {
+            SyncProviderSource.TRAKT -> http.stubTraktUsersMeUnauthorized()
+            SyncProviderSource.SIMKL -> http.stubSimklUserSettingsUnauthorized()
+        }
     }
 
     /**
@@ -229,7 +197,7 @@ internal class Scenarios(
 
     fun stubUnauthenticatedState(provider: SyncProviderSource = SyncProviderSource.TRAKT) {
         stubPublicCatalog()
-        mockHandler.stubEndpoint(userEndpoint(provider), HttpStatusCode.Unauthorized)
+        stubUsersMeUnauthorized(provider)
     }
 
     /**
@@ -255,7 +223,6 @@ internal class Scenarios(
     ) {
         when (provider) {
             SyncProviderSource.TRAKT -> {
-                mockHandler.stubEndpoint(Endpoints.Trakt.UsersMe, HttpStatusCode.Unauthorized)
                 val refreshedAuthState = AuthState(
                     accessToken = accessToken,
                     refreshToken = refreshToken,
@@ -264,10 +231,7 @@ internal class Scenarios(
                     tokenLifetimeSeconds = tokenLifetimeSeconds,
                 )
                 graph.traktAuthRepository.setRefreshOutcome(TokenRefreshResult.Success(refreshedAuthState))
-                mockHandler.stubEndpoint(Endpoints.Trakt.UsersMe)
-                mockHandler.stubEndpoint(Endpoints.Trakt.userStats(TEST_PROFILE_SLUG))
-                mockHandler.stubEndpoint(Endpoints.Trakt.userLists(TEST_PROFILE_SLUG))
-                mockHandler.stubEndpoint(Endpoints.Trakt.UserListItems)
+                http.stubTraktTokenRefreshEndpoints()
             }
             SyncProviderSource.SIMKL -> error(
                 "Simkl token refresh is not stubbed yet; add it when a Simkl refresh journey exists.",
@@ -315,88 +279,25 @@ internal class Scenarios(
             }
         }
 
-        fun stubProfileEndpoints() {
-            mockHandler.stubEndpoint(
-                endpoint = Endpoints.Simkl.UsersSettings,
-                method = HttpMethod.Post,
-            )
-            mockHandler.stubEndpoint(
-                endpoint = Endpoints.Simkl.UsersStats,
-                method = HttpMethod.Post,
-            )
-        }
+        fun stubProfileEndpoints(): Unit = http.stubSimklProfileEndpoints()
 
-        fun stubWatchedHistoryEndpoints() {
-            mockHandler.stubEndpoint(Endpoints.Simkl.SyncAllItems)
-        }
+        fun stubWatchedHistoryEndpoints(): Unit = http.stubSimklWatchedHistory()
 
-        fun stubPlanToWatchWatchlist() {
-            mockHandler.stubFixture(
-                path = Endpoints.Simkl.SyncAllItems.path,
-                fixturePath = "simkl/sync/all-items/start_watching.json",
-            )
-        }
+        fun stubPlanToWatchWatchlist(): Unit = http.stubSimklPlanToWatchWatchlist()
 
-        fun stubActivities() {
-            mockHandler.stubEndpoint(Endpoints.Simkl.SyncActivities)
-        }
+        fun stubActivities(): Unit = http.stubSimklActivities()
     }
 
     inner class Discover {
-        /**
-         * Stubs the agnostic public data graph reachable from the Discover surface, independent
-         * of login state: the Trakt and TMDB list endpoints, plus the per-show graph (details,
-         * seasons, episodes, people, related, videos, TMDB show, credits, season, watch
-         * providers). Account-specific endpoints (e.g. watched progress, watch history) are
-         * stubbed by [stubActiveProvider], not here.
-         */
-        fun stubBrowseGraph() {
-            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowsFavoritedWeekly)
-            mockHandler.stubEndpoint(Endpoints.PublicCatalog.GenresShows)
-            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowsTrending)
-            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowsPopular)
-            mockHandler.stubEndpoint(Endpoints.Tmdb.DiscoverTv)
-            mockHandler.stubEndpoint(Endpoints.PublicCatalog.SearchByTmdb)
-
-            // Per-show public-catalog endpoints — single canonical fixture for any trakt id.
-            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowDetails)
-            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowSeasons)
-            // Per-season episodes: catch-all returns empty so unstubbed seasons don't re-write
-            // episode rows. The per-season stubs registered after win under last-registered-first-match
-            // ordering. (Catalog has no entry for the catch-all because the empty-array fixture is
-            // shared across endpoints and isn't tied to one resource folder.)
-            mockHandler.stubPatternFixture(pathRegex = "/shows/\\d+/seasons/\\d+", fixturePath = "empty_array.json")
-            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowSeasonEpisodesS1)
-            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowSeasonEpisodesS2)
-            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowPeople)
-            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowRelated)
-            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowVideos)
-
-            // Per-show TMDB endpoints — single canonical fixture for any tmdb id.
-            mockHandler.stubEndpoint(Endpoints.Tmdb.ShowDetails)
-            mockHandler.stubEndpoint(Endpoints.Tmdb.Credits)
-            // Per-season episodes: catch-all returns empty so unstubbed seasons don't re-write
-            // episode rows. The per-season stubs registered after win under last-registered-first-match
-            // ordering.
-            mockHandler.stubEndpoint(Endpoints.Tmdb.SeasonDetails)
-            mockHandler.stubEndpoint(Endpoints.Tmdb.SeasonDetailsS1)
-            mockHandler.stubEndpoint(Endpoints.Tmdb.SeasonDetailsS2)
-            mockHandler.stubEndpoint(Endpoints.Tmdb.WatchProviders)
-        }
+        fun stubBrowseGraph(): Unit = http.stubBrowseGraph()
     }
 
     inner class Search {
-        fun stubSearch(query: String) {
-            mockHandler.stubSearchByQuery(query)
-        }
+        fun stubSearch(query: String): Unit = http.stubSearch(query)
 
-        fun stubEmptySearch() {
-            mockHandler.stubFixture(path = Endpoints.PublicCatalog.Search.path, fixturePath = EMPTY_ARRAY_FIXTURE)
-        }
+        fun stubEmptySearch(): Unit = http.stubEmptySearch()
 
-        fun stubSearchError(query: String) {
-            mockHandler.stubSearchByQuery(query, HttpStatusCode.Forbidden)
-        }
+        fun stubSearchError(query: String): Unit = http.stubSearchError(query)
     }
 
     inner class UpNext {
@@ -405,25 +306,22 @@ internal class Scenarios(
             provider: SyncProviderSource = SyncProviderSource.TRAKT,
         ) {
             when (provider) {
-                SyncProviderSource.TRAKT -> mockHandler.stubEndpoint(Endpoints.Trakt.SyncHistory, method = HttpMethod.Post)
-                SyncProviderSource.SIMKL -> mockHandler.stubEndpoint(Endpoints.Simkl.SyncHistory, method = HttpMethod.Post)
+                SyncProviderSource.TRAKT -> http.stubTraktSyncHistoryPost()
+                SyncProviderSource.SIMKL -> http.stubSimklSyncHistoryPost()
             }
         }
     }
 
     inner class Calendar {
-        private fun endpoint(provider: SyncProviderSource, weekStart: String, days: Int): Endpoint.Exact =
-            when (provider) {
-                SyncProviderSource.TRAKT -> Endpoints.Trakt.calendar(weekStart, days)
-                SyncProviderSource.SIMKL -> Endpoints.Simkl.CalendarTvFeed
-            }
-
         fun stubWeek(
             provider: SyncProviderSource = SyncProviderSource.TRAKT,
             weekStart: String = TEST_TODAY,
             days: Int = 7,
         ) {
-            mockHandler.stubEndpoint(endpoint(provider, weekStart, days))
+            when (provider) {
+                SyncProviderSource.TRAKT -> http.stubTraktCalendarWeek(weekStart, days)
+                SyncProviderSource.SIMKL -> http.stubSimklCalendarFeed()
+            }
         }
 
         fun stubEmptyWeek(
@@ -431,12 +329,10 @@ internal class Scenarios(
             weekStart: String = TEST_TODAY,
             days: Int = 7,
         ) {
-            val calendar = endpoint(provider, weekStart, days)
-            mockHandler.stubFixture(
-                path = calendar.path,
-                fixturePath = EMPTY_ARRAY_FIXTURE,
-                host = calendar.host,
-            )
+            when (provider) {
+                SyncProviderSource.TRAKT -> http.stubTraktCalendarWeekEmpty(weekStart, days)
+                SyncProviderSource.SIMKL -> http.stubSimklCalendarFeedEmpty()
+            }
         }
 
         fun stubWeekError(
@@ -445,55 +341,31 @@ internal class Scenarios(
             days: Int = 7,
             status: Int = 404,
         ) {
-            mockHandler.stubEndpoint(endpoint(provider, weekStart, days), HttpStatusCode.fromValue(status))
+            val code = HttpStatusCode.fromValue(status)
+            when (provider) {
+                SyncProviderSource.TRAKT -> http.stubTraktCalendarWeekError(weekStart, days, code)
+                SyncProviderSource.SIMKL -> http.stubSimklCalendarFeedError(code)
+            }
         }
     }
 
     inner class Library {
-        fun stubLibrarySyncEndpoints() {
-            mockHandler.stubEndpoint(Endpoints.Trakt.SyncLastActivities)
-            mockHandler.stubEndpoint(Endpoints.Trakt.SyncWatchedShows)
-            mockHandler.stubEndpoint(Endpoints.Trakt.UsersMeWatchlistShows)
-            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowDetails)
-            mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowSeasons)
-            mockHandler.stubEndpoint(Endpoints.Tmdb.ShowDetails)
-            mockHandler.stubEndpoint(Endpoints.Tmdb.WatchProviders)
-
-            val watchedShows = FixtureLoader.load(Endpoints.Trakt.SyncWatchedShows.successFixture)
-            showFixtures(watchedShows).forEach { mockHandler.stubShow(it) }
-        }
+        fun stubLibrarySyncEndpoints(): Unit = http.stubTraktLibrarySync()
     }
 
     inner class Watchlist {
-        fun stubWatchlistSyncEndpoints() {
-            mockHandler.stubEndpoint(Endpoints.Trakt.SyncProgressUpNextNitro)
-            mockHandler.stubEndpoint(Endpoints.Trakt.SyncPlaybackEpisodes)
-            mockHandler.stubEndpoint(Endpoints.Trakt.SyncWatchedShows)
-            mockHandler.stubEndpoint(Endpoints.Trakt.ShowProgressWatched)
-            mockHandler.stubEndpoint(Endpoints.Trakt.UsersHiddenProgressWatched)
-
-            val nitroShows = FixtureLoader.load(Endpoints.Trakt.SyncProgressUpNextNitro.successFixture)
-            showFixtures(nitroShows).forEach { mockHandler.stubShow(it) }
-        }
+        fun stubWatchlistSyncEndpoints(): Unit = http.stubTraktWatchlistSync()
     }
 
     inner class Profile {
-        fun stubProfileSyncEndpoints(slug: String = TEST_PROFILE_SLUG) {
-            mockHandler.stubEndpoint(Endpoints.Trakt.UsersMe)
-            mockHandler.stubEndpoint(Endpoints.Trakt.userStats(slug))
-            mockHandler.stubEndpoint(Endpoints.Trakt.userLists(slug))
-            mockHandler.stubEndpoint(Endpoints.Trakt.UserListItems)
-        }
+        fun stubProfileSyncEndpoints(slug: String = TEST_PROFILE_SLUG): Unit = http.stubTraktProfileSync(slug)
     }
 
     inner class TraktLists {
-        fun stubAddShowToList(listId: Long, slug: String = TEST_PROFILE_SLUG) {
-            mockHandler.stubEndpoint(Endpoints.Trakt.addShowToList(slug, listId), method = HttpMethod.Post)
-        }
+        fun stubAddShowToList(listId: Long, slug: String = TEST_PROFILE_SLUG): Unit =
+            http.stubTraktAddShowToList(listId, slug)
 
-        fun stubCreateList(slug: String = TEST_PROFILE_SLUG) {
-            mockHandler.stubEndpoint(Endpoints.Trakt.createList(slug), method = HttpMethod.Post)
-        }
+        fun stubCreateList(slug: String = TEST_PROFILE_SLUG): Unit = http.stubTraktCreateList(slug)
     }
 
     inner class Flags {

--- a/core/integration/stubs/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/HttpScenarios.kt
+++ b/core/integration/stubs/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/HttpScenarios.kt
@@ -1,0 +1,229 @@
+package com.thomaskioko.tvmaniac.testing.integration
+
+import com.thomaskioko.tvmaniac.testing.integration.util.FixtureLoader
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+
+public const val TEST_PROFILE_SLUG: String = "integration-test-user"
+public const val TEST_TODAY: String = "2026-04-19"
+public const val TEST_NEXT_WEEK: String = "2026-04-26"
+
+/** Trakt id of the list returned by `trakt/users/lists/create/success.json`. */
+public const val TEST_CREATED_LIST_TRAKT_ID: Long = 99887766L
+
+/** Name of the list returned by `trakt/users/lists/create/success.json`. */
+public const val TEST_CREATED_LIST_NAME: String = "Watch Later"
+
+/**
+ * Every stub registration that is purely HTTP, so Android, the JVM and iOS answer test requests
+ * from one set of saved responses instead of three different backends.
+ *
+ * Methods name their provider rather than taking a `SyncProviderSource`. That keeps this module
+ * free of project dependencies, which matters because `ios-framework` has to depend on it and
+ * `data/account-manager/api` would pull SQLDelight along with the enum. Callers that already hold
+ * a provider value do the branch themselves.
+ *
+ * Anything that mutates a dependency graph fake, drives the UI, or seeds credentials stays with
+ * the caller; this class only ever touches [mockHandler].
+ */
+public class HttpScenarios(private val mockHandler: MockEngineHandler) {
+
+    /**
+     * Public data reachable from Discover regardless of login state: the Trakt and TMDB list
+     * endpoints plus the per-show graph. Account-specific endpoints belong to the authenticated
+     * methods below, not here.
+     */
+    public fun stubBrowseGraph() {
+        mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowsFavoritedWeekly)
+        mockHandler.stubEndpoint(Endpoints.PublicCatalog.GenresShows)
+        mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowsTrending)
+        mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowsPopular)
+        mockHandler.stubEndpoint(Endpoints.Tmdb.DiscoverTv)
+        mockHandler.stubEndpoint(Endpoints.PublicCatalog.SearchByTmdb)
+
+        // Per-show public-catalog endpoints — single canonical fixture for any trakt id.
+        mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowDetails)
+        mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowSeasons)
+        // Per-season episodes: catch-all returns empty so unstubbed seasons don't re-write
+        // episode rows. The per-season stubs registered after win under last-registered-first-match
+        // ordering. (Catalog has no entry for the catch-all because the empty-array fixture is
+        // shared across endpoints and isn't tied to one resource folder.)
+        mockHandler.stubPatternFixture(pathRegex = "/shows/\\d+/seasons/\\d+", fixturePath = "empty_array.json")
+        mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowSeasonEpisodesS1)
+        mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowSeasonEpisodesS2)
+        mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowPeople)
+        mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowRelated)
+        mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowVideos)
+
+        // Per-show TMDB endpoints — single canonical fixture for any tmdb id.
+        mockHandler.stubEndpoint(Endpoints.Tmdb.ShowDetails)
+        mockHandler.stubEndpoint(Endpoints.Tmdb.Credits)
+        mockHandler.stubEndpoint(Endpoints.Tmdb.SeasonDetails)
+        mockHandler.stubEndpoint(Endpoints.Tmdb.SeasonDetailsS1)
+        mockHandler.stubEndpoint(Endpoints.Tmdb.SeasonDetailsS2)
+        mockHandler.stubEndpoint(Endpoints.Tmdb.WatchProviders)
+    }
+
+    public fun stubSearch(query: String) {
+        mockHandler.stubSearchByQuery(query)
+    }
+
+    public fun stubEmptySearch() {
+        mockHandler.stubFixture(path = Endpoints.PublicCatalog.Search.path, fixturePath = EMPTY_ARRAY_FIXTURE)
+    }
+
+    public fun stubSearchError(query: String) {
+        mockHandler.stubSearchByQuery(query, HttpStatusCode.Forbidden)
+    }
+
+    public fun stubTraktSyncHistoryPost() {
+        mockHandler.stubEndpoint(Endpoints.Trakt.SyncHistory, method = HttpMethod.Post)
+    }
+
+    public fun stubSimklSyncHistoryPost() {
+        mockHandler.stubEndpoint(Endpoints.Simkl.SyncHistory, method = HttpMethod.Post)
+    }
+
+    public fun stubTraktCalendarWeek(weekStart: String = TEST_TODAY, days: Int = 7) {
+        mockHandler.stubEndpoint(Endpoints.Trakt.calendar(weekStart, days))
+    }
+
+    public fun stubTraktCalendarWeekEmpty(weekStart: String = TEST_TODAY, days: Int = 7) {
+        val calendar = Endpoints.Trakt.calendar(weekStart, days)
+        mockHandler.stubFixture(path = calendar.path, fixturePath = EMPTY_ARRAY_FIXTURE, host = calendar.host)
+    }
+
+    public fun stubTraktCalendarWeekError(
+        weekStart: String = TEST_TODAY,
+        days: Int = 7,
+        status: HttpStatusCode = HttpStatusCode.NotFound,
+    ) {
+        mockHandler.stubEndpoint(Endpoints.Trakt.calendar(weekStart, days), status)
+    }
+
+    public fun stubSimklCalendarFeed() {
+        mockHandler.stubEndpoint(Endpoints.Simkl.CalendarTvFeed)
+    }
+
+    public fun stubSimklCalendarFeedEmpty() {
+        val calendar = Endpoints.Simkl.CalendarTvFeed
+        mockHandler.stubFixture(path = calendar.path, fixturePath = EMPTY_ARRAY_FIXTURE, host = calendar.host)
+    }
+
+    public fun stubSimklCalendarFeedError(status: HttpStatusCode = HttpStatusCode.NotFound) {
+        mockHandler.stubEndpoint(Endpoints.Simkl.CalendarTvFeed, status)
+    }
+
+    public fun stubTraktLibrarySync() {
+        mockHandler.stubEndpoint(Endpoints.Trakt.SyncLastActivities)
+        mockHandler.stubEndpoint(Endpoints.Trakt.SyncWatchedShows)
+        mockHandler.stubEndpoint(Endpoints.Trakt.UsersMeWatchlistShows)
+        mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowDetails)
+        mockHandler.stubEndpoint(Endpoints.PublicCatalog.ShowSeasons)
+        mockHandler.stubEndpoint(Endpoints.Tmdb.ShowDetails)
+        mockHandler.stubEndpoint(Endpoints.Tmdb.WatchProviders)
+
+        stubShowsFrom(Endpoints.Trakt.SyncWatchedShows.successFixture)
+    }
+
+    public fun stubTraktWatchlistSync() {
+        mockHandler.stubEndpoint(Endpoints.Trakt.SyncProgressUpNextNitro)
+        mockHandler.stubEndpoint(Endpoints.Trakt.SyncPlaybackEpisodes)
+        mockHandler.stubEndpoint(Endpoints.Trakt.SyncWatchedShows)
+        mockHandler.stubEndpoint(Endpoints.Trakt.ShowProgressWatched)
+        mockHandler.stubEndpoint(Endpoints.Trakt.UsersHiddenProgressWatched)
+
+        stubShowsFrom(Endpoints.Trakt.SyncProgressUpNextNitro.successFixture)
+    }
+
+    public fun stubTraktProfileSync(slug: String = TEST_PROFILE_SLUG) {
+        mockHandler.stubEndpoint(Endpoints.Trakt.UsersMe)
+        mockHandler.stubEndpoint(Endpoints.Trakt.userStats(slug))
+        mockHandler.stubEndpoint(Endpoints.Trakt.userLists(slug))
+        mockHandler.stubEndpoint(Endpoints.Trakt.UserListItems)
+    }
+
+    public fun stubTraktAddShowToList(listId: Long, slug: String = TEST_PROFILE_SLUG) {
+        mockHandler.stubEndpoint(Endpoints.Trakt.addShowToList(slug, listId), method = HttpMethod.Post)
+    }
+
+    public fun stubTraktCreateList(slug: String = TEST_PROFILE_SLUG) {
+        mockHandler.stubEndpoint(Endpoints.Trakt.createList(slug), method = HttpMethod.Post)
+    }
+
+    public fun stubTraktUsersMeUnauthorized() {
+        mockHandler.stubEndpoint(Endpoints.Trakt.UsersMe, HttpStatusCode.Unauthorized)
+    }
+
+    public fun stubSimklProfileEndpoints() {
+        mockHandler.stubEndpoint(endpoint = Endpoints.Simkl.UsersSettings, method = HttpMethod.Post)
+        mockHandler.stubEndpoint(endpoint = Endpoints.Simkl.UsersStats, method = HttpMethod.Post)
+    }
+
+    public fun stubSimklWatchedHistory() {
+        mockHandler.stubEndpoint(Endpoints.Simkl.SyncAllItems)
+    }
+
+    public fun stubSimklPlanToWatchWatchlist() {
+        mockHandler.stubFixture(
+            path = Endpoints.Simkl.SyncAllItems.path,
+            fixturePath = "simkl/sync/all-items/start_watching.json",
+        )
+    }
+
+    public fun stubSimklActivities() {
+        mockHandler.stubEndpoint(Endpoints.Simkl.SyncActivities)
+    }
+
+    public fun stubSimklUserSettingsUnauthorized() {
+        mockHandler.stubEndpoint(Endpoints.Simkl.UsersSettings, HttpStatusCode.Unauthorized)
+    }
+
+    /**
+     * Trakt's catalog-declared authenticated endpoints plus the account endpoints that carry a
+     * slug or a date. Pair with [stubBrowseGraph], the only source of TMDB and Discover coverage.
+     */
+    public fun stubTraktAuthenticatedEndpoints(
+        slug: String = TEST_PROFILE_SLUG,
+        today: String = TEST_TODAY,
+        nextWeek: String = TEST_NEXT_WEEK,
+    ) {
+        val endpoints = Endpoints.Trakt.authenticatedEndpoints + listOf(
+            Endpoints.Trakt.userStats(slug),
+            Endpoints.Trakt.userLists(slug),
+            Endpoints.Trakt.calendar(today, 7),
+            Endpoints.Trakt.calendar(nextWeek, 7),
+        )
+        endpoints.forEach { mockHandler.stubEndpoint(it) }
+
+        // Shared empty-array fixture, not tied to one catalog entry, so it isn't a plain Endpoint.
+        // Kept as explicit glue, mirroring the seasons catch-all in stubBrowseGraph.
+        mockHandler.stubPatternFixture(
+            pathRegex = "/users/me/history/shows/\\d+",
+            fixturePath = EMPTY_ARRAY_FIXTURE,
+        )
+
+        stubShowsFrom(Endpoints.Trakt.SyncWatchedShows.successFixture)
+        stubShowsFrom(Endpoints.Trakt.SyncProgressUpNextNitro.successFixture)
+    }
+
+    public fun stubSimklAuthenticatedEndpoints() {
+        Endpoints.Simkl.authenticatedEndpoints.forEach { mockHandler.stubEndpoint(it) }
+    }
+
+    /**
+     * Answers `/users/me` with 401 once, then registers the endpoints a successful refresh calls,
+     * so the last-registered-wins ordering replays the round-trip.
+     */
+    public fun stubTraktTokenRefreshEndpoints(slug: String = TEST_PROFILE_SLUG) {
+        mockHandler.stubEndpoint(Endpoints.Trakt.UsersMe, HttpStatusCode.Unauthorized)
+        mockHandler.stubEndpoint(Endpoints.Trakt.UsersMe)
+        mockHandler.stubEndpoint(Endpoints.Trakt.userStats(slug))
+        mockHandler.stubEndpoint(Endpoints.Trakt.userLists(slug))
+        mockHandler.stubEndpoint(Endpoints.Trakt.UserListItems)
+    }
+
+    private fun stubShowsFrom(fixturePath: String) {
+        showFixtures(FixtureLoader.load(fixturePath)).forEach { mockHandler.stubShow(it) }
+    }
+}


### PR DESCRIPTION
## Description
This PR moves the part of the test setup that answers network calls into the shared module, so Android and iOS can both prepare the same starting conditions for a test. What stays behind on Android is the part iOS could never reach anyway, namely changing values inside the running app and tapping through the screen.

## Changes
- Create `HttpScenarios` in `core/integration/stubs` and move every saved response registration into it, covering Discover, search, calendar, library, watchlist, profile, lists and both account providers
- Name each method after the account provider it serves rather than passing the provider in, so the shared module stays free of project dependencies that `ios-framework` would otherwise inherit
- Keep the `Scenarios` class on Android as the caller that chooses a provider, so no journey or flow test changes
- Move the test account name, the dates and the created list details into the shared module, since the saved responses already contain them
- Preserve the order stubs are registered in, because the fake server answers with the most recently registered match

> Stacked on #1112. Review that one first; this PR's base is `ios-shared-stub-module`, so the diff here is only the extraction.
