### PR TITLE
chore: Test show details on iOS

### DIFF
--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -23,6 +23,14 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 Run Snapshot Tests
 
+### ios ui_tests
+
+```sh
+[bundle exec] fastlane ios ui_tests
+```
+
+Run UI Tests
+
 ### ios record_snapshots
 
 ```sh

--- a/ios/Packages/ShowDetails/Sources/ShowDetails/SeasonProgressCard.swift
+++ b/ios/Packages/ShowDetails/Sources/ShowDetails/SeasonProgressCard.swift
@@ -2,6 +2,7 @@ import Components
 import DesignSystem
 import Models
 import SwiftUI
+import TvManiacKit
 
 public struct SeasonProgressCard: View {
     @Environment(\.appTheme) private var theme
@@ -26,6 +27,7 @@ public struct SeasonProgressCard: View {
             isSelected: isSelected,
             action: onClick
         )
+        .testTag(ShowDetailsTestTags.shared.seasonChip(seasonNumber: season.seasonNumber))
     }
 }
 

--- a/ios/Packages/ShowDetails/Sources/ShowDetails/ShowDetailsScreen.swift
+++ b/ios/Packages/ShowDetails/Sources/ShowDetails/ShowDetailsScreen.swift
@@ -2,6 +2,7 @@ import Components
 import DesignSystem
 import Models
 import SwiftUI
+import TvManiacKit
 
 public struct ShowDetailsScreen<Content: View>: View {
     public struct State {
@@ -116,6 +117,7 @@ public struct ShowDetailsScreen<Content: View>: View {
                 leadingIcon: {
                     GlassButton(icon: "chevron.left", action: onBack)
                         .opacity(1 - showGlass)
+                        .testTag(ShowDetailsTestTags.shared.BACK_BUTTON_TEST_TAG)
                 },
                 trailingIcon: {
                     GlassButton(icon: "arrow.clockwise", action: onRefresh)

--- a/ios/Packages/ShowDetails/Sources/ShowDetails/ShowDetailsView.swift
+++ b/ios/Packages/ShowDetails/Sources/ShowDetails/ShowDetailsView.swift
@@ -42,6 +42,7 @@ public struct ShowDetailsView: View {
                 showStatus: headerState.status
             )
         }
+        .screenTag(ShowDetailsTestTags.shared.SHOW_DETAILS_SCREEN_TEST_TAG)
         .onChange(of: hostState.message) { _, newValue in
             if let message = newValue {
                 toast = Toast(type: .error, title: "Error", message: message.message)

--- a/ios/tvmaniacUITests/ShowDetailsTests.swift
+++ b/ios/tvmaniacUITests/ShowDetailsTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+final class ShowDetailsTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func test_ShowDetails_ShowsSeasonsFromTheSavedResponses() {
+        let app = XCUIApplication.launchTvManiac(scenario: StubScenario.search)
+        app.openShowDetailsFromSearch()
+        app.awaitScreen(TestTags.showDetailsScreen)
+
+        let seasonChip = app.element(TestTags.showDetailsSeasonChip(1))
+        XCTAssertTrue(
+            seasonChip.waitForExistence(timeout: UITestTimeouts.screen),
+            "Show details never listed season 1. The app is not reading the saved responses."
+        )
+    }
+
+    func test_ShowDetails_GoesBackToSearch() {
+        let app = XCUIApplication.launchTvManiac(scenario: StubScenario.search)
+        app.openShowDetailsFromSearch()
+        app.awaitScreen(TestTags.showDetailsScreen)
+
+        let backButton = app.element(TestTags.showDetailsBackButton)
+        XCTAssertTrue(backButton.waitForExistence(timeout: UITestTimeouts.screen))
+        backButton.tap()
+
+        app.awaitScreen(TestTags.searchScreen)
+    }
+}

--- a/ios/tvmaniacUITests/TestTags.swift
+++ b/ios/tvmaniacUITests/TestTags.swift
@@ -25,4 +25,11 @@ enum TestTags {
     static func searchResultItem(_ showId: Int) -> String {
         "search_result_item_\(showId)"
     }
+
+    static let showDetailsScreen = "show_details_screen"
+    static let showDetailsBackButton = "show_details_back_button"
+
+    static func showDetailsSeasonChip(_ seasonNumber: Int) -> String {
+        "show_details_season_chip_\(seasonNumber)"
+    }
 }

--- a/ios/tvmaniacUITests/XCUIApplicationExtensions.swift
+++ b/ios/tvmaniacUITests/XCUIApplicationExtensions.swift
@@ -49,6 +49,34 @@ extension XCUIApplication {
         return element
     }
 
+    func openShowDetailsFromSearch(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        awaitScreen(TestTags.discoverScreen)
+        buttons[TestTags.discoverSearchButton].tap()
+        awaitScreen(TestTags.searchScreen)
+
+        let field = textFields[TestTags.searchBar]
+        XCTAssertTrue(
+            field.waitForExistence(timeout: UITestTimeouts.screen),
+            "The search field never appeared.",
+            file: file,
+            line: line
+        )
+        field.tap()
+        field.typeText(FixtureData.searchQuery)
+
+        let result = element(TestTags.searchResultItem(FixtureData.breakingBadId))
+        XCTAssertTrue(
+            result.waitForExistence(timeout: UITestTimeouts.screen),
+            "Searching for \(FixtureData.searchQuery) never showed a result to tap.",
+            file: file,
+            line: line
+        )
+        result.tap()
+    }
+
     func dismissSystemAlertIfPresent() {
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         let alert = springboard.alerts.firstMatch


### PR DESCRIPTION
## Description
This PR adds iOS tests for show details. They open a show from a search result, check the seasons come back from the saved responses, and check the back button returns to search.

## Changes
- Open a show from a search result and check the first season is listed from the saved responses
- Check the back button returns to search
- Give the show details screen, its back button and each season chip the same names Android gives them
- Put the search steps in one helper, since both tests walk the same path to reach show details
- Name the season chips rather than the title in the header. The header is laid out by a reader that measures the screen, and a name inside it does not reliably reach the tests
- Document the `ui_tests` fastlane lane, which was missing from the generated README