### PR TITLE
chore: Add My Shows UI Test on iOS

### DIFF
--- a/ios/Packages/MyShows/Sources/MyShows/MyShowsScreen.swift
+++ b/ios/Packages/MyShows/Sources/MyShows/MyShowsScreen.swift
@@ -2,6 +2,7 @@ import Components
 import DesignSystem
 import Models
 import SwiftUI
+import TvManiacKit
 import UpNext
 
 public struct MyShowsScreen: View {
@@ -226,6 +227,7 @@ public struct MyShowsScreen: View {
             title: state.emptyText,
             message: subtitle
         )
+        .screenTag(MyShowsTestTags.shared.EMPTY_STATE_TEST_TAG)
     }
 
     private var upNextEmptyView: some View {
@@ -233,5 +235,6 @@ public struct MyShowsScreen: View {
             systemName: "checkmark.circle",
             title: state.upToDateText
         )
+        .screenTag(MyShowsTestTags.shared.EMPTY_STATE_TEST_TAG)
     }
 }

--- a/ios/Packages/MyShows/Sources/MyShows/MyShowsSortOptionsSheet.swift
+++ b/ios/Packages/MyShows/Sources/MyShows/MyShowsSortOptionsSheet.swift
@@ -36,6 +36,7 @@ struct MyShowsSortOptionsSheet: View {
                 }
             }
         }
+        .screenTag(MyShowsTestTags.shared.SORT_SHEET_TEST_TAG)
     }
 
     private var sortBySection: some View {

--- a/ios/Packages/MyShows/Sources/MyShows/MyShowsTab.swift
+++ b/ios/Packages/MyShows/Sources/MyShows/MyShowsTab.swift
@@ -101,7 +101,9 @@ public struct MyShowsTab: View {
             set: { presenter.dispatch(action: MyShowsActionSelectPage(index: Int32($0))) }
         )) {
             Text(uiState.continueWatchingTitle).tag(0)
+                .testTag(MyShowsTestTags.shared.CONTINUE_WATCHING_TAB)
             Text(uiState.startWatchingTitle).tag(1)
+                .testTag(MyShowsTestTags.shared.START_WATCHING_TAB)
         }
         .pickerStyle(.segmented)
         .padding(.horizontal)
@@ -147,9 +149,11 @@ public struct MyShowsTab: View {
                             isSearchFocused = true
                         }
                     }
+                    .testTag(MyShowsTestTags.shared.SEARCH_BUTTON_TEST_TAG)
                     GlassButton(icon: "line.3.horizontal.decrease.circle") {
                         showSortOptions = true
                     }
+                    .testTag(MyShowsTestTags.shared.SORT_BUTTON_TEST_TAG)
                 }
             }
         }
@@ -236,6 +240,7 @@ public struct MyShowsTab: View {
                 systemName: "play.rectangle.on.rectangle",
                 title: String(\.label_start_watching_empty)
             )
+            .screenTag(StartWatchingTestTags.shared.EMPTY_STATE)
         } else {
             GridView(
                 items: startWatchingState.items.map { $0.toSwift() },

--- a/ios/tvmaniacUITests/MyShowsTests.swift
+++ b/ios/tvmaniacUITests/MyShowsTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+final class MyShowsTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func test_MyShows_ShowsEmptyStateWhenSignedOut() {
+        let app = XCUIApplication.launchTvManiac()
+        app.openTab(.myShows)
+
+        let emptyState = app.element(TestTags.myShowsEmptyState)
+        XCTAssertTrue(
+            emptyState.waitForExistence(timeout: UITestTimeouts.screen),
+            "My Shows never showed its empty state for a signed out account."
+        )
+    }
+
+    func test_MyShows_SwitchesToStartWatching() {
+        let app = XCUIApplication.launchTvManiac()
+        app.openTab(.myShows)
+
+        app.buttons[TestTags.myShowsStartWatchingTab].tap()
+
+        let emptyState = app.element(TestTags.startWatchingEmptyState)
+        XCTAssertTrue(
+            emptyState.waitForExistence(timeout: UITestTimeouts.screen),
+            "Start Watching never showed its empty state for a signed out account."
+        )
+    }
+
+    func test_MyShows_OpensSortOptions() {
+        let app = XCUIApplication.launchTvManiac()
+        app.openTab(.myShows)
+
+        app.buttons[TestTags.myShowsSortButton].tap()
+
+        let sheet = app.element(TestTags.myShowsSortSheet)
+        XCTAssertTrue(
+            sheet.waitForExistence(timeout: UITestTimeouts.screen),
+            "Tapping sort never opened the sort options."
+        )
+    }
+}

--- a/ios/tvmaniacUITests/ProgressTests.swift
+++ b/ios/tvmaniacUITests/ProgressTests.swift
@@ -8,7 +8,7 @@ final class ProgressTests: XCTestCase {
 
     func test_Progress_ShowsUpNextEmptyStateWhenSignedOut() {
         let app = XCUIApplication.launchTvManiac()
-        app.openProgress()
+        app.openTab(.progress)
 
         let emptyState = app.element(TestTags.upNextEmptyState)
         XCTAssertTrue(
@@ -19,7 +19,7 @@ final class ProgressTests: XCTestCase {
 
     func test_Progress_SwitchesToCalendar() {
         let app = XCUIApplication.launchTvManiac()
-        app.openProgress()
+        app.openTab(.progress)
 
         app.buttons[TestTags.progressCalendarTab].tap()
         app.awaitScreen(TestTags.calendarScreen)

--- a/ios/tvmaniacUITests/TestTags.swift
+++ b/ios/tvmaniacUITests/TestTags.swift
@@ -26,6 +26,13 @@ enum TestTags {
         "search_result_item_\(showId)"
     }
 
+    static let myShowsContinueWatchingTab = "my_shows_tab_0"
+    static let myShowsStartWatchingTab = "my_shows_tab_1"
+    static let myShowsEmptyState = "my_shows_empty_state"
+    static let myShowsSortButton = "my_shows_sort_button"
+    static let myShowsSortSheet = "my_shows_sort_sheet"
+    static let startWatchingEmptyState = "start_watching_empty_state"
+
     static let progressUpNextTab = "progress_tab_0"
     static let progressCalendarTab = "progress_tab_1"
     static let upNextEmptyState = "upnext_empty_state"

--- a/ios/tvmaniacUITests/XCUIApplicationExtensions.swift
+++ b/ios/tvmaniacUITests/XCUIApplicationExtensions.swift
@@ -49,7 +49,8 @@ extension XCUIApplication {
         return element
     }
 
-    func openProgress(
+    func openTab(
+        _ tab: TabIndex,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
@@ -59,8 +60,8 @@ extension XCUIApplication {
             file: file,
             line: line
         )
-        tabBar.buttons.element(boundBy: TabIndex.progress.rawValue).tap()
-        awaitScreen(TestTags.progressScreen)
+        tabBar.buttons.element(boundBy: tab.rawValue).tap()
+        awaitScreen(tab.screenTag, file: file, line: line)
     }
 
     func openShowDetailsFromSearch(


### PR DESCRIPTION
## Description
This PR adds iOS tests for the My Shows screen. They check that both pages tell a signed out account they have nothing saved, and that the sort button opens the sort options.

## Changes
- Check My Shows shows its empty state when nobody is signed in
- Switch to the Start Watching page and check it shows its own empty state
- Check the sort button opens the sort options
- Give the two page buttons, both empty states, the search and sort buttons and the sort sheet the same names Android gives them
- Replace the helper that opened the Progress tab with one that opens any tab, since the tests now reach two of them