### PR TITLE
fix: Stop the UI tests fetching posters

### DIFF
--- a/ios/Packages/Components/Sources/Components/CarouselView.swift
+++ b/ios/Packages/Components/Sources/Components/CarouselView.swift
@@ -102,7 +102,7 @@ public struct CarouselView<T, Content: View>: View {
     }
 
     private func setupAutoScroll() {
-        guard items.count > 1, !isDrivenByUITest else { return }
+        guard items.count > 1, !isRunningUITests else { return }
         stopAutoScroll()
         let itemCount = items.count
         timerCancellable = Timer.publish(every: 5, on: .main, in: .common)
@@ -116,7 +116,7 @@ public struct CarouselView<T, Content: View>: View {
 
     /// No test can assert which item is on screen while the carousel moves on its own. Only a UI
     /// test sets this variable, so it doubles as the signal to hold still.
-    private var isDrivenByUITest: Bool {
+    private var isRunningUITests: Bool {
         ProcessInfo.processInfo.environment["TVMANIAC_STUB_SCENARIO"] != nil
     }
 

--- a/ios/Packages/CoreKit/Sources/CoreKit/ImageCacheManager.swift
+++ b/ios/Packages/CoreKit/Sources/CoreKit/ImageCacheManager.swift
@@ -22,6 +22,10 @@ import UIKit
 public enum ImageCacheManager {
     private static var isConfigured = false
 
+    private static var isRunningUITests: Bool {
+        ProcessInfo.processInfo.environment["TVMANIAC_STUB_SCENARIO"] != nil
+    }
+
     /// Configures the shared `ImagePipeline` with memory-aware limits.
     /// Safe to call multiple times — subsequent calls are no-ops.
     public static func configure() {
@@ -47,11 +51,16 @@ public enum ImageCacheManager {
             memoryCapacity: isLowMem ? 2 * 1024 * 1024 : 5 * 1024 * 1024,
             diskCapacity: 100 * 1024 * 1024
         )
-        config.dataLoader = DataLoader(configuration: {
-            let configuration = DataLoader.defaultConfiguration
-            configuration.urlCache = urlCache
-            return configuration
-        }())
+        if isRunningUITests {
+            config.dataLoader = StubImageDataLoader()
+            config.dataCache = nil
+        } else {
+            config.dataLoader = DataLoader(configuration: {
+                let configuration = DataLoader.defaultConfiguration
+                configuration.urlCache = urlCache
+                return configuration
+            }())
+        }
 
         ImagePipeline.shared = ImagePipeline(configuration: config)
     }

--- a/ios/Packages/CoreKit/Sources/CoreKit/StubImageDataLoader.swift
+++ b/ios/Packages/CoreKit/Sources/CoreKit/StubImageDataLoader.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Nuke
+import UIKit
+
+struct StubImageDataLoader: DataLoading {
+    private static let placeholder: Data = {
+        let size = CGSize(width: 8, height: 12)
+        let image = UIGraphicsImageRenderer(size: size).image { context in
+            UIColor.darkGray.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
+        return image.pngData() ?? Data()
+    }()
+
+    func loadData(
+        with request: URLRequest,
+        didReceiveData: @escaping @Sendable (Data, URLResponse) -> Void,
+        completion: @escaping @Sendable (Error?) -> Void
+    ) -> any Cancellable {
+        let data = Self.placeholder
+        let response = URLResponse(
+            url: request.url ?? URL(fileURLWithPath: "/"),
+            mimeType: "image/png",
+            expectedContentLength: data.count,
+            textEncodingName: nil
+        )
+        didReceiveData(data, response)
+        completion(nil)
+        return NoopCancellable()
+    }
+}
+
+private final class NoopCancellable: Cancellable {
+    func cancel() {}
+}


### PR DESCRIPTION
## Description
This PR stops the iOS UI tests reaching the internet.

## Bug Fixes
- Serve posters from a placeholder made on the device while the tests run. The saved responses cover what the app asks the shows api for, but posters are fetched separately and were still going out on every screen, so a run depended on a network we do not control and on whether a poster was loaded. That also decides whether a card draws as a picture or falls back to its title, which is what made an earlier Discover check pass and fail at random
