### PR TITLE
chore: Add iOS UI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,3 +351,55 @@ jobs:
                         fastlane/test_output
                         fastlane/logs
                         derived_data/Logs/Test
+
+
+    ios-ui-test:
+        needs: [build-ios-framework]
+        runs-on: macos-26
+        timeout-minutes: 60
+        env:
+            FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 60
+            TVMANIAC_SKIP_FRAMEWORK_BUILD: '1'
+
+        steps:
+            -   name: 🚚 Checkout project
+                uses: actions/checkout@v7
+
+            -   name: 📱 Setup iOS Environment
+                uses: ./.github/actions/setup-ios
+                with:
+                    xcode-version: ${{ env.XCODE_VERSION }}
+
+            -   name: 🗂️ Restore prebuilt KMP frameworks
+                uses: ./.github/actions/kmp-ios-framework
+                with:
+                    mode: restore
+
+            -   name: 🗂️ Restore DerivedData
+                id: derived-data
+                uses: actions/cache/restore@v6
+                with:
+                    path: derived_data
+                    key: ${{ runner.os }}-uitest-derived-data-${{ hashFiles('ios/tv-maniac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'ios/Packages/**/Package.swift') }}
+                    restore-keys: |
+                        ${{ runner.os }}-uitest-derived-data-
+
+            -   name: 🧭 Run UI Tests
+                run: bundle exec fastlane ui_tests
+
+            -   name: 🗂️ Save DerivedData
+                if: github.ref == 'refs/heads/main' && steps.derived-data.outputs.cache-hit != 'true'
+                uses: actions/cache/save@v6
+                with:
+                    path: derived_data
+                    key: ${{ runner.os }}-uitest-derived-data-${{ hashFiles('ios/tv-maniac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'ios/Packages/**/Package.swift') }}
+
+            -   name: Upload test results
+                uses: actions/upload-artifact@v7
+                if: ${{ !cancelled() }}
+                with:
+                    name: ui-test-results
+                    path: |
+                        fastlane/test_output
+                        fastlane/logs
+                        derived_data/Logs/Test

--- a/api/simkl/implementation/build.gradle.kts
+++ b/api/simkl/implementation/build.gradle.kts
@@ -58,6 +58,7 @@ kotlin {
         iosMain {
             dependencies {
                 implementation(libs.ktor.darwin)
+                implementation(projects.core.integration.stubs)
             }
         }
     }

--- a/api/simkl/implementation/src/iosMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklPlatformBindingContainer.kt
+++ b/api/simkl/implementation/src/iosMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklPlatformBindingContainer.kt
@@ -1,6 +1,7 @@
 package com.thomaskioko.tvmaniac.simkl.implementation
 
 import com.thomaskioko.tvmaniac.core.base.SimklApi
+import com.thomaskioko.tvmaniac.testing.integration.StubHttpEngine
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
@@ -16,5 +17,5 @@ public object SimklPlatformBindingContainer {
     @Provides
     @SingleIn(AppScope::class)
     @SimklApi
-    public fun provideSimklHttpClientEngine(): HttpClientEngine = Darwin.create()
+    public fun provideSimklHttpClientEngine(): HttpClientEngine = StubHttpEngine.createOrNull() ?: Darwin.create()
 }

--- a/api/tmdb/implementation/build.gradle.kts
+++ b/api/tmdb/implementation/build.gradle.kts
@@ -29,6 +29,11 @@ kotlin {
 
         commonTest { dependencies { implementation(libs.ktor.serialization) } }
 
-        iosMain { dependencies { implementation(libs.ktor.darwin) } }
+        iosMain {
+            dependencies {
+                implementation(libs.ktor.darwin)
+                implementation(projects.core.integration.stubs)
+            }
+        }
     }
 }

--- a/api/tmdb/implementation/src/iosMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/TmdbPlatformBindingContainer.kt
+++ b/api/tmdb/implementation/src/iosMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/TmdbPlatformBindingContainer.kt
@@ -1,6 +1,7 @@
 package com.thomaskioko.tvmaniac.tmdb.implementation
 
 import com.thomaskioko.tvmaniac.core.base.TmdbApi
+import com.thomaskioko.tvmaniac.testing.integration.StubHttpEngine
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
@@ -16,5 +17,5 @@ public object TmdbPlatformBindingContainer {
     @Provides
     @SingleIn(AppScope::class)
     @TmdbApi
-    public fun provideTmdbHttpClientEngine(): HttpClientEngine = Darwin.create()
+    public fun provideTmdbHttpClientEngine(): HttpClientEngine = StubHttpEngine.createOrNull() ?: Darwin.create()
 }

--- a/api/trakt/implementation/build.gradle.kts
+++ b/api/trakt/implementation/build.gradle.kts
@@ -59,6 +59,7 @@ kotlin {
         iosMain {
             dependencies {
                 implementation(libs.ktor.darwin)
+                implementation(projects.core.integration.stubs)
             }
         }
     }

--- a/api/trakt/implementation/src/iosMain/kotlin/com/thomaskioko/trakt/service/implementation/TraktPlatformBindingContainer.kt
+++ b/api/trakt/implementation/src/iosMain/kotlin/com/thomaskioko/trakt/service/implementation/TraktPlatformBindingContainer.kt
@@ -1,6 +1,7 @@
 package com.thomaskioko.trakt.service.implementation
 
 import com.thomaskioko.tvmaniac.core.base.TraktApi
+import com.thomaskioko.tvmaniac.testing.integration.StubHttpEngine
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
@@ -16,5 +17,5 @@ public object TraktPlatformBindingContainer {
     @Provides
     @SingleIn(AppScope::class)
     @TraktApi
-    public fun provideTraktHttpClientEngine(): HttpClientEngine = Darwin.create()
+    public fun provideTraktHttpClientEngine(): HttpClientEngine = StubHttpEngine.createOrNull() ?: Darwin.create()
 }

--- a/core/integration/stubs/build.gradle.kts
+++ b/core/integration/stubs/build.gradle.kts
@@ -23,6 +23,13 @@ kotlin {
             implementation(libs.kotlinx.serialization.json)
         }
 
+        iosMain.dependencies {
+            api(projects.data.accountManager.api)
+            api(projects.data.oauth.api)
+            implementation(projects.data.database.sqldelight)
+            implementation(projects.data.datastore.implementation)
+        }
+
         commonTest.dependencies {
             implementation(libs.bundles.unittest)
         }

--- a/core/integration/stubs/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/Scenario.kt
+++ b/core/integration/stubs/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/Scenario.kt
@@ -1,0 +1,54 @@
+package com.thomaskioko.tvmaniac.testing.integration
+
+/**
+ * @property provider Matches a `SyncProviderSource` entry name. Kept as a string so this module
+ *   declares no project dependencies; the caller resolves it.
+ */
+public data class ScenarioAuthState(
+    val provider: String,
+    val accessToken: String,
+    val refreshToken: String,
+    val expiresInSeconds: Long = 3600,
+)
+
+public data class Scenario(
+    val name: String,
+    val authState: ScenarioAuthState? = null,
+    val register: HttpScenarios.() -> Unit,
+)
+
+public object Scenarios {
+
+    public const val UNAUTHENTICATED: String = "unauthenticated"
+    public const val AUTHENTICATED_TRAKT: String = "authenticatedTrakt"
+
+    private val all: List<Scenario> = listOf(
+        Scenario(name = UNAUTHENTICATED) {
+            stubBrowseGraph()
+            stubTraktUsersMeUnauthorized()
+        },
+        Scenario(
+            name = AUTHENTICATED_TRAKT,
+            authState = ScenarioAuthState(
+                provider = "TRAKT",
+                accessToken = "ui-test-access",
+                refreshToken = "ui-test-refresh",
+            ),
+        ) {
+            stubBrowseGraph()
+            stubTraktAuthenticatedEndpoints()
+        },
+    )
+
+    public fun find(name: String): Scenario? = all.firstOrNull { it.name == name }
+
+    public fun names(): List<String> = all.map { it.name }
+
+    public fun apply(handler: MockEngineHandler, name: String): Scenario {
+        val scenario = checkNotNull(find(name)) {
+            "Unknown stub scenario \"$name\". Available: ${names().joinToString()}"
+        }
+        HttpScenarios(handler).apply(scenario.register)
+        return scenario
+    }
+}

--- a/core/integration/stubs/src/iosMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/IosTestHooks.kt
+++ b/core/integration/stubs/src/iosMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/IosTestHooks.kt
@@ -1,0 +1,55 @@
+package com.thomaskioko.tvmaniac.testing.integration
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AuthState
+import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
+import com.thomaskioko.tvmaniac.datastore.implementation.DATA_STORE_FILE_NAME
+import com.thomaskioko.tvmaniac.datastore.implementation.clearDataStoreReference
+import com.thomaskioko.tvmaniac.db.IosDatabaseDriverBuilder
+import com.thomaskioko.tvmaniac.oauth.api.AuthStore
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.runBlocking
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSURL
+import platform.Foundation.NSUserDomainMask
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+
+public object IosTestHooks {
+
+    @OptIn(ExperimentalForeignApi::class)
+    public fun clearPersistentStateIfNeeded() {
+        if (!StubHttpEngine.shouldClearPersistentState) return
+
+        IosDatabaseDriverBuilder().deleteDatabase()
+
+        clearDataStoreReference()
+        val documents: NSURL? = NSFileManager.defaultManager.URLForDirectory(
+            directory = NSDocumentDirectory,
+            inDomain = NSUserDomainMask,
+            appropriateForURL = null,
+            create = false,
+            error = null,
+        )
+        documents?.path?.let { path ->
+            NSFileManager.defaultManager.removeItemAtPath("$path/$DATA_STORE_FILE_NAME", null)
+        }
+    }
+
+    public fun saveAuthStateIfNeeded(authStore: AuthStore) {
+        val scenarioAuthState = StubHttpEngine.scenario?.authState ?: return
+        val provider = SyncProviderSource.valueOf(scenarioAuthState.provider)
+        runBlocking {
+            authStore.save(
+                provider = provider,
+                state = AuthState(
+                    accessToken = scenarioAuthState.accessToken,
+                    refreshToken = scenarioAuthState.refreshToken,
+                    isAuthorized = true,
+                    expiresAt = Clock.System.now() + scenarioAuthState.expiresInSeconds.seconds,
+                    tokenLifetimeSeconds = scenarioAuthState.expiresInSeconds,
+                ),
+            )
+        }
+    }
+}

--- a/core/integration/stubs/src/iosMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/StubHttpEngine.kt
+++ b/core/integration/stubs/src/iosMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/StubHttpEngine.kt
@@ -1,0 +1,27 @@
+package com.thomaskioko.tvmaniac.testing.integration
+
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.mock.MockEngine
+import platform.Foundation.NSProcessInfo
+
+public const val STUB_SCENARIO_ENV: String = "TVMANIAC_STUB_SCENARIO"
+public const val CLEAR_STATE_ENV: String = "TVMANIAC_CLEAR_STATE"
+
+/** XCUITest runs in a separate process, so the launch environment is its only channel. */
+public object StubHttpEngine {
+
+    private val environment: Map<Any?, *> get() = NSProcessInfo.processInfo.environment
+
+    public val shouldClearPersistentState: Boolean
+        get() = environment[CLEAR_STATE_ENV] as String? == "1"
+
+    public val scenario: Scenario? by lazy {
+        (environment[STUB_SCENARIO_ENV] as String?)?.let { Scenarios.apply(MockEngineHandler.handler, it) }
+    }
+
+    /** Returns null when no scenario was named, which is every launch outside a UI test. */
+    public fun createOrNull(): HttpClientEngine? {
+        scenario ?: return null
+        return MockEngine { request -> MockEngineHandler.handler.handle(this, request) }
+    }
+}

--- a/docs/architecture/ios-testing.md
+++ b/docs/architecture/ios-testing.md
@@ -2,46 +2,76 @@
 
 ## Table of Contents
 
-- [The Layers](#the-layers)
+- [Test Layers](#test-layers)
 - [Kotlin/Native Tests](#kotlinnative-tests)
 - [State Isolation](#state-isolation)
 - [Snapshot Tests](#snapshot-tests)
+- [UI Tests](#ui-tests)
+- [Launch Environment](#launch-environment)
 - [Running Tests](#running-tests)
 
-Android's equivalent harness is described in [`integration-testing.md`](integration-testing.md).
+Android's harness is described in [`integration-testing.md`](integration-testing.md).
 
-## The Layers
+## Test Layers
 
-| Layer | Runs | Catches | CI job |
+| Layer | Runs | Covers | CI job |
 |---|---|---|---|
-| Kotlin/Native tests | Simulator, no app | Broken iOS `actual` declarations, [Metro](glossary.md#metro) graph wiring, presenter logic on Kotlin/Native | `ios-test` |
-| Snapshot tests | Simulator, no app | Visual regressions in stateless `XScreen` structs | `ios-snapshot-test` |
+| Kotlin/Native tests | Simulator, no app | iOS `actual` declarations, [Metro](glossary.md#metro) graph construction, presenter logic on Kotlin/Native | `ios-test` |
+| Snapshot tests | Simulator, no app | Rendering of stateless `XScreen` structs | `ios-snapshot-test` |
+| UI tests | Simulator, real app | App launch, graph construction at runtime, framework linking, navigation | `ios-ui-test` |
 
-A third layer, XCUITest against the real app, is planned. Neither existing layer starts the binary, so a crash inside `AppDelegate.init` still reaches main: `fastlane build_tvmaniac` compiles and links the app without ever launching it, and snapshot tests never import `TvManiac`.
+`fastlane build_tvmaniac` compiles and links the app without launching it, and the snapshot targets never import `TvManiac`. The UI tests are the only layer that starts the binary, so they are the only layer that fails when `AppDelegate.init` throws.
 
 ## Kotlin/Native Tests
 
-`./gradlew iosTest` runs every `iosTest` source set on `iosSimulatorArm64`. Most are ordinary unit tests. Two of them, `HomePresenterIosTest` and `DefaultRootPresenterIosTest`, build presenters out of a real Metro graph and are the closest thing iOS has to Android's flow tests.
+`./gradlew iosTest` runs every `iosTest` source set on `iosSimulatorArm64`. `HomePresenterIosTest` and `DefaultRootPresenterIosTest` build presenters from a real Metro graph; the rest are unit tests.
 
-That graph is `TestGraph` in `core/integration/infra/src/iosMain/.../TestGraph.kt`, entered through `runTestWithGraph`. It is the iOS twin of the JVM `TestGraph`; the two are duplicated per source set because Metro materializes `@DependencyGraph.Factory` per target.
+That graph is `TestGraph` (`core/integration/infra/src/iosMain/.../TestGraph.kt`), entered through `runTestWithGraph`. `core/integration/infra/src/jvmMain/.../TestGraph.kt` declares the same graph for the JVM. Metro materializes `@DependencyGraph.Factory` per target, so the two cannot share a declaration.
 
-Always pass `--continue`. Without it Gradle stops at the first failing module and hides every other failure.
+Pass `--continue`. Gradle otherwise stops at the first failing module and reports no others.
 
 ## State Isolation
 
-`iosTest` runs one Kotlin/Native binary per module, so **all tests in a module share one process and one on-disk state**. `FakeIosPlatformBindingContainer` overrides the three pieces that would otherwise leak between tests, matching what `TestJvmPlatformBindingContainer` already does on the JVM:
+`iosTest` runs one Kotlin/Native binary per module, so every test in a module shares one process and one set of files on disk. `FakeIosPlatformBindingContainer` replaces the three bindings that carry values from one test into the next, matching `TestJvmPlatformBindingContainer` on the JVM:
 
-- **Keychain**: `IosAuthStore` is replaced by `FakeAuthStore`. A Kotlin/Native test binary is not an app bundle, so it has no keychain entitlement and every keychain read fails with `-25291`.
-- **Preferences**: `DataStorePlatformBindingContainer` writes a single file in `NSDocumentDirectory`, and `createDataStore` in `DataStoreHelper.kt` caches one instance for the whole process behind a lock. A fresh Metro graph does *not* get a fresh DataStore. The override builds `PreferenceDataStoreFactory` directly against a unique temporary directory, bypassing the singleton.
-- **Database**: `DatabasePlatformBindingContainer` opens a named file. The override uses `createNativeSqliteDriver(inMemory = true)`.
+- **Keychain**: replaces `IosAuthStore` with `FakeAuthStore`. A Kotlin/Native test binary is not an app bundle and holds no keychain entitlement, so `KeychainSettings` fails every read with `-25291`.
+- **Preferences**: replaces `DataStorePlatformBindingContainer`, which writes one file in `NSDocumentDirectory`. `createDataStore` in `DataStoreHelper.kt` also caches a single instance for the process, so building a new Metro graph returns the same `DataStore`. The override calls `PreferenceDataStoreFactory.createWithPath` against a unique temporary directory.
+- **Database**: replaces `DatabasePlatformBindingContainer`, which opens a named file, with `createNativeSqliteDriver(inMemory = true)`.
 
-When one of these is missing, the symptom is an assertion whose "actual" is a value some *other* test set, such as `fontSizePercent=120` appearing in a theme assertion. It reads as flakiness but is really execution order. Any new binding that persists state needs a matching override here.
+A missing override surfaces as an assertion reading a value an earlier test wrote, such as `fontSizePercent=120` in a theme assertion. The failure depends on execution order. Add an override here for every new binding that writes to disk.
 
 ## Snapshot Tests
 
-Described by the `Snapshots` scheme plus `ios/Packages/SnapshotTestingLib`. Each feature package owns a `Tests/` target that renders its `XScreen` struct in light and dark against committed PNG baselines.
+The `Snapshots` scheme runs them, and `ios/Packages/SnapshotTestingLib` holds the harness. Each feature package owns a `Tests/` target that renders its `XScreen` struct in light and dark against committed PNG baselines.
 
-Screens stay free of `import TvManiac` on purpose. That keeps snapshot targets off the framework and keeps the View/Screen split honest: the `XView` owns the presenter, the `XScreen` is a plain `State` struct plus closures.
+`XScreen` structs do not import `TvManiac`. That keeps the snapshot targets off the framework and holds the split: `XView` owns the presenter, `XScreen` takes a `State` struct and closures.
+
+## UI Tests
+
+`ios/tvmaniacUITests` drives the app through XCUITest.
+
+`XCUIApplication.launchTvManiac(scenario:)` starts the app with the [launch environment](#launch-environment) below. `IosHttpEngineBindingContainer` (`ios-framework/src/iosMain/`) reads `TVMANIAC_STUB_SCENARIO` and returns either a `MockEngine` backed by `MockEngineHandler` or `Darwin.create()`. Metro resolves `replaces` at compile time, so both branches live in that one container. A launch without the variable reaches the live services.
+
+`IosTestHooks` performs the two steps Android's journey tests run inside the test process:
+
+- `clearPersistentStateIfNeeded()` deletes the database, the preferences file and the saved credentials. `AppDelegate.init` calls it before the first `appGraph` access, because the SQLDelight driver holds the database file open and `createDataStore` caches one instance for the process.
+- `saveAuthStateIfNeeded(authStore:)` writes the credentials named by the scenario through the production `AuthStore`, which emits the login event `ContinueWatchingTasksInitializer` collects.
+
+`AppLaunchTests` and `SettingsNavigationTests` assert that a screen container exists, which holds in every data state. `DiscoverContentTests` asserts on a show title that only the saved responses contain, and fails when the app reaches the live services instead.
+
+Locate tabs by index through `app.tabBar.buttons.element(boundBy:)`. SwiftUI discards accessibility identifiers set inside `.tabItem`, so `HomeTestTags` constants do not resolve there.
+
+`TestTags.swift` repeats the `core:test-tags` strings as literals. Importing `TvManiac` links the Kotlin/Native static framework into the test bundle, which fails on missing `_sqlite3_*` symbols unless the app's `OTHER_LDFLAGS` are copied.
+
+## Launch Environment
+
+| Variable | Effect |
+|---|---|
+| `TVMANIAC_STUB_SCENARIO` | Names an entry in the Kotlin `Scenarios` table. The app answers HTTP from that scenario's saved responses. |
+| `TVMANIAC_FIXTURE_DIR` | Absolute path to the saved responses. `XCUIApplicationExtensions.swift` derives it from `#filePath`, so it resolves on a laptop and on CI without a build setting. |
+| `TVMANIAC_CLEAR_STATE` | Set to `1` to delete the database, preferences and saved credentials before the graph is built. |
+
+XCUITest runs in a separate process from the app, so the launch environment is the only channel between them.
 
 ## Running Tests
 
@@ -51,8 +81,11 @@ Screens stay free of `import TvManiac` on purpose. That keeps snapshot targets o
 
 # Snapshots
 bundle exec fastlane ios snapshot_tests
+
+# UI tests
+bundle exec fastlane ios ui_tests
 ```
 
-The snapshot lane builds the KMP framework first. Set `TVMANIAC_SKIP_FRAMEWORK_BUILD=1` to reuse an existing build.
+Both Fastlane lanes build the KMP framework first. Set `TVMANIAC_SKIP_FRAMEWORK_BUILD=1` to reuse an existing build.
 
-Note that `TvManiacFramework/Package.swift` calls `fatalError` when `TvManiac.xcframework` is missing, so a fresh checkout cannot even list Xcode schemes until `./scripts/build-kmp-framework.sh` has run.
+`TvManiacFramework/Package.swift` calls `fatalError` when `TvManiac.xcframework` is missing, so `xcodebuild -list` fails on a fresh checkout until `./scripts/build-kmp-framework.sh` has run.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -65,6 +65,23 @@ platform :ios do
     )
   end
 
+  desc "Run UI Tests"
+  lane :ui_tests do
+    build_kmp_framework
+
+    run_tests(
+      project: "ios/tv-maniac.xcodeproj",
+      scheme: "tv-maniac",
+      destination: TEST_DESTINATION,
+      skip_detect_devices: true,
+      result_bundle: true,
+      xcargs: "-retry-tests-on-failure -skipPackagePluginValidation",
+      number_of_retries: 2,
+      fail_build: true,
+      derived_data_path: DERIVED_DATA_PATH
+    )
+  end
+
   desc "Re-record snapshot baselines"
   lane :record_snapshots do
     build_kmp_framework

--- a/ios-framework/README.md
+++ b/ios-framework/README.md
@@ -47,6 +47,10 @@ graph TB
     direction TB
     :core:imageloading:api[api]:::multiplatform
   end
+  subgraph :core:integration
+    direction TB
+    :core:integration:stubs[stubs]:::multiplatform
+  end
   subgraph :core:locale
     direction TB
     :core:locale:api[api]:::multiplatform
@@ -1274,6 +1278,7 @@ graph TB
   :ios-framework -.-> :core:connectivity:implementation
   :ios-framework --> :core:feature-flags:api
   :ios-framework -.-> :core:feature-flags:implementation
+  :ios-framework --> :core:integration:stubs
   :ios-framework -.-> :core:locale:api
   :ios-framework -.-> :core:locale:implementation
   :ios-framework -.-> :core:logger:api

--- a/ios-framework/build.gradle.kts
+++ b/ios-framework/build.gradle.kts
@@ -72,6 +72,7 @@ scaffold {
             export(projects.features.featureFlags.presenter)
             export(projects.features.root.presenter)
             export(projects.features.root.nav)
+            export(projects.core.integration.stubs)
             export(projects.core.testTags)
             export(projects.domain.notifications)
 
@@ -133,6 +134,7 @@ kotlin {
                 api(projects.features.library.nav)
                 api(projects.features.profile.nav)
                 api(projects.features.myShows.nav)
+                api(projects.core.integration.stubs)
                 api(projects.core.testTags)
 
                 api(projects.domain.calendar)

--- a/ios-framework/dependencies/iosArm64CompileKlibraries.txt
+++ b/ios-framework/dependencies/iosArm64CompileKlibraries.txt
@@ -64,6 +64,8 @@ io.ktor:ktor-client-darwin-iosarm64:3.5.1
 io.ktor:ktor-client-darwin:3.5.1
 io.ktor:ktor-client-logging-iosarm64:3.5.1
 io.ktor:ktor-client-logging:3.5.1
+io.ktor:ktor-client-mock-iosarm64:3.5.1
+io.ktor:ktor-client-mock:3.5.1
 io.ktor:ktor-events-iosarm64:3.5.1
 io.ktor:ktor-events:3.5.1
 io.ktor:ktor-http-cio-iosarm64:3.5.1

--- a/ios-framework/src/iosMain/kotlin/com.thomaskioko.tvmaniac.iosframework/IosApplicationGraph.kt
+++ b/ios-framework/src/iosMain/kotlin/com.thomaskioko.tvmaniac.iosframework/IosApplicationGraph.kt
@@ -10,6 +10,7 @@ import com.thomaskioko.tvmaniac.core.base.IsDebugBuild
 import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.core.tasks.api.BackgroundTaskScheduler
 import com.thomaskioko.tvmaniac.featureflags.RemoteConfigBridge
+import com.thomaskioko.tvmaniac.oauth.api.AuthStore
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
@@ -24,6 +25,7 @@ public interface IosApplicationGraph {
     public val appMetadata: AppMetadata
     public val debugConfig: DebugConfig
     public val logger: Logger
+    public val authStore: AuthStore
 
     @DependencyGraph.Factory
     public fun interface Factory {

--- a/ios/Packages/Components/Sources/Components/ViewModifiers/TestTagModifier.swift
+++ b/ios/Packages/Components/Sources/Components/ViewModifiers/TestTagModifier.swift
@@ -9,4 +9,14 @@ public extension View {
     func testTag(_ identifier: String) -> some View {
         accessibilityIdentifier(identifier)
     }
+
+    /// Tags a screen's outermost container so XCUITest can assert the screen is on
+    /// display. Unlike `testTag`, this also publishes the container itself as an
+    /// accessibility element, which SwiftUI otherwise skips for plain layout views,
+    /// leaving it unreachable through `app.otherElements`. Apply it outside every
+    /// loading, empty, and error branch so the tag survives whatever state renders.
+    func screenTag(_ identifier: String) -> some View {
+        accessibilityElement(children: .contain)
+            .accessibilityIdentifier(identifier)
+    }
 }

--- a/ios/Packages/Discover/Sources/Discover/DiscoverTab.swift
+++ b/ios/Packages/Discover/Sources/Discover/DiscoverTab.swift
@@ -37,5 +37,6 @@ public struct DiscoverTab: View {
                 presenter.dispatch(action: MessageShown(id: message.id))
             }
         }
+        .screenTag(DiscoverTestTags.shared.SCREEN_TEST_TAG)
     }
 }

--- a/ios/Packages/Home/Sources/Home/ProgressTab.swift
+++ b/ios/Packages/Home/Sources/Home/ProgressTab.swift
@@ -43,6 +43,7 @@ struct ProgressTab: View {
             }
         }
         .toastView(toast: $toast)
+        .screenTag(ProgressTestTags.shared.SCREEN_TEST_TAG)
     }
 
     private var upNextContent: some View {

--- a/ios/Packages/MyShows/Sources/MyShows/MyShowsTab.swift
+++ b/ios/Packages/MyShows/Sources/MyShows/MyShowsTab.swift
@@ -92,6 +92,7 @@ public struct MyShowsTab: View {
             watchNextEpisodesSwift.removeAll()
             staleEpisodesSwift.removeAll()
         }
+        .screenTag(MyShowsTestTags.shared.SCREEN_TEST_TAG)
     }
 
     private var pagePicker: some View {

--- a/ios/Packages/Profile/Sources/Profile/ProfileScreen.swift
+++ b/ios/Packages/Profile/Sources/Profile/ProfileScreen.swift
@@ -2,6 +2,7 @@ import Components
 import DesignSystem
 import Models
 import SwiftUI
+import TvManiac
 
 public struct ProfileScreen: View {
     public struct State: Equatable {
@@ -166,6 +167,7 @@ public struct ProfileScreen: View {
                         }
 
                         GlassButton(icon: "gearshape", action: onSettingsClicked)
+                            .testTag(ProfileTestTags.shared.SETTINGS_BUTTON_TEST_TAG)
                     }
                 }
             )

--- a/ios/Packages/Profile/Sources/Profile/ProfileTab.swift
+++ b/ios/Packages/Profile/Sources/Profile/ProfileTab.swift
@@ -37,6 +37,7 @@ public struct ProfileTab: View {
                 presenter.dispatch(action: ProfileActionMessageShown(id: errorMessage.id))
             }
         }
+        .screenTag(ProfileTestTags.shared.SCREEN_TEST_TAG)
     }
 }
 

--- a/ios/Packages/Settings/Sources/Settings/SettingsScreen.swift
+++ b/ios/Packages/Settings/Sources/Settings/SettingsScreen.swift
@@ -2,6 +2,7 @@ import Components
 import DesignSystem
 import Models
 import SwiftUI
+import TvManiac
 
 public struct SettingsScreen<Theme: ThemeItem>: View {
     public struct State {
@@ -106,6 +107,7 @@ public struct SettingsScreen<Theme: ThemeItem>: View {
                 opacity: 1.0,
                 leadingIcon: {
                     GlassButton(icon: "chevron.left", action: onBack)
+                        .testTag(SettingsTestTags.shared.BACK_BUTTON_TEST_TAG)
                 }
             ),
             alignment: .top

--- a/ios/Packages/Settings/Sources/Settings/SettingsView.swift
+++ b/ios/Packages/Settings/Sources/Settings/SettingsView.swift
@@ -108,6 +108,7 @@ public struct SettingsView: View {
             store.fontSizePercent = Int(newValue)
         }
         .settingsPosterStyleObservers(uiState: uiState, store: store)
+        .screenTag(SettingsTestTags.shared.SCREEN_TEST_TAG)
     }
 
     // MARK: - Root Sections

--- a/ios/Packages/TvManiacKit/Sources/TvManiacKit/AppDelegate.swift
+++ b/ios/Packages/TvManiacKit/Sources/TvManiacKit/AppDelegate.swift
@@ -38,6 +38,8 @@ public class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
 
     override public init() {
         super.init()
+        // Must precede the first `appGraph` access: the driver holds the database file open.
+        IosTestHooks.shared.clearPersistentStateIfNeeded()
         if Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist") != nil {
             FirebaseApp.configure()
             CrashReportingBridgeHolder.shared.bridge = FirebaseCrashlyticsBridge()
@@ -46,6 +48,7 @@ public class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
         // Force IosTaskScheduler construction so BGTask handlers are registered
         // synchronously during app launch — Apple silently discards late registrations.
         _ = appGraph.backgroundTaskScheduler
+        IosTestHooks.shared.saveAuthStateIfNeeded(authStore: appGraph.authStore)
         appGraph.initializers.initialize()
         setupNotifications()
         setupNotificationDelegate()

--- a/ios/tv-maniac.xcodeproj/project.pbxproj
+++ b/ios/tv-maniac.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D6F1A0002F61B0A100000001 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		E9AC834B26CEE00D00829A0D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		D6C17E510000000000000001 /* tvmaniacUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = tvmaniacUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -54,6 +55,7 @@
 		D65009DC2CF644BE00394D67 /* App */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = App; sourceTree = "<group>"; };
 		D68A22262F415DC30034550F /* Config */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Config; sourceTree = "<group>"; };
 		D6A2A0EB2EC7FD8C0001CD82 /* Packages */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Packages; sourceTree = "<group>"; };
+		D6C17E510000000000000002 /* tvmaniacUITests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = tvmaniacUITests; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,6 +84,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D6C17E510000000000000004 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -91,6 +100,7 @@
 				D68A22262F415DC30034550F /* Config */,
 				7555FF7D242A565900829871 /* ios */,
 				D6A2A0EB2EC7FD8C0001CD82 /* Packages */,
+				D6C17E510000000000000002 /* tvmaniacUITests */,
 				7555FF7C242A565900829871 /* Products */,
 				D6619D2A2C8738F200D273E7 /* Frameworks */,
 			);
@@ -100,6 +110,7 @@
 			isa = PBXGroup;
 			children = (
 				7555FF7B242A565900829871 /* tv-maniac.app */,
+				D6C17E510000000000000001 /* tvmaniacUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -170,6 +181,27 @@
 			productReference = 7555FF7B242A565900829871 /* tv-maniac.app */;
 			productType = "com.apple.product-type.application";
 		};
+		D6997E342C95A04600D18112 /* tvmaniacUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D6C17E51000000000000000A /* Build configuration list for PBXNativeTarget "tvmaniacUITests" */;
+			buildPhases = (
+				D6C17E510000000000000003 /* Sources */,
+				D6C17E510000000000000004 /* Frameworks */,
+				D6C17E510000000000000005 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D6C17E510000000000000006 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				D6C17E510000000000000002 /* tvmaniacUITests */,
+			);
+			name = tvmaniacUITests;
+			productName = tvmaniacUITests;
+			productReference = D6C17E510000000000000001 /* tvmaniacUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -183,6 +215,10 @@
 				TargetAttributes = {
 					7555FF7A242A565900829871 = {
 						CreatedOnToolsVersion = 11.3.1;
+					};
+					D6997E342C95A04600D18112 = {
+						CreatedOnToolsVersion = 26.5;
+						TestTargetID = 7555FF7A242A565900829871;
 					};
 				};
 			};
@@ -202,6 +238,7 @@
 			projectRoot = "";
 			targets = (
 				7555FF7A242A565900829871 /* tv-maniac */,
+				D6997E342C95A04600D18112 /* tvmaniacUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -213,6 +250,13 @@
 			files = (
 				E9AC834C26CEE00D00829A0D /* Assets.xcassets in Resources */,
 				D6F1A0012F61B0A100000001 /* PrivacyInfo.xcprivacy in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6C17E510000000000000005 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -287,7 +331,32 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D6C17E510000000000000003 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXContainerItemProxy section */
+		D6C17E510000000000000007 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7555FF73242A565900829871 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7555FF7A242A565900829871;
+			remoteInfo = "tv-maniac";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXTargetDependency section */
+		D6C17E510000000000000006 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7555FF7A242A565900829871 /* tv-maniac */;
+			targetProxy = D6C17E510000000000000007 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		7555FFA3242A565B00829871 /* Debug */ = {
@@ -514,6 +583,52 @@
 			};
 			name = Release;
 		};
+		D6C17E510000000000000008 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 2M53227BD2;
+				EXCLUDED_ARCHS = x86_64;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.thomaskioko.tvmaniac.uitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_TARGET_NAME = "tv-maniac";
+			};
+			name = Debug;
+		};
+		D6C17E510000000000000009 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 2M53227BD2;
+				EXCLUDED_ARCHS = x86_64;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.thomaskioko.tvmaniac.uitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_TARGET_NAME = "tv-maniac";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -531,6 +646,15 @@
 			buildConfigurations = (
 				7555FFA6242A565B00829871 /* Debug */,
 				7555FFA7242A565B00829871 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D6C17E51000000000000000A /* Build configuration list for PBXNativeTarget "tvmaniacUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D6C17E510000000000000008 /* Debug */,
+				D6C17E510000000000000009 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/tv-maniac.xcodeproj/xcshareddata/xcschemes/tv-maniac.xcscheme
+++ b/ios/tv-maniac.xcodeproj/xcshareddata/xcschemes/tv-maniac.xcscheme
@@ -63,8 +63,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D6997E342C95A04600D18112"
-               BuildableName = "tv-maniacUITests.xctest"
-               BlueprintName = "tv-maniacUITests"
+               BuildableName = "tvmaniacUITests.xctest"
+               BlueprintName = "tvmaniacUITests"
                ReferencedContainer = "container:tv-maniac.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/ios/tvmaniacUITests/AppLaunchTests.swift
+++ b/ios/tvmaniacUITests/AppLaunchTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+
+final class AppLaunchTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func test_TabBar_ShownAfterColdLaunch() {
+        let app = XCUIApplication.launchTvManiac()
+
+        XCTAssertTrue(
+            app.tabBar.waitForExistence(timeout: UITestTimeouts.launch),
+            "Tab bar never appeared, so the app did not finish launching."
+        )
+        XCTAssertEqual(app.tabBar.buttons.count, TabIndex.allCases.count)
+    }
+
+    func test_EachTab_ShowsItsScreen() {
+        let app = XCUIApplication.launchTvManiac()
+        XCTAssertTrue(app.tabBar.waitForExistence(timeout: UITestTimeouts.launch))
+
+        app.awaitScreen(TestTags.discoverScreen)
+
+        for tab in TabIndex.allCases {
+            app.tabBar.buttons.element(boundBy: tab.rawValue).tap()
+            app.awaitScreen(tab.screenTag)
+        }
+    }
+}
+
+enum TabIndex: Int, CaseIterable {
+    case discover
+    case progress
+    case myShows
+    case profile
+
+    var screenTag: String {
+        switch self {
+        case .discover: TestTags.discoverScreen
+        case .progress: TestTags.progressScreen
+        case .myShows: TestTags.myShowsScreen
+        case .profile: TestTags.profileScreen
+        }
+    }
+}

--- a/ios/tvmaniacUITests/DiscoverContentTests.swift
+++ b/ios/tvmaniacUITests/DiscoverContentTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+
+final class DiscoverContentTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func test_Discover_ShowsAShowFromTheSavedResponses() {
+        let app = XCUIApplication.launchTvManiac()
+        XCTAssertTrue(app.tabBar.waitForExistence(timeout: UITestTimeouts.launch))
+        app.awaitScreen(TestTags.discoverScreen)
+
+        let title = app.staticTexts[FixtureData.featuredShowTitle]
+        XCTAssertTrue(
+            title.waitForExistence(timeout: UITestTimeouts.screen),
+            "Discover never showed \"\(FixtureData.featuredShowTitle)\". "
+                + "The app is not reading the saved responses."
+        )
+    }
+}
+
+enum FixtureData {
+    /// First entry of `trakt/shows/favorite/success.json`, rendered by the featured section.
+    static let featuredShowTitle = "Breaking Bad"
+}

--- a/ios/tvmaniacUITests/SettingsNavigationTests.swift
+++ b/ios/tvmaniacUITests/SettingsNavigationTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+final class SettingsNavigationTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func test_Settings_OpensFromProfileAndReturns() {
+        let app = XCUIApplication.launchTvManiac()
+        XCTAssertTrue(app.tabBar.waitForExistence(timeout: UITestTimeouts.launch))
+
+        app.tabBar.buttons.element(boundBy: TabIndex.profile.rawValue).tap()
+        app.awaitScreen(TestTags.profileScreen)
+
+        let settingsButton = app.buttons[TestTags.profileSettingsButton]
+        XCTAssertTrue(settingsButton.waitForExistence(timeout: UITestTimeouts.screen))
+        settingsButton.tap()
+
+        app.awaitScreen(TestTags.settingsScreen)
+
+        app.buttons[TestTags.settingsBackButton].tap()
+        app.awaitScreen(TestTags.profileScreen)
+    }
+}

--- a/ios/tvmaniacUITests/TestTags.swift
+++ b/ios/tvmaniacUITests/TestTags.swift
@@ -1,0 +1,12 @@
+/// Literals rather than the Kotlin `core:test-tags` constants: importing `TvManiac` links the
+/// whole Kotlin/Native framework into the test bundle, which fails on missing sqlite3 symbols.
+enum TestTags {
+    static let discoverScreen = "discover_screen"
+    static let progressScreen = "progress_screen"
+    static let myShowsScreen = "my_shows_screen"
+    static let profileScreen = "profile_screen"
+    static let settingsScreen = "settings_screen"
+
+    static let profileSettingsButton = "profile_settings_button"
+    static let settingsBackButton = "settings_back_button"
+}

--- a/ios/tvmaniacUITests/XCUIApplicationExtensions.swift
+++ b/ios/tvmaniacUITests/XCUIApplicationExtensions.swift
@@ -1,0 +1,76 @@
+import XCTest
+
+extension XCUIApplication {
+    static func launchTvManiac(scenario: String = StubScenario.unauthenticated) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchEnvironment["TVMANIAC_STUB_SCENARIO"] = scenario
+        app.launchEnvironment["TVMANIAC_FIXTURE_DIR"] = fixtureDirectory
+        app.launchEnvironment["TVMANIAC_CLEAR_STATE"] = "1"
+        app.launch()
+        app.dismissSystemAlertIfPresent()
+        return app
+    }
+
+    /// Derived from this file's location so it resolves on a laptop and on CI with no build
+    /// setting. Simulator processes can read the host filesystem, so nothing is copied into the app.
+    private static var fixtureDirectory: String {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("core/integration/stubs/src/commonMain/resources")
+            .path
+    }
+
+    var tabBar: XCUIElement {
+        tabBars.firstMatch
+    }
+
+    func screen(_ identifier: String) -> XCUIElement {
+        otherElements[identifier]
+    }
+
+    @discardableResult
+    func awaitScreen(
+        _ identifier: String,
+        timeout: TimeInterval = UITestTimeouts.screen,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> XCUIElement {
+        let element = screen(identifier)
+        XCTAssertTrue(
+            element.waitForExistence(timeout: timeout),
+            "Screen \"\(identifier)\" never appeared within \(timeout)s.",
+            file: file,
+            line: line
+        )
+        return element
+    }
+
+    func dismissSystemAlertIfPresent() {
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        let alert = springboard.alerts.firstMatch
+        guard alert.waitForExistence(timeout: UITestTimeouts.systemAlert) else { return }
+
+        for label in ["Allow", "Allow While Using App", "OK", "Don’t Allow"] {
+            let button = alert.buttons[label]
+            if button.exists {
+                button.tap()
+                return
+            }
+        }
+        alert.buttons.firstMatch.tap()
+    }
+}
+
+/// Mirrors the Kotlin `Scenarios` table.
+enum StubScenario {
+    static let unauthenticated = "unauthenticated"
+    static let authenticatedTrakt = "authenticatedTrakt"
+}
+
+enum UITestTimeouts {
+    static let launch: TimeInterval = 90
+    static let screen: TimeInterval = 30
+    static let systemAlert: TimeInterval = 5
+}


### PR DESCRIPTION
## Description
This PR adds UI tests for iOS. They install the app on a simulator, walk through the tabs, open settings, and check that Discover shows data from the saved responses. This is the first step towards having the suite running, and a follow up will increase coverage.

## Changes
- Add the `tvmaniacUITests` target with four tests, covering a cold launch, all four tabs, navigation into settings and back, and Discover content
- Answer the app's network calls from the shared saved responses when a test names a scenario, so the suite gives the same result whether or not the services are reachable
- Add named scenarios a test can select, each holding the responses to serve and any credentials the app should start with
- Clear the database, the preferences and the saved credentials before the app starts, so one test cannot change what the next one reads
- Run the suite as a new `ios-ui-test` job on every pull request, reusing the framework the earlier job already built
- Add `screenTag` alongside `testTag`, because iOS does not expose a plain container to a test without it
- Describe the three iOS test layers and what each one covers
