### PR TITLE
chore: Improve iOS CI test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,24 +323,29 @@ jobs:
                 with:
                     mode: restore
 
-            -   name: 🗂️ Restore DerivedData
-                id: derived-data
+            -   name: 🗂️ Restore Compilation Cache
+                id: compilation-cache
                 uses: actions/cache/restore@v6
                 with:
-                    path: derived_data
-                    key: ${{ runner.os }}-snapshot-derived-data-${{ hashFiles('ios/tv-maniac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'ios/Packages/**/Package.swift') }}
+                    path: compilation_cache
+                    key: ${{ runner.os }}-xcode-cas-snapshot-${{ env.XCODE_VERSION }}-${{ github.sha }}
                     restore-keys: |
-                        ${{ runner.os }}-snapshot-derived-data-
+                        ${{ runner.os }}-xcode-cas-snapshot-${{ env.XCODE_VERSION }}-
+                        ${{ runner.os }}-xcode-cas-
 
             -   name: 📸 Run Snapshot Tests
                 run: bundle exec fastlane snapshot_tests
 
-            -   name: 🗂️ Save DerivedData
-                if: github.ref == 'refs/heads/main' && steps.derived-data.outputs.cache-hit != 'true'
+            -   name: 📏 Compilation cache size
+                if: ${{ !cancelled() }}
+                run: du -sh compilation_cache || true
+
+            -   name: 🗂️ Save Compilation Cache
+                if: github.ref == 'refs/heads/main' && steps.compilation-cache.outputs.cache-hit != 'true'
                 uses: actions/cache/save@v6
                 with:
-                    path: derived_data
-                    key: ${{ runner.os }}-snapshot-derived-data-${{ hashFiles('ios/tv-maniac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'ios/Packages/**/Package.swift') }}
+                    path: compilation_cache
+                    key: ${{ runner.os }}-xcode-cas-snapshot-${{ env.XCODE_VERSION }}-${{ github.sha }}
 
             -   name: Upload test results
                 uses: actions/upload-artifact@v7
@@ -375,24 +380,29 @@ jobs:
                 with:
                     mode: restore
 
-            -   name: 🗂️ Restore DerivedData
-                id: derived-data
+            -   name: 🗂️ Restore Compilation Cache
+                id: compilation-cache
                 uses: actions/cache/restore@v6
                 with:
-                    path: derived_data
-                    key: ${{ runner.os }}-uitest-derived-data-${{ hashFiles('ios/tv-maniac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'ios/Packages/**/Package.swift') }}
+                    path: compilation_cache
+                    key: ${{ runner.os }}-xcode-cas-uitest-${{ env.XCODE_VERSION }}-${{ github.sha }}
                     restore-keys: |
-                        ${{ runner.os }}-uitest-derived-data-
+                        ${{ runner.os }}-xcode-cas-uitest-${{ env.XCODE_VERSION }}-
+                        ${{ runner.os }}-xcode-cas-
 
             -   name: 🧭 Run UI Tests
                 run: bundle exec fastlane ui_tests
 
-            -   name: 🗂️ Save DerivedData
-                if: github.ref == 'refs/heads/main' && steps.derived-data.outputs.cache-hit != 'true'
+            -   name: 📏 Compilation cache size
+                if: ${{ !cancelled() }}
+                run: du -sh compilation_cache || true
+
+            -   name: 🗂️ Save Compilation Cache
+                if: github.ref == 'refs/heads/main' && steps.compilation-cache.outputs.cache-hit != 'true'
                 uses: actions/cache/save@v6
                 with:
-                    path: derived_data
-                    key: ${{ runner.os }}-uitest-derived-data-${{ hashFiles('ios/tv-maniac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'ios/Packages/**/Package.swift') }}
+                    path: compilation_cache
+                    key: ${{ runner.os }}-xcode-cas-uitest-${{ env.XCODE_VERSION }}-${{ github.sha }}
 
             -   name: Upload test results
                 uses: actions/upload-artifact@v7

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -7,7 +7,14 @@ PACKAGE_NAME = "com.thomaskioko.tvmaniac"
 PROJECT_DIR = File.expand_path('..', Dir.pwd)
 DERIVED_DATA_PATH = "#{PROJECT_DIR}/derived_data"
 COMPILATION_CACHE_PATH = "#{PROJECT_DIR}/compilation_cache"
+SOURCE_PACKAGES_PATH = "#{PROJECT_DIR}/ios/SourcePackages"
 UI_TEST_ALLOWANCE_SECONDS = 600
+
+# The compilation cache defaults to a directory inside derived data, which the lanes
+# below delete. It has to live outside for anything to survive between runs.
+BUILD_CACHE_XCARGS = "COMPILATION_CACHE_CAS_PATH=#{COMPILATION_CACHE_PATH} " \
+                     "COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS=YES " \
+                     "COMPILER_INDEX_STORE_ENABLE=NO"
 
 platform :ios do
 
@@ -47,7 +54,8 @@ platform :ios do
       destination: TEST_DESTINATION,
       skip_detect_devices: true,
       build_for_testing: true,
-      xcargs: "-skipPackagePluginValidation",
+      cloned_source_packages_path: SOURCE_PACKAGES_PATH,
+      xcargs: "#{BUILD_CACHE_XCARGS} -skipPackagePluginValidation",
       xcodebuild_formatter: "",
       derived_data_path: DERIVED_DATA_PATH
     )
@@ -59,6 +67,7 @@ platform :ios do
       skip_detect_devices: true,
       test_without_building: true,
       result_bundle: true,
+      cloned_source_packages_path: SOURCE_PACKAGES_PATH,
       xcargs: "-retry-tests-on-failure -skipPackagePluginValidation",
       number_of_retries: 2,
       fail_build: true,
@@ -78,7 +87,9 @@ platform :ios do
       prelaunch_simulator: true,
       skip_detect_devices: true,
       result_bundle: true,
-      xcargs: "-skipPackagePluginValidation " \
+      cloned_source_packages_path: SOURCE_PACKAGES_PATH,
+      xcargs: "#{BUILD_CACHE_XCARGS} " \
+              "-skipPackagePluginValidation " \
               "-parallel-testing-enabled NO " \
               "-test-timeouts-enabled YES " \
               "-default-test-execution-time-allowance #{UI_TEST_ALLOWANCE_SECONDS} " \
@@ -128,8 +139,8 @@ platform :ios do
       configuration: "Debug",
       destination: TEST_DESTINATION,
       derived_data_path: DERIVED_DATA_PATH,
-      cloned_source_packages_path: "ios/SourcePackages",
-      xcargs: "COMPILATION_CACHE_CAS_PATH=#{COMPILATION_CACHE_PATH} COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS=YES COMPILER_INDEX_STORE_ENABLE=NO -skipPackagePluginValidation",
+      cloned_source_packages_path: SOURCE_PACKAGES_PATH,
+      xcargs: "#{BUILD_CACHE_XCARGS} -skipPackagePluginValidation",
       buildlog_path: "fastlane/logs",
       clean: true,
       skip_archive: true,


### PR DESCRIPTION
This PR speeds up the builds inside the iOS test jobs. The `ui_tests` and `snapshot_tests` lanes never set `cloned_source_packages_path`, so xcodebuild resolved Swift packages into derived data and ignored the copy that `setup-ios` had already restored. They also left the compilation cache at its default location inside derived data, so deleting derived data deleted the cache with it.

- Both lanes now point at `ios/SourcePackages`, write the compilation cache outside derived data, and stop building the index store that only Xcode reads.

- The two test jobs now cache the compilation cache instead of derived data. It is much smaller, and it falls back to the cache any other iOS job saved, because the compilation cache is addressed by content rather than by job.

