### PR TITLE
chore: Standardize test data

### DIFF
--- a/core/integration/infra/build.gradle.kts
+++ b/core/integration/infra/build.gradle.kts
@@ -32,6 +32,13 @@ kotlin {
         getByName("jvmMain").dependsOn(jvmAndIosMain)
         getByName("iosMain").dependsOn(jvmAndIosMain)
 
+        val jvmAndIosTest =
+            create("jvmAndIosTest") {
+                dependsOn(getByName("commonTest"))
+            }
+        getByName("jvmTest").dependsOn(jvmAndIosTest)
+        getByName("iosTest").dependsOn(jvmAndIosTest)
+
         commonMain.dependencies {
             api(projects.core.integration.stubs)
             api(projects.api.simkl.implementation)

--- a/core/integration/infra/src/jvmAndIosMain/kotlin/com/thomaskioko/tvmaniac/testing/di/FakeAppBindingContainer.kt
+++ b/core/integration/infra/src/jvmAndIosMain/kotlin/com/thomaskioko/tvmaniac/testing/di/FakeAppBindingContainer.kt
@@ -37,6 +37,7 @@ import com.thomaskioko.tvmaniac.presenter.root.DefaultRootPresenter
 import com.thomaskioko.tvmaniac.presenter.root.RootPresenter
 import com.thomaskioko.tvmaniac.profile.nav.ProfileRoot
 import com.thomaskioko.tvmaniac.progress.nav.ProgressRoot
+import com.thomaskioko.tvmaniac.testing.integration.MockEngineHandler
 import com.thomaskioko.tvmaniac.traktauth.implementation.TokenRefreshWorker
 import com.thomaskioko.tvmaniac.util.api.AppUtils
 import dev.zacsweers.metro.AppScope
@@ -45,8 +46,6 @@ import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
 import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.respond
-import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -120,19 +119,19 @@ public object FakeAppBindingContainer {
     @SingleIn(AppScope::class)
     @SimklApi
     public fun provideSimklHttpClientEngine(): io.ktor.client.engine.HttpClientEngine =
-        MockEngine { respond("{}", HttpStatusCode.OK) }
+        MockEngine { request -> MockEngineHandler.handler.handle(this, request) }
 
     @Provides
     @SingleIn(AppScope::class)
     @TmdbApi
     public fun provideTmdbHttpClientEngine(): io.ktor.client.engine.HttpClientEngine =
-        MockEngine { respond("{}", HttpStatusCode.OK) }
+        MockEngine { request -> MockEngineHandler.handler.handle(this, request) }
 
     @Provides
     @SingleIn(AppScope::class)
     @TraktApi
     public fun provideTraktHttpClientEngine(): io.ktor.client.engine.HttpClientEngine =
-        MockEngine { respond("{}", HttpStatusCode.OK) }
+        MockEngine { request -> MockEngineHandler.handler.handle(this, request) }
 
     @Provides
     public fun provideAppUtils(): AppUtils = object : AppUtils {

--- a/core/integration/infra/src/jvmAndIosTest/kotlin/com/thomaskioko/tvmaniac/testing/di/FakeAppBindingContainerTest.kt
+++ b/core/integration/infra/src/jvmAndIosTest/kotlin/com/thomaskioko/tvmaniac/testing/di/FakeAppBindingContainerTest.kt
@@ -1,0 +1,48 @@
+package com.thomaskioko.tvmaniac.testing.di
+
+import com.thomaskioko.tvmaniac.testing.integration.MockEngineHandler
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.matchers.string.shouldContain
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+/**
+ * Guards the wiring rather than the handler: these providers used to answer every request with
+ * `{}`, which silently gave the JVM and iOS a different backend from Android's. A revert would
+ * not fail any presenter test, because those make no HTTP calls, so assert it here.
+ */
+class FakeAppBindingContainerTest {
+
+    @AfterTest
+    fun tearDown() {
+        MockEngineHandler.handler.reset()
+    }
+
+    @Test
+    fun `should reject an unstubbed request given the graph's engine`() = runTest {
+        val client = HttpClient(FakeAppBindingContainer.provideTmdbHttpClientEngine())
+
+        val error = shouldThrowAny {
+            client.get("https://api.themoviedb.org/3/tv/1")
+        }
+
+        error.message shouldContain "No stub registered for"
+    }
+
+    @Test
+    fun `should answer from the shared handler given a registered stub`() = runTest {
+        MockEngineHandler.handler.stub(
+            path = "/3/tv/1",
+            body = """{"id":1}""",
+            status = HttpStatusCode.OK,
+        )
+        val client = HttpClient(FakeAppBindingContainer.provideTraktHttpClientEngine())
+
+        client.get("https://api.themoviedb.org/3/tv/1").bodyAsText() shouldContain "\"id\":1"
+    }
+}


### PR DESCRIPTION
## Description
This PR points the iOS and desktop test setup at the same fake backend Android already uses. Until now those tests answered every network call with an empty response, so a test could read nothing at all and still pass. From here a call that nobody prepared an answer for fails the test and says which one was missing.

## Changes
- Answer requests in the shared test setup from the same saved responses Android uses, instead of returning an empty response for everything
- Add a test that the shared setup rejects a call nobody prepared an answer for and returns the saved one when someone did, since no other test would notice this reverting
- Create a test source folder shared by iOS and desktop, matching the one the main sources already use
