### PR TITLE
test: Add token refresh tests for the Trakt HTTP client

### DIFF
--- a/api/trakt/implementation/build.gradle.kts
+++ b/api/trakt/implementation/build.gradle.kts
@@ -50,9 +50,12 @@ kotlin {
                 implementation(libs.ktor.serialization.json)
                 implementation(projects.api.trakt.api)
                 implementation(projects.api.trakt.testing)
+                implementation(projects.core.connectivity.testing)
+                implementation(projects.core.logger.testing)
                 implementation(projects.core.networkUtil.api)
                 implementation(projects.data.calendar.api)
                 implementation(projects.data.followedshows.testing)
+                implementation(projects.data.traktauth.testing)
             }
         }
 

--- a/api/trakt/implementation/src/commonTest/kotlin/com/thomaskioko/trakt/service/implementation/TraktHttpClientAuthTest.kt
+++ b/api/trakt/implementation/src/commonTest/kotlin/com/thomaskioko/trakt/service/implementation/TraktHttpClientAuthTest.kt
@@ -1,0 +1,128 @@
+package com.thomaskioko.trakt.service.implementation
+
+import com.thomaskioko.tvmaniac.accountmanager.api.AuthState
+import com.thomaskioko.tvmaniac.accountmanager.api.TokenRefreshResult
+import com.thomaskioko.tvmaniac.core.connectivity.testing.FakeInternetConnectionChecker
+import com.thomaskioko.tvmaniac.core.logger.fixture.FakeLogger
+import com.thomaskioko.tvmaniac.traktauth.testing.FakeTraktAuthRepository
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.get
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+
+class TraktHttpClientAuthTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun client(
+        repository: FakeTraktAuthRepository,
+        statuses: MutableList<HttpStatusCode>,
+        authorizationHeaders: MutableList<String?> = mutableListOf(),
+    ): HttpClient {
+        val engine = MockEngine { request ->
+            authorizationHeaders += request.headers[HttpHeaders.Authorization]
+            respond(
+                content = "{}",
+                status = statuses.removeFirst(),
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        return traktHttpClient(
+            traktClientId = "test-client-id",
+            json = json,
+            httpClientEngine = engine,
+            kermitLogger = FakeLogger(),
+            oAuthRepository = repository,
+            internetConnectionChecker = FakeInternetConnectionChecker(),
+        )
+    }
+
+    private fun authState(accessToken: String, refreshToken: String) = AuthState(
+        accessToken = accessToken,
+        refreshToken = refreshToken,
+        isAuthorized = true,
+    )
+
+    @Test
+    fun `should refresh tokens and retry given the first request is unauthorized`() = runTest {
+        val repository = FakeTraktAuthRepository()
+        repository.setAuthState(authState("stale-access", "stale-refresh"))
+        repository.setRefreshOutcome(
+            TokenRefreshResult.Success(authState("fresh-access", "fresh-refresh")),
+        )
+        val sentAuthorization = mutableListOf<String?>()
+        val client = client(
+            repository = repository,
+            statuses = mutableListOf(HttpStatusCode.Unauthorized, HttpStatusCode.OK),
+            authorizationHeaders = sentAuthorization,
+        )
+
+        val response = client.get("https://api.trakt.tv/users/me")
+
+        response.status shouldBe HttpStatusCode.OK
+        repository.refreshTokenCallCount() shouldBe 1
+        sentAuthorization.first() shouldBe "Bearer stale-access"
+        sentAuthorization.last() shouldBe "Bearer fresh-access"
+    }
+
+    @Test
+    fun `should reuse the stored tokens given another caller already refreshed them`() = runTest {
+        val repository = FakeTraktAuthRepository()
+        repository.setAuthState(authState("stale-access", "stale-refresh"))
+        repository.setRefreshOutcome(
+            TokenRefreshResult.Success(authState("unused-access", "unused-refresh")),
+        )
+        val sentAuthorization = mutableListOf<String?>()
+        val statuses = mutableListOf(HttpStatusCode.Unauthorized, HttpStatusCode.OK)
+        val engine = MockEngine { request ->
+            sentAuthorization += request.headers[HttpHeaders.Authorization]
+            val status = statuses.removeFirst()
+            if (status == HttpStatusCode.Unauthorized) {
+                repository.setAuthState(authState("other-caller-access", "other-caller-refresh"))
+            }
+            respond(
+                content = "{}",
+                status = status,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = traktHttpClient(
+            traktClientId = "test-client-id",
+            json = json,
+            httpClientEngine = engine,
+            kermitLogger = FakeLogger(),
+            oAuthRepository = repository,
+            internetConnectionChecker = FakeInternetConnectionChecker(),
+        )
+
+        val response = client.get("https://api.trakt.tv/users/me")
+
+        response.status shouldBe HttpStatusCode.OK
+        repository.refreshTokenCallCount() shouldBe 0
+        sentAuthorization.first() shouldBe "Bearer stale-access"
+        sentAuthorization.last() shouldBe "Bearer other-caller-access"
+    }
+
+    @Test
+    fun `should not retry given the refresh fails`() = runTest {
+        val repository = FakeTraktAuthRepository()
+        repository.setAuthState(authState("stale-access", "stale-refresh"))
+        repository.setRefreshOutcome(TokenRefreshResult.NotLoggedIn)
+        val client = client(
+            repository = repository,
+            statuses = mutableListOf(HttpStatusCode.Unauthorized),
+        )
+
+        val response = client.get("https://api.trakt.tv/users/me")
+
+        response.status shouldBe HttpStatusCode.Unauthorized
+        repository.refreshTokenCallCount() shouldBe 1
+    }
+}

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/journey/AuthenticatedUserJourneyTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/journey/AuthenticatedUserJourneyTest.kt
@@ -169,9 +169,6 @@ internal class AuthenticatedUserJourneyTest : BaseAppFlowTest() {
             .scrollToUpNextEpisode(breakingBadTmdbId)
             .assertUpNextEpisodeDisplayed(breakingBadTmdbId)
 
-        // Trigger token refresh round-trip
-        scenarios.stubTokenRefresh()
-
         homeRobot
             .clickProfileTab()
             .assertTabSelected(HomeTestTags.PROFILE_TAB)

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
@@ -209,36 +209,6 @@ internal class Scenarios(
         stubUnauthenticatedState()
     }
 
-    /**
-     * Simulates 401-then-refresh round-trip on `/users/me`. Configures fake repo with fresh
-     * AuthState so next refresh resolves successfully, and re-stubs the profile endpoints so
-     * post-refresh calls pass. Stubs the profile endpoints directly rather than going through
-     * [stubActiveProvider], which would also reset the auth/refresh state this test is verifying.
-     */
-    fun stubTokenRefresh(
-        provider: SyncProviderSource = SyncProviderSource.TRAKT,
-        accessToken: String = "refreshed-access",
-        refreshToken: String = "refreshed-refresh",
-        tokenLifetimeSeconds: Long = 3600,
-    ) {
-        when (provider) {
-            SyncProviderSource.TRAKT -> {
-                val refreshedAuthState = AuthState(
-                    accessToken = accessToken,
-                    refreshToken = refreshToken,
-                    isAuthorized = true,
-                    expiresAt = Clock.System.now() + tokenLifetimeSeconds.seconds,
-                    tokenLifetimeSeconds = tokenLifetimeSeconds,
-                )
-                graph.traktAuthRepository.setRefreshOutcome(TokenRefreshResult.Success(refreshedAuthState))
-                http.stubTraktTokenRefreshEndpoints()
-            }
-            SyncProviderSource.SIMKL -> error(
-                "Simkl token refresh is not stubbed yet; add it when a Simkl refresh journey exists.",
-            )
-        }
-    }
-
     inner class Auth {
         fun stubLoggedInUser(
             accessToken: String = TEST_ACCESS_TOKEN,

--- a/core/integration/stubs/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/HttpScenarios.kt
+++ b/core/integration/stubs/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/HttpScenarios.kt
@@ -189,14 +189,6 @@ public class HttpScenarios(private val mockHandler: MockEngineHandler) {
         Endpoints.Simkl.authenticatedEndpoints.forEach { mockHandler.stubEndpoint(it) }
     }
 
-    public fun stubTraktTokenRefreshEndpoints(slug: String = TEST_PROFILE_SLUG) {
-        mockHandler.stubEndpoint(Endpoints.Trakt.UsersMe, HttpStatusCode.Unauthorized)
-        mockHandler.stubEndpoint(Endpoints.Trakt.UsersMe)
-        mockHandler.stubEndpoint(Endpoints.Trakt.userStats(slug))
-        mockHandler.stubEndpoint(Endpoints.Trakt.userLists(slug))
-        mockHandler.stubEndpoint(Endpoints.Trakt.UserListItems)
-    }
-
     private fun stubShowsFrom(fixturePath: String) {
         showFixtures(FixtureLoader.load(fixturePath)).forEach { mockHandler.stubShow(it) }
     }

--- a/data/traktauth/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/testing/FakeTraktAuthRepository.kt
+++ b/data/traktauth/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktauth/testing/FakeTraktAuthRepository.kt
@@ -26,6 +26,7 @@ public class FakeTraktAuthRepository : OAuthRepository {
     private val _state = MutableStateFlow(AccountAuthState.LOGGED_OUT)
     private val _authState = MutableStateFlow<AuthState?>(null)
     private var refreshOutcome: TokenRefreshResult = TokenRefreshResult.NotLoggedIn
+    private var refreshCount: Int = 0
     private val _authError = MutableStateFlow<AuthError?>(null)
     private val _loginEvents = MutableSharedFlow<Unit>(replay = 1, extraBufferCapacity = 1)
 
@@ -40,6 +41,9 @@ public class FakeTraktAuthRepository : OAuthRepository {
     public fun setRefreshOutcome(outcome: TokenRefreshResult) {
         refreshOutcome = outcome
     }
+
+    /** How many times [refreshTokens] has been called, so tests can assert a refresh happened. */
+    public fun refreshTokenCallCount(): Int = refreshCount
 
     /**
      * Emits a login event in tests without going through the real OAuth handshake.
@@ -61,7 +65,10 @@ public class FakeTraktAuthRepository : OAuthRepository {
 
     override suspend fun getAuthState(): AuthState? = _authState.value
 
-    override suspend fun refreshTokens(): TokenRefreshResult = refreshOutcome
+    override suspend fun refreshTokens(): TokenRefreshResult {
+        refreshCount++
+        return refreshOutcome
+    }
 
     override suspend fun logout() {
         _state.emit(AccountAuthState.LOGGED_OUT)


### PR DESCRIPTION
## Description
This PR replaces a token refresh step that never ran with real tests for the Trakt HTTP client. The step stubbed a failed request followed by a successful one, but stub matching takes the last registered entry first, so the success stub always won and the refresh path was never exercised.

## Changes
- Add tests covering the three token refresh outcomes: refresh and retry after a rejected request, reuse tokens another caller already refreshed, and return the failure when the refresh itself fails.
- Add a refresh counter to the fake auth repository so tests can tell a real refresh from a reused token.
- Remove the token refresh step from the authenticated journey test and the two stub helpers it was the only caller of.
