### PR TITLE
chore: Update Fastlane configuration

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,3 @@
-require 'json'
-
 default_platform(:ios)
 
 TEST_DEVICE = "iPhone 17 Pro"
@@ -71,12 +69,13 @@ platform :ios do
   desc "Run UI Tests"
   lane :ui_tests do
     build_kmp_framework
-    boot_test_simulator
 
     run_tests(
       project: "ios/tv-maniac.xcodeproj",
       scheme: "tv-maniac",
       destination: TEST_DESTINATION,
+      devices: ["#{TEST_DEVICE} (#{TEST_OS})"],
+      prelaunch_simulator: true,
       skip_detect_devices: true,
       result_bundle: true,
       xcargs: "-skipPackagePluginValidation " \
@@ -88,18 +87,6 @@ platform :ios do
       fail_build: true,
       derived_data_path: DERIVED_DATA_PATH
     )
-  end
-
-  desc "Start the test simulator and wait for it to finish booting"
-  private_lane :boot_test_simulator do
-    runtime = "com.apple.CoreSimulator.SimRuntime.iOS-#{TEST_OS.tr('.', '-')}"
-    devices = JSON.parse(sh("xcrun simctl list devices available -j", log: false))["devices"]
-    device = (devices[runtime] || []).find { |candidate| candidate["name"] == TEST_DEVICE }
-
-    UI.user_error!("No #{TEST_DEVICE} available on iOS #{TEST_OS}") if device.nil?
-
-    sh("xcrun simctl boot #{device['udid']}") unless device["state"] == "Booted"
-    sh("xcrun simctl bootstatus #{device['udid']} -b")
   end
 
   desc "Re-record snapshot baselines"


### PR DESCRIPTION
## Description
This PR removes the `boot_test_simulator` lane and updates the configuration by adding the `prelaunch_simulator` flag. Fastlane already starts the simulator and waits for it, using the same command the lane ran, so the lane was doing work Fastlane does itself.

## Changes
- Remove the `boot_test_simulator` lane
- Add `prelaunch_simulator` so Fastlane starts the simulator, and `devices` so it knows which one. It reads the device from `devices` rather than `destination`, so without it the flag does nothing