### PR TITLE
chore: Test the Discover screen on iOS

### DIFF
--- a/ios/Packages/Components/Sources/Components/CarouselView.swift
+++ b/ios/Packages/Components/Sources/Components/CarouselView.swift
@@ -102,7 +102,7 @@ public struct CarouselView<T, Content: View>: View {
     }
 
     private func setupAutoScroll() {
-        guard items.count > 1 else { return }
+        guard items.count > 1, !isDrivenByUITest else { return }
         stopAutoScroll()
         let itemCount = items.count
         timerCancellable = Timer.publish(every: 5, on: .main, in: .common)
@@ -112,6 +112,13 @@ public struct CarouselView<T, Content: View>: View {
                     currentIndex = (currentIndex + 1) % itemCount
                 }
             }
+    }
+
+    /// A UI test cannot assert which item is on screen while the carousel moves on its own. The
+    /// launch environment naming a stub scenario is only ever set by one, so it doubles as the
+    /// signal to hold still.
+    private var isDrivenByUITest: Bool {
+        ProcessInfo.processInfo.environment["TVMANIAC_STUB_SCENARIO"] != nil
     }
 
     private func stopAutoScroll() {

--- a/ios/Packages/Components/Sources/Components/HorizontalShowContentView.swift
+++ b/ios/Packages/Components/Sources/Components/HorizontalShowContentView.swift
@@ -22,6 +22,7 @@ public struct HorizontalShowContentView: View {
     private let onMoreClicked: () -> Void
     private let spacing: CGFloat?
     private let edgeInsets: EdgeInsets?
+    private let cardTag: ((Int64) -> String)?
 
     public init(
         title: String,
@@ -33,7 +34,8 @@ public struct HorizontalShowContentView: View {
         spacing: CGFloat? = nil,
         edgeInsets: EdgeInsets? = nil,
         onClick: @escaping (Int64) -> Void,
-        onMoreClicked: @escaping () -> Void = {}
+        onMoreClicked: @escaping () -> Void = {},
+        cardTag: ((Int64) -> String)? = nil
     ) {
         self.title = title
         self.subtitle = subtitle
@@ -45,6 +47,7 @@ public struct HorizontalShowContentView: View {
         self.onMoreClicked = onMoreClicked
         self.spacing = spacing
         self.edgeInsets = edgeInsets
+        self.cardTag = cardTag
     }
 
     public var body: some View {
@@ -76,6 +79,7 @@ public struct HorizontalShowContentView: View {
                         .onTapGesture { onClick(item.showId) }
                         .accessibilityElement(children: .combine)
                         .accessibilityLabel("\(item.title), tap to view details")
+                        .testTag(cardTag?(item.showId))
                 }
             }
             .padding(edgeInsets ?? EdgeInsets(top: 0, leading: theme.spacing.medium, bottom: 0, trailing: 0))

--- a/ios/Packages/Components/Sources/Components/ViewModifiers/TestTagModifier.swift
+++ b/ios/Packages/Components/Sources/Components/ViewModifiers/TestTagModifier.swift
@@ -10,6 +10,12 @@ public extension View {
         accessibilityIdentifier(identifier)
     }
 
+    /// No-ops when `identifier` is nil, so a shared component can stay untagged for the callers
+    /// that do not need to reach its items.
+    func testTag(_ identifier: String?) -> some View {
+        modifier(OptionalTestTag(identifier: identifier))
+    }
+
     /// Tags a screen's outermost container so XCUITest can assert the screen is on
     /// display. Unlike `testTag`, this also publishes the container itself as an
     /// accessibility element, which SwiftUI otherwise skips for plain layout views,
@@ -18,5 +24,17 @@ public extension View {
     func screenTag(_ identifier: String) -> some View {
         accessibilityElement(children: .contain)
             .accessibilityIdentifier(identifier)
+    }
+}
+
+private struct OptionalTestTag: ViewModifier {
+    let identifier: String?
+
+    func body(content: Content) -> some View {
+        if let identifier {
+            content.accessibilityIdentifier(identifier)
+        } else {
+            content
+        }
     }
 }

--- a/ios/Packages/Discover/Sources/Discover/Sections/DiscoverCatalogSection.swift
+++ b/ios/Packages/Discover/Sources/Discover/Sections/DiscoverCatalogSection.swift
@@ -112,7 +112,8 @@ struct DiscoverCatalogContent: View {
                     cardStyle: .poster,
                     items: trendingShows,
                     onClick: onShowClicked,
-                    onMoreClicked: onTrendingMoreClicked
+                    onMoreClicked: onTrendingMoreClicked,
+                    cardTag: { DiscoverTestTags.shared.showCard(rowKey: DiscoverTestTags.shared.ROW_KEY_TRENDING, traktId: $0) }
                 )
             }
 
@@ -123,7 +124,8 @@ struct DiscoverCatalogContent: View {
                     cardStyle: .poster,
                     items: upcomingShows,
                     onClick: onShowClicked,
-                    onMoreClicked: onUpcomingMoreClicked
+                    onMoreClicked: onUpcomingMoreClicked,
+                    cardTag: { DiscoverTestTags.shared.showCard(rowKey: DiscoverTestTags.shared.ROW_KEY_UPCOMING, traktId: $0) }
                 )
             }
 
@@ -134,7 +136,8 @@ struct DiscoverCatalogContent: View {
                     cardStyle: .poster,
                     items: popularShows,
                     onClick: onShowClicked,
-                    onMoreClicked: onPopularMoreClicked
+                    onMoreClicked: onPopularMoreClicked,
+                    cardTag: { DiscoverTestTags.shared.showCard(rowKey: DiscoverTestTags.shared.ROW_KEY_POPULAR, traktId: $0) }
                 )
             }
 
@@ -145,7 +148,8 @@ struct DiscoverCatalogContent: View {
                     cardStyle: .poster,
                     items: topRatedShows,
                     onClick: onShowClicked,
-                    onMoreClicked: onTopRatedMoreClicked
+                    onMoreClicked: onTopRatedMoreClicked,
+                    cardTag: { DiscoverTestTags.shared.showCard(rowKey: DiscoverTestTags.shared.ROW_KEY_TOP_RATED, traktId: $0) }
                 )
             }
         }

