### PR TITLE
chore: Test the Settings pages on iOS

### DIFF
--- a/ios/Packages/Settings/Sources/Settings/Components/AppearancePageView.swift
+++ b/ios/Packages/Settings/Sources/Settings/Components/AppearancePageView.swift
@@ -1,6 +1,7 @@
 import Components
 import DesignSystem
 import SwiftUI
+import TvManiacKit
 
 struct AppearancePageView<Theme: ThemeItem>: View {
     @Environment(\.appTheme) private var appTheme
@@ -44,6 +45,7 @@ struct AppearancePageView<Theme: ThemeItem>: View {
                                     isSelected: option.id == imageQualityItem.selectedOptionId,
                                     action: option.onSelect
                                 )
+                                .testTag(SettingsTestTags.shared.imageQualityChip(name: option.id))
                             }
                         }
                         Text(imageQualityItem.subtitle)

--- a/ios/Packages/Settings/Sources/Settings/Components/InfoPageView.swift
+++ b/ios/Packages/Settings/Sources/Settings/Components/InfoPageView.swift
@@ -1,5 +1,6 @@
 import DesignSystem
 import SwiftUI
+import TvManiacKit
 
 struct InfoPageView: View {
     @Environment(\.appTheme) private var appTheme
@@ -26,6 +27,7 @@ struct InfoPageView: View {
                     .textStyle(appTheme.typography.bodyLarge)
                     .foregroundColor(appTheme.colors.secondary)
                     .onTapGesture(perform: content.onVersionTap)
+                    .testTag(SettingsTestTags.shared.INFO_VERSION_TEXT_TEST_TAG)
             }
             .frame(maxWidth: .infinity)
             .padding(.top, appTheme.spacing.large)

--- a/ios/Packages/Settings/Sources/Settings/Components/SettingsRootContentView.swift
+++ b/ios/Packages/Settings/Sources/Settings/Components/SettingsRootContentView.swift
@@ -1,5 +1,6 @@
 import DesignSystem
 import SwiftUI
+import TvManiacKit
 
 struct SettingsRootContentView: View {
     @Environment(\.appTheme) private var appTheme
@@ -17,6 +18,7 @@ struct SettingsRootContentView: View {
                     SettingsCard {
                         ForEach(Array(section.items.enumerated()), id: \.element.id) { index, item in
                             SettingsNavigationRow(item)
+                                .testTag(rootRowTestTag(for: item.id))
                             if index != section.items.count - 1 {
                                 SettingsRowDivider()
                             }
@@ -24,6 +26,21 @@ struct SettingsRootContentView: View {
                     }
                 }
             }
+        }
+    }
+
+    private func rootRowTestTag(for id: String) -> String? {
+        let tags = SettingsTestTags.shared
+        switch SettingsPageRoute(rawValue: id) {
+        case .appearance: return tags.GENERAL_APPEARANCE_ROW_TEST_TAG
+        case .layout: return tags.GENERAL_LAYOUT_ROW_TEST_TAG
+        case .behavior: return tags.GENERAL_BEHAVIOR_ROW_TEST_TAG
+        case .notifications: return tags.GENERAL_NOTIFICATIONS_ROW_TEST_TAG
+        case .privacy: return tags.GENERAL_PRIVACY_ROW_TEST_TAG
+        case .info: return tags.ABOUT_INFO_ROW_TEST_TAG
+        case .licenses: return tags.ABOUT_LICENSES_ROW_TEST_TAG
+        case .account: return tags.ACCOUNT_TRAKT_ROW_TEST_TAG
+        default: return nil
         }
     }
 }

--- a/ios/tvmaniacUITests/SettingsNavigationTests.swift
+++ b/ios/tvmaniacUITests/SettingsNavigationTests.swift
@@ -6,18 +6,31 @@ final class SettingsNavigationTests: XCTestCase {
         continueAfterFailure = false
     }
 
-    func test_Settings_OpensFromProfileAndReturns() {
+    func test_Settings_WalksItsPagesAndReturnsToProfile() {
         let app = XCUIApplication.launchTvManiac()
-        XCTAssertTrue(app.tabBar.waitForExistence(timeout: UITestTimeouts.launch))
-
-        app.tabBar.buttons.element(boundBy: TabIndex.profile.rawValue).tap()
-        app.awaitScreen(TestTags.profileScreen)
+        app.openTab(.profile)
 
         let settingsButton = app.buttons[TestTags.profileSettingsButton]
-        XCTAssertTrue(settingsButton.waitForExistence(timeout: UITestTimeouts.screen))
+        XCTAssertTrue(
+            settingsButton.waitForExistence(timeout: UITestTimeouts.screen),
+            "Profile never showed its settings button."
+        )
         settingsButton.tap()
-
         app.awaitScreen(TestTags.settingsScreen)
+
+        app.openSettingsPage(TestTags.settingsAppearanceRow)
+        XCTAssertTrue(
+            app.element(TestTags.settingsImageQualityChip("AUTO")).waitForExistence(timeout: UITestTimeouts.screen),
+            "The appearance page never showed the image quality choices."
+        )
+        app.leaveSettingsPage()
+
+        app.openSettingsPage(TestTags.settingsInfoRow)
+        XCTAssertTrue(
+            app.element(TestTags.settingsVersionText).waitForExistence(timeout: UITestTimeouts.screen),
+            "The about page never showed the version."
+        )
+        app.leaveSettingsPage()
 
         app.buttons[TestTags.settingsBackButton].tap()
         app.awaitScreen(TestTags.profileScreen)

--- a/ios/tvmaniacUITests/TestTags.swift
+++ b/ios/tvmaniacUITests/TestTags.swift
@@ -7,6 +7,13 @@ enum TestTags {
 
     static let profileSettingsButton = "profile_settings_button"
     static let settingsBackButton = "settings_back_button"
+    static let settingsAppearanceRow = "settings_general_appearance_row"
+    static let settingsInfoRow = "settings_about_info_row"
+    static let settingsVersionText = "settings_info_version_text"
+
+    static func settingsImageQualityChip(_ quality: String) -> String {
+        "settings_image_quality_\(quality.lowercased())"
+    }
 
     static func discoverShowCard(row: DiscoverRow, showId: Int) -> String {
         "discover_show_card_\(row.rawValue)_\(showId)"

--- a/ios/tvmaniacUITests/XCUIApplicationExtensions.swift
+++ b/ios/tvmaniacUITests/XCUIApplicationExtensions.swift
@@ -64,6 +64,25 @@ extension XCUIApplication {
         awaitScreen(tab.screenTag, file: file, line: line)
     }
 
+    func openSettingsPage(
+        _ rowTag: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let row = element(rowTag)
+        XCTAssertTrue(
+            row.waitForExistence(timeout: UITestTimeouts.screen),
+            "Settings never showed the \"\(rowTag)\" row.",
+            file: file,
+            line: line
+        )
+        row.tap()
+    }
+
+    func leaveSettingsPage() {
+        buttons[TestTags.settingsBackButton].tap()
+    }
+
     func openShowDetailsFromSearch(
         file: StaticString = #filePath,
         line: UInt = #line


### PR DESCRIPTION
## Description
This PR adds iOS tests for the Settings pages.

## Changes
- Walk into the Appearance and About pages and back out, then leave Settings
- Give every row on the Settings list the same name Android gives it
- Give the image quality choices and the version text the same names Android gives them