### PR TITLE
chore: Shrink the iOS framework

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1229,7 +1229,6 @@ graph TB
   :features:discover:presenter --> :domain:episode
   :features:discover:presenter --> :domain:followedshows
   :features:discover:presenter --> :domain:genre
-  :features:discover:presenter --> :domain:showdetails
   :features:discover:presenter --> :domain:start-watching
   :features:discover:presenter --> :features:discover:nav
   :features:discover:presenter -.-> :features:episode-sheet:nav

--- a/data/account-manager/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/api/SyncProviderSource.kt
+++ b/data/account-manager/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/accountmanager/api/SyncProviderSource.kt
@@ -1,6 +1,8 @@
 package com.thomaskioko.tvmaniac.accountmanager.api
 
 import com.thomaskioko.tvmaniac.db.Provider
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
 
 public enum class SyncProviderSource {
     TRAKT,
@@ -13,6 +15,8 @@ public val SyncProviderSource.displayName: String
         SyncProviderSource.SIMKL -> "Simkl"
     }
 
+@OptIn(ExperimentalObjCRefinement::class)
+@HiddenFromObjC
 public fun SyncProviderSource.toDbProvider(): Provider = when (this) {
     SyncProviderSource.TRAKT -> Provider.TRAKT
     SyncProviderSource.SIMKL -> Provider.SIMKL

--- a/domain/seasondetails/build.gradle.kts
+++ b/domain/seasondetails/build.gradle.kts
@@ -8,11 +8,6 @@ scaffold {
 
 kotlin {
     sourceSets {
-        androidMain {
-            dependencies {
-                implementation(projects.data.database.sqldelight)
-            }
-        }
 
         commonMain {
             dependencies {

--- a/domain/showdetails/build.gradle.kts
+++ b/domain/showdetails/build.gradle.kts
@@ -10,12 +10,6 @@ scaffold {
 
 kotlin {
     sourceSets {
-        androidMain {
-            dependencies {
-                implementation(projects.data.database.sqldelight)
-            }
-        }
-
         commonMain {
             dependencies {
                 api(libs.coroutines.core)

--- a/features/calendar/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/calendar/CalendarPresenter.kt
+++ b/features/calendar/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/calendar/CalendarPresenter.kt
@@ -45,7 +45,7 @@ import kotlinx.coroutines.flow.combine as combineFlows
 
 @ChildPresenter(scope = ProgressChildScope::class, parentScope = ProgressRoot::class)
 @Inject
-public class CalendarPresenter(
+public class CalendarPresenter internal constructor(
     componentContext: ComponentContext,
     private val navigator: Navigator,
     private val observeCalendarInteractor: ObserveCalendarInteractor,

--- a/features/calendar/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/calendar/CalendarStateMapper.kt
+++ b/features/calendar/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/calendar/CalendarStateMapper.kt
@@ -18,7 +18,7 @@ public class CalendarStateMapper(
 
     public fun getString(key: StringResourceKey): String = localizer.getString(key)
 
-    public fun toCalendarDateGroups(
+    internal fun toCalendarDateGroups(
         entries: List<GroupedCalendarEntry>,
     ): ImmutableList<CalendarDateGroup> {
         return entries.map { group ->

--- a/features/continue-watching/presenter/build.gradle.kts
+++ b/features/continue-watching/presenter/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
         androidMain {
             dependencies {
                 api(projects.core.syncstate.api)
-                api(projects.data.database.sqldelight)
+                implementation(projects.data.database.sqldelight)
                 implementation(projects.i18n.generator)
             }
         }

--- a/features/continue-watching/presenter/build.gradle.kts
+++ b/features/continue-watching/presenter/build.gradle.kts
@@ -36,7 +36,6 @@ kotlin {
         androidMain {
             dependencies {
                 api(projects.core.syncstate.api)
-                implementation(projects.data.database.sqldelight)
                 implementation(projects.i18n.generator)
             }
         }

--- a/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingMapper.kt
+++ b/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingMapper.kt
@@ -36,7 +36,7 @@ public class ContinueWatchingMapper(
         },
     )
 
-    public fun toSectionedItems(
+    internal fun toSectionedItems(
         sections: WatchlistSections,
         sortOption: WatchlistSortOption,
     ): SectionedItems {
@@ -47,7 +47,7 @@ public class ContinueWatchingMapper(
         )
     }
 
-    public fun toSectionedEpisodes(sections: UpNextSections): SectionedEpisodes = sections.toPresenter()
+    internal fun toSectionedEpisodes(sections: UpNextSections): SectionedEpisodes = sections.toPresenter()
 
     private fun ImmutableList<ContinueWatchingItem>.applySorting(
         sortOption: WatchlistSortOption,

--- a/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingPresenter.kt
+++ b/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingPresenter.kt
@@ -42,7 +42,7 @@ import kotlinx.coroutines.launch
 
 @ChildPresenter(scope = MyShowsChildScope::class, parentScope = MyShowsRoot::class)
 @Inject
-public class ContinueWatchingPresenter(
+public class ContinueWatchingPresenter internal constructor(
     @ContinueWatchingNitroFlagQualifier
     nitroFlag: FeatureFlag<Boolean>,
     syncObserver: SyncObserver,

--- a/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/Mapper.kt
+++ b/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/Mapper.kt
@@ -19,7 +19,7 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import com.thomaskioko.tvmaniac.domain.continuewatching.model.EpisodeBadge as DomainEpisodeBadge
 
-public fun List<FollowedShows>.entityToWatchlistShowList(
+internal fun List<FollowedShows>.entityToWatchlistShowList(
     lastWatchedMap: Map<Long, Long?> = emptyMap(),
 ): PersistentList<ContinueWatchingItem> {
     return this.map {
@@ -43,7 +43,7 @@ public fun List<FollowedShows>.entityToWatchlistShowList(
         .toPersistentList()
 }
 
-public fun List<SearchFollowedShows>.entityToWatchlistShowList(
+internal fun List<SearchFollowedShows>.entityToWatchlistShowList(
     lastWatchedMap: Map<Long, Long?> = emptyMap(),
 ): ImmutableList<ContinueWatchingItem> {
     return this.map {

--- a/features/debug/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/debug/presenter/DebugPresenter.kt
+++ b/features/debug/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/debug/presenter/DebugPresenter.kt
@@ -44,7 +44,7 @@ import com.thomaskioko.tvmaniac.domain.notifications.interactor.ScheduleDebugEpi
     kind = DestinationKind.SCREEN,
 )
 @Inject
-public class DebugPresenter(
+public class DebugPresenter internal constructor(
     componentContext: ComponentContext,
     private val navigator: Navigator,
     private val datastoreRepository: DatastoreRepository,

--- a/features/discover/presenter/README.md
+++ b/features/discover/presenter/README.md
@@ -302,7 +302,6 @@ graph TB
   :features:discover:presenter --> :domain:episode
   :features:discover:presenter --> :domain:followedshows
   :features:discover:presenter --> :domain:genre
-  :features:discover:presenter --> :domain:showdetails
   :features:discover:presenter --> :domain:start-watching
   :features:discover:presenter --> :features:discover:nav
   :features:discover:presenter -.-> :features:episode-sheet:nav

--- a/features/discover/presenter/build.gradle.kts
+++ b/features/discover/presenter/build.gradle.kts
@@ -20,7 +20,6 @@ kotlin {
                 api(projects.domain.episode)
                 api(projects.domain.followedshows)
                 api(projects.domain.genre)
-                api(projects.domain.showdetails)
                 api(projects.domain.startWatching)
                 api(projects.features.discover.nav)
                 api(projects.i18n.api)

--- a/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/catalog/DiscoverCatalogPresenter.kt
+++ b/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/catalog/DiscoverCatalogPresenter.kt
@@ -45,7 +45,7 @@ import kotlinx.coroutines.launch
 
 @ChildPresenter(scope = DiscoverChildScope::class, parentScope = DiscoverRoot::class)
 @Inject
-public class DiscoverCatalogPresenter(
+public class DiscoverCatalogPresenter internal constructor(
     componentContext: ComponentContext,
     private val navigator: Navigator,
     private val observeTrendingShowsInteractor: ObserveTrendingShowsInteractor,

--- a/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/startwatching/DiscoverStartWatchingPresenter.kt
+++ b/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/startwatching/DiscoverStartWatchingPresenter.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.flow.stateIn
 
 @ChildPresenter(scope = DiscoverChildScope::class, parentScope = DiscoverRoot::class)
 @Inject
-public class DiscoverStartWatchingPresenter(
+public class DiscoverStartWatchingPresenter internal constructor(
     componentContext: ComponentContext,
     private val navigator: Navigator,
     private val observeStartWatchingInteractor: ObserveStartWatchingInteractor,

--- a/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/upnext/DiscoverUpNextPresenter.kt
+++ b/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/upnext/DiscoverUpNextPresenter.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.flow.stateIn
 
 @ChildPresenter(scope = DiscoverChildScope::class, parentScope = DiscoverRoot::class)
 @Inject
-public class DiscoverUpNextPresenter(
+public class DiscoverUpNextPresenter internal constructor(
     componentContext: ComponentContext,
     private val navigator: Navigator,
     observeUpNextInteractor: ObserveUpNextInteractor,

--- a/features/discover/ui/README.md
+++ b/features/discover/ui/README.md
@@ -311,7 +311,6 @@ graph TB
   :features:discover:presenter --> :domain:episode
   :features:discover:presenter --> :domain:followedshows
   :features:discover:presenter --> :domain:genre
-  :features:discover:presenter --> :domain:showdetails
   :features:discover:presenter --> :domain:start-watching
   :features:discover:presenter --> :features:discover:nav
   :features:discover:presenter -.-> :features:episode-sheet:nav

--- a/features/episode-sheet/presenter/build.gradle.kts
+++ b/features/episode-sheet/presenter/build.gradle.kts
@@ -38,7 +38,6 @@ kotlin {
                 implementation(libs.bundles.unittest)
                 implementation(projects.core.base.testing)
                 implementation(projects.core.logger.testing)
-                implementation(projects.data.database.sqldelight)
                 implementation(projects.data.episode.testing)
                 implementation(projects.data.ratings.testing)
                 implementation(projects.data.followedshows.testing)

--- a/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenter.kt
+++ b/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenter.kt
@@ -47,7 +47,7 @@ import kotlinx.coroutines.launch
     kind = DestinationKind.OVERLAY,
 )
 @AssistedInject
-public class EpisodeSheetPresenter(
+public class EpisodeSheetPresenter internal constructor(
     @Assisted private val param: EpisodeSheetParam,
     componentContext: ComponentContext,
     observeEpisodeByIdInteractor: ObserveEpisodeByIdInteractor,

--- a/features/home/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/home/HomePresenter.kt
+++ b/features/home/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/home/HomePresenter.kt
@@ -36,7 +36,7 @@ public data class ProfileAvatar(val url: String? = null)
 
 @ChildPresenter(scope = HomeScope::class, parentScope = ActivityScope::class)
 @Inject
-public class HomePresenter(
+public class HomePresenter internal constructor(
     componentContext: ComponentContext,
     private val navigator: Navigator,
     private val navDestinations: Set<NavDestination<*>>,

--- a/features/library/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/library/LibraryPresenter.kt
+++ b/features/library/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/library/LibraryPresenter.kt
@@ -46,7 +46,7 @@ import com.thomaskioko.tvmaniac.data.library.model.LibrarySortOption as DataLibr
     parentScope = ActivityScope::class,
     kind = DestinationKind.TAB_ROOT,
 )
-public class LibraryPresenter(
+public class LibraryPresenter internal constructor(
     componentContext: ComponentContext,
     private val navigator: Navigator,
     private val repository: LibraryRepository,

--- a/features/profile/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/profile/presenter/ProfilePresenter.kt
+++ b/features/profile/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/profile/presenter/ProfilePresenter.kt
@@ -83,7 +83,7 @@ import kotlinx.coroutines.launch
     parentScope = ActivityScope::class,
     kind = DestinationKind.TAB_ROOT,
 )
-public class ProfilePresenter(
+public class ProfilePresenter internal constructor(
     componentContext: ComponentContext,
     private val navigator: Navigator,
     private val localizer: Localizer,

--- a/features/rating-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/ratingsheet/presenter/RatingSheetPresenter.kt
+++ b/features/rating-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/ratingsheet/presenter/RatingSheetPresenter.kt
@@ -36,7 +36,7 @@ import kotlinx.coroutines.flow.stateIn
     kind = DestinationKind.OVERLAY,
 )
 @AssistedInject
-public class RatingSheetPresenter(
+public class RatingSheetPresenter internal constructor(
     @Assisted private val param: RatingSheetParam,
     componentContext: ComponentContext,
     observeRatingInteractor: ObserveRatingInteractor,

--- a/features/root/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultNotificationRationale.kt
+++ b/features/root/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultNotificationRationale.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.take
 
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
-public class DefaultNotificationRationale(
+public class DefaultNotificationRationale internal constructor(
     private val datastoreRepository: DatastoreRepository,
 ) : NotificationRationale {
 

--- a/features/root/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenter.kt
+++ b/features/root/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenter.kt
@@ -61,10 +61,13 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
 import kotlin.time.Duration.Companion.milliseconds
 import com.thomaskioko.tvmaniac.syncstate.api.SyncError as SyncStateError
 
-@OptIn(kotlinx.coroutines.FlowPreview::class)
+@OptIn(kotlinx.coroutines.FlowPreview::class, ExperimentalObjCRefinement::class)
+@HiddenFromObjC
 @AppRoot(parentScope = ActivityScope::class)
 @AssistedInject
 public class DefaultRootPresenter(

--- a/features/season-details/presenter/build.gradle.kts
+++ b/features/season-details/presenter/build.gradle.kts
@@ -39,7 +39,6 @@ kotlin {
                 implementation(libs.kotlinx.datetime)
                 implementation(projects.core.logger.testing)
                 implementation(projects.data.cast.testing)
-                implementation(projects.data.database.sqldelight)
                 implementation(projects.data.episode.testing)
                 implementation(projects.data.ratings.testing)
                 implementation(projects.data.seasondetails.testing)

--- a/features/season-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/SeasonDetailsPresenter.kt
+++ b/features/season-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/SeasonDetailsPresenter.kt
@@ -58,7 +58,7 @@ import kotlinx.coroutines.launch
     kind = DestinationKind.SCREEN,
 )
 @AssistedInject
-public class SeasonDetailsPresenter(
+public class SeasonDetailsPresenter internal constructor(
     componentContext: ComponentContext,
     @Assisted private val param: SeasonDetailsUiParam,
     private val navigator: Navigator,

--- a/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsPresenter.kt
+++ b/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsPresenter.kt
@@ -66,7 +66,7 @@ import kotlin.time.Duration.Companion.minutes
     kind = DestinationKind.SCREEN,
 )
 @Inject
-public class SettingsPresenter(
+public class SettingsPresenter internal constructor(
     componentContext: ComponentContext,
     observeSettingsPreferencesInteractor: ObserveSettingsPreferencesInteractor,
     userRepository: UserRepository,

--- a/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/ThemeModel.kt
+++ b/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/ThemeModel.kt
@@ -3,6 +3,8 @@ package com.thomaskioko.tvmaniac.settings.presenter
 import com.thomaskioko.tvmaniac.datastore.api.AppTheme
 import com.thomaskioko.tvmaniac.domain.theme.Theme
 import com.thomaskioko.tvmaniac.i18n.StringResourceKey
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
 
 public enum class ThemeModel(public val theme: Theme) {
     SYSTEM(Theme.SYSTEM_THEME),
@@ -31,13 +33,15 @@ public enum class ThemeModel(public val theme: Theme) {
     }
 }
 
+@OptIn(ExperimentalObjCRefinement::class)
+@HiddenFromObjC
 public fun AppTheme.toTheme(): Theme = Theme.valueOf(name)
 
-public fun Theme.toAppTheme(): AppTheme = AppTheme.valueOf(name)
+internal fun Theme.toAppTheme(): AppTheme = AppTheme.valueOf(name)
 
 public fun Theme.toThemeModel(): ThemeModel =
     ThemeModel.entries.first { it.theme == this }
 
 public fun ThemeModel.toTheme(): Theme = theme
 
-public fun ThemeModel.toAppTheme(): AppTheme = theme.toAppTheme()
+internal fun ThemeModel.toAppTheme(): AppTheme = theme.toAppTheme()

--- a/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/cast/ShowDetailsCastPresenter.kt
+++ b/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/cast/ShowDetailsCastPresenter.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.launch
 
 @ChildPresenter(scope = ShowDetailsChildScope::class, parentScope = ShowDetailsRoute::class)
 @AssistedInject
-public class ShowDetailsCastPresenter(
+public class ShowDetailsCastPresenter internal constructor(
     componentContext: ComponentContext,
     @Assisted private val showId: Long,
     @Assisted private val forceRefresh: Boolean,

--- a/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/header/ShowDetailsHeaderPresenter.kt
+++ b/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/header/ShowDetailsHeaderPresenter.kt
@@ -51,7 +51,7 @@ import kotlinx.coroutines.launch
 
 @ChildPresenter(scope = ShowDetailsChildScope::class, parentScope = ShowDetailsRoute::class)
 @AssistedInject
-public class ShowDetailsHeaderPresenter(
+public class ShowDetailsHeaderPresenter internal constructor(
     componentContext: ComponentContext,
     @Assisted private val showId: Long,
     @Assisted private val forceRefresh: Boolean,

--- a/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/providers/ShowDetailsProvidersPresenter.kt
+++ b/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/providers/ShowDetailsProvidersPresenter.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.launch
 
 @ChildPresenter(scope = ShowDetailsChildScope::class, parentScope = ShowDetailsRoute::class)
 @AssistedInject
-public class ShowDetailsProvidersPresenter(
+public class ShowDetailsProvidersPresenter internal constructor(
     componentContext: ComponentContext,
     @Assisted private val showId: Long,
     @Assisted private val forceRefresh: Boolean,

--- a/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/seasonsepisodes/ShowDetailsSeasonsEpisodesPresenter.kt
+++ b/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/seasonsepisodes/ShowDetailsSeasonsEpisodesPresenter.kt
@@ -49,7 +49,7 @@ import kotlinx.coroutines.launch
 
 @ChildPresenter(scope = ShowDetailsChildScope::class, parentScope = ShowDetailsRoute::class)
 @AssistedInject
-public class ShowDetailsSeasonsEpisodesPresenter(
+public class ShowDetailsSeasonsEpisodesPresenter internal constructor(
     componentContext: ComponentContext,
     @Assisted private val showId: Long,
     @Assisted private val forceRefresh: Boolean,

--- a/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/similar/ShowDetailsSimilarPresenter.kt
+++ b/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/similar/ShowDetailsSimilarPresenter.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.launch
 
 @ChildPresenter(scope = ShowDetailsChildScope::class, parentScope = ShowDetailsRoute::class)
 @AssistedInject
-public class ShowDetailsSimilarPresenter(
+public class ShowDetailsSimilarPresenter internal constructor(
     componentContext: ComponentContext,
     @Assisted private val showId: Long,
     @Assisted private val forceRefresh: Boolean,

--- a/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/trailers/ShowDetailsTrailersPresenter.kt
+++ b/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/trailers/ShowDetailsTrailersPresenter.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.launch
 
 @ChildPresenter(scope = ShowDetailsChildScope::class, parentScope = ShowDetailsRoute::class)
 @AssistedInject
-public class ShowDetailsTrailersPresenter(
+public class ShowDetailsTrailersPresenter internal constructor(
     componentContext: ComponentContext,
     @Assisted private val showId: Long,
     @Assisted private val forceRefresh: Boolean,

--- a/features/trailers/presenter/build.gradle.kts
+++ b/features/trailers/presenter/build.gradle.kts
@@ -10,12 +10,6 @@ scaffold {
 
 kotlin {
     sourceSets {
-        androidMain {
-            dependencies {
-                implementation(projects.data.database.sqldelight)
-            }
-        }
-
         commonMain {
             dependencies {
                 api(projects.core.base)

--- a/features/upnext/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextPresenter.kt
+++ b/features/upnext/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextPresenter.kt
@@ -46,7 +46,7 @@ import kotlinx.coroutines.launch
 
 @ChildPresenter(scope = ProgressChildScope::class, parentScope = ProgressRoot::class)
 @Inject
-public class UpNextPresenter(
+public class UpNextPresenter internal constructor(
     componentContext: ComponentContext,
     private val navigator: Navigator,
     private val syncContinueWatchingInteractor: SyncContinueWatchingInteractor,

--- a/ios-framework/README.md
+++ b/ios-framework/README.md
@@ -1018,7 +1018,6 @@ graph TB
   :features:discover:presenter --> :domain:episode
   :features:discover:presenter --> :domain:followedshows
   :features:discover:presenter --> :domain:genre
-  :features:discover:presenter --> :domain:showdetails
   :features:discover:presenter --> :domain:start-watching
   :features:discover:presenter --> :features:discover:nav
   :features:discover:presenter -.-> :features:episode-sheet:nav

--- a/ios/tv-maniac.xcodeproj/project.pbxproj
+++ b/ios/tv-maniac.xcodeproj/project.pbxproj
@@ -525,7 +525,6 @@
 				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
-					"-ObjC",
 					"-l\"c++\"",
 					"-lsqlite3",
 				);
@@ -563,7 +562,6 @@
 				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
-					"-ObjC",
 					"-l\"c++\"",
 					"-lsqlite3",
 				);


### PR DESCRIPTION
## Description
This PR shrinks the iOS framework. The shared Kotlin code no longer publishes presenter internals and helper types that Swift never calls.

## Changes
- Add internal constructors to the exported presenters so their injected dependencies stay out of the framework's public surface.
- Make the mapping functions in the continue watching and calendar presenters internal.
- Add HiddenFromObjC annotations to declarations other Kotlin modules call but Swift never names.
- Remove the ObjC linker flag from the Xcode project after checking release builds come out identical without it.
- Remove an unused dependency from the discover presenter.