--- a/ios/Packages/Discover/Sources/Discover/Sections/DiscoverFeaturedSection.swift
+++ b/ios/Packages/Discover/Sources/Discover/Sections/DiscoverFeaturedSection.swift
@@ -85,6 +85,7 @@ struct DiscoverFeaturedContent: View {
             ) { index in
                 carouselItemView(item: shows[index])
             }
+            .testTag(DiscoverTestTags.shared.FEATURED_PAGER_TEST_TAG)
         }
     }
 
@@ -101,6 +102,7 @@ struct DiscoverFeaturedContent: View {
             .onTapGesture {
                 onShowClicked(item.showId)
             }
+            .testTag(DiscoverTestTags.shared.featuredShowItem(traktId: item.showId))
         }
     }
 

--- a/ios/tvmaniacUITests/DiscoverContentTests.swift
+++ b/ios/tvmaniacUITests/DiscoverContentTests.swift
@@ -21,6 +21,10 @@ final class DiscoverContentTests: XCTestCase {
 }
 
 enum FixtureData {
-    /// First entry of `trakt/shows/favorite/success.json`, rendered by the featured section.
+    /// First two entries of `trakt/shows/favorite/success.json`, rendered by the featured section.
     static let featuredShowTitle = "Breaking Bad"
+    static let breakingBadId = 1396
+
+    /// Second entry of the featured carousel, matching what the Android journey asserts.
+    static let betterCallSaulId = 60059
 }

--- a/ios/tvmaniacUITests/DiscoverTests.swift
+++ b/ios/tvmaniacUITests/DiscoverTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+final class DiscoverTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func test_Discover_ShowsTrendingCardFromTheSavedResponses() {
+        let app = XCUIApplication.launchTvManiac()
+        app.awaitScreen(TestTags.discoverScreen)
+
+        let card = app.element(TestTags.discoverTrendingCard(FixtureData.breakingBadId))
+        XCTAssertTrue(
+            card.waitForExistence(timeout: UITestTimeouts.screen),
+            "Trending row never showed Breaking Bad. The app is not reading the saved responses."
+        )
+    }
+
+    func test_FeaturedPager_ChangesShowOnSwipe() {
+        let app = XCUIApplication.launchTvManiac()
+        app.awaitScreen(TestTags.discoverScreen)
+
+        let pager = app.scrollViews[TestTags.discoverFeaturedPager]
+        XCTAssertTrue(pager.waitForExistence(timeout: UITestTimeouts.screen))
+
+        let first = app.element(TestTags.discoverFeaturedItem(FixtureData.breakingBadId))
+        XCTAssertTrue(first.waitForExistence(timeout: UITestTimeouts.screen))
+
+        pager.swipeLeft()
+
+        let second = app.element(TestTags.discoverFeaturedItem(FixtureData.betterCallSaulId))
+        XCTAssertTrue(
+            second.waitForExistence(timeout: UITestTimeouts.screen),
+            "Swiping the featured pager did not reach the second featured show."
+        )
+    }
+}

--- a/ios/tvmaniacUITests/TestTags.swift
+++ b/ios/tvmaniacUITests/TestTags.swift
@@ -9,4 +9,14 @@ enum TestTags {
 
     static let profileSettingsButton = "profile_settings_button"
     static let settingsBackButton = "settings_back_button"
+
+    static let discoverFeaturedPager = "discover_featured_pager"
+
+    static func discoverFeaturedItem(_ showId: Int) -> String {
+        "discover_featured_show_\(showId)"
+    }
+
+    static func discoverTrendingCard(_ showId: Int) -> String {
+        "discover_show_card_trending_\(showId)"
+    }
 }

--- a/ios/tvmaniacUITests/XCUIApplicationExtensions.swift
+++ b/ios/tvmaniacUITests/XCUIApplicationExtensions.swift
@@ -30,6 +30,12 @@ extension XCUIApplication {
         otherElements[identifier]
     }
 
+    /// Looks up by identifier without naming a type. A card renders as an image when its poster
+    /// loads and as static text when it does not, so the type is not stable.
+    func element(_ identifier: String) -> XCUIElement {
+        descendants(matching: .any).matching(identifier: identifier).firstMatch
+    }
+
     @discardableResult
     func awaitScreen(
         _ identifier: String,


### PR DESCRIPTION
## Description
This PR adds two iOS tests for Discover. One checks that a show from the saved responses reaches the trending row, and the other swipes the featured carousel and checks the show changes. It is the first of several that grow iOS coverage one screen at a time.

## Changes
- Check that Breaking Bad reaches the trending row on Discover
- Swipe the featured carousel and check it moves from Breaking Bad to Better Call Saul, matching what the Android test checks
- Stop the featured carousel moving on its own while a test drives the app, so a test can tell which show is on screen
- Give each Discover card and each carousel item the same name Android gives it, so both platforms look for the same thing
- Look elements up by name alone, because a card is an image when its poster loads and text when it does not

## Bug Fixes
- Fix the Discover content test, which relied on the carousel coming back around to Breaking Bad inside the time it waited
