### PR TITLE
chore: Record size history in a Google Sheet

### DIFF
--- a/.github/workflows/ios-binary-size.yml
+++ b/.github/workflows/ios-binary-size.yml
@@ -3,7 +3,14 @@ name: iOS Binary Size
 on:
     push:
         branches: [ main ]
+    schedule:
+        -   cron: '30 4 * * *'
     workflow_dispatch:
+        inputs:
+            append_to_sheet:
+                description: Append this run's measurements to the size sheet
+                type: boolean
+                default: false
 
 env:
     XCODE_VERSION: 26.5
@@ -14,6 +21,7 @@ env:
     SIMKL_CLIENT_ID: ${{ secrets.SIMKL_CLIENT_ID }}
     SIMKL_CLIENT_SECRET: ${{ secrets.SIMKL_CLIENT_SECRET }}
     SIMKL_REDIRECT_URI: ${{ secrets.SIMKL_REDIRECT_URI }}
+    SHEET_SECRETS_PRESENT: ${{ secrets.GCP_SA_KEY != '' && secrets.GSHEET_ID != '' }}
 
 jobs:
     measure:
@@ -47,3 +55,34 @@ jobs:
                 with:
                     name: ios-framework-size
                     path: framework-size.txt
+
+            -   name: 🔐 Authenticate for the size sheet
+                id: sheet-auth
+                if: ${{ (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.append_to_sheet)) && env.SHEET_SECRETS_PRESENT == 'true' }}
+                uses: google-github-actions/auth@v3
+                with:
+                    credentials_json: ${{ secrets.GCP_SA_KEY }}
+                    token_format: access_token
+                    access_token_scopes: https://www.googleapis.com/auth/spreadsheets
+
+            -   name: 📈 Append rows to the size sheet
+                if: ${{ steps.sheet-auth.outcome == 'success' }}
+                shell: bash
+                run: |
+                    {
+                      ./scripts/ios-framework-size.sh --csv
+                      python3 scripts/ios-framework-size-analysis.py --csv
+                    } > metrics.csv
+                    ROWS="$(awk -F, \
+                      -v ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+                      -v sha="$GITHUB_SHA" \
+                      -v ev="${{ github.event_name }}" \
+                      '{printf "%s[\"%s\",\"%s\",\"%s\",\"%s\",%s]", (NR > 1 ? "," : ""), ts, sha, ev, $1, $2}' metrics.csv)"
+                    RESPONSE="$(curl -sSf -X POST \
+                      -H "Authorization: Bearer ${{ steps.sheet-auth.outputs.access_token }}" \
+                      -H "Content-Type: application/json" \
+                      "https://sheets.googleapis.com/v4/spreadsheets/${{ secrets.GSHEET_ID }}/values/A1:append?valueInputOption=RAW" \
+                      -d "{\"values\": [$ROWS]}")"
+                    printf '%s\n' "$RESPONSE"
+                    RANGE="$(printf '%s' "$RESPONSE" | python3 -c 'import json, sys; print(json.load(sys.stdin)["updates"]["updatedRange"])')"
+                    echo "Appended to the size sheet: $RANGE" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/ios-framework-size-analysis.py
+++ b/scripts/ios-framework-size-analysis.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Attributes Objective-C bridge bytes in the TvManiac framework to Gradle modules.
+
+Bridge wrapper symbols (_objc2kotlin_*/_kotlin2objc_*) carry the Kotlin
+fully qualified name they wrap. Symbol sizes come from nm -n address deltas,
+the package to module mapping comes from walking every .kt file (including
+KSP generated sources), and the result is bridge bytes for each module.
+
+Usage:
+  scripts/ios-framework-size-analysis.py [--csv] [path-to-framework-binary]
+
+Default output is a table for each module, largest first. --csv prints one
+"module/<gradle-path>,bytes" line for each module plus "module/unattributed"
+so the lines sum to the total bridge bytes.
+"""
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DEFAULT_BINARY = REPO / "ios-framework/build/bin/iosArm64/releaseFramework/TvManiac.framework/TvManiac"
+
+FQN_RE = re.compile(r"(?:kfun|kclass|kprop):#?([A-Za-z0-9_.]+)")
+SYMBOL_RE = re.compile(r"^([0-9a-f]{8,16}) ([tT]) (.+)$")
+
+
+def package_to_module() -> dict:
+    mapping = {}
+    for kt in REPO.rglob("*.kt"):
+        rel = str(kt.relative_to(REPO))
+        if rel.startswith("ios/") or "/SourcePackages/" in rel or "/.build/" in rel:
+            continue
+        if "/src/" in rel:
+            module = rel.split("/src/")[0]
+        elif "/build/generated/" in rel:
+            module = rel.split("/build/")[0]
+        else:
+            continue
+        if module.startswith(("build", "gradle")):
+            continue
+        try:
+            with open(kt, "r", encoding="utf-8", errors="ignore") as f:
+                for line in f:
+                    line = line.strip()
+                    if line.startswith("package "):
+                        pkg = line[len("package "):].strip().rstrip(";")
+                        prev = mapping.get(pkg)
+                        if prev is None or len(module) < len(prev):
+                            mapping[pkg] = module
+                        break
+                    if line and not line.startswith(("//", "/*", "*", "@file")):
+                        break
+        except OSError:
+            pass
+    return mapping
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    csv = "--csv" in args
+    positional = [a for a in args if a != "--csv"]
+    binary = Path(positional[0]) if positional else DEFAULT_BINARY
+    if not binary.is_file():
+        print(f"error: {binary} not found", file=sys.stderr)
+        return 1
+
+    mapping = package_to_module()
+    packages = sorted(mapping, key=len, reverse=True)
+
+    def module_for(fqn):
+        for pkg in packages:
+            if fqn.startswith(pkg + "."):
+                rest = fqn[len(pkg) + 1:]
+                if rest and rest[0].isupper():
+                    return mapping[pkg]
+        return None
+
+    out = subprocess.run(
+        ["nm", "-arch", "arm64", "-n", str(binary)],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    symbols = []
+    for line in out.splitlines():
+        m = SYMBOL_RE.match(line)
+        if m:
+            symbols.append((int(m.group(1), 16), m.group(3)))
+
+    per_module = defaultdict(int)
+    unattributed = 0
+    for i, (addr, name) in enumerate(symbols):
+        if "objc2kotlin" not in name and "kotlin2objc" not in name:
+            continue
+        size = (symbols[i + 1][0] - addr) if i + 1 < len(symbols) else 0
+        m = FQN_RE.search(name)
+        module = module_for(m.group(1)) if m else None
+        if module:
+            per_module[module] += size
+        else:
+            unattributed += size
+
+    ranked = sorted(per_module.items(), key=lambda kv: -kv[1])
+    if csv:
+        for module, size in ranked:
+            print(f"module/{module},{size}")
+        print(f"module/unattributed,{unattributed}")
+    else:
+        total = sum(per_module.values()) + unattributed
+        print(f"bridge bytes total: {total:,}")
+        for module, size in ranked:
+            print(f"{size:>10,}  {module}")
+        print(f"{unattributed:>10,}  (unattributed)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ios-framework-size.sh
+++ b/scripts/ios-framework-size.sh
@@ -6,10 +6,25 @@
 # runs no dead code elimination in debug builds. The framework file size is
 # deliberately not reported: it is ~40% DWARF and moves for unrelated reasons.
 #
-# Usage: ./scripts/ios-framework-size.sh [path-to-framework-binary]
+# Usage: ./scripts/ios-framework-size.sh [--csv] [path-to-framework-binary]
+#
+# --csv prints "metric,value" lines instead of the section listing: one
+# "section/<name>" line for each Mach-O section of the framework image plus
+# "bridge/symbols". Metric names are path shaped so a dashboard can split
+# them into levels; scripts/ios-framework-size-analysis.py emits "module/<path>" rows
+# in the same format.
 set -euo pipefail
 
-F="${1:-ios-framework/build/bin/iosArm64/releaseFramework/TvManiac.framework/TvManiac}"
+CSV=0
+POSITIONAL=()
+for ARG in "$@"; do
+  case "$ARG" in
+    --csv) CSV=1 ;;
+    *) POSITIONAL+=("$ARG") ;;
+  esac
+done
+
+F="${POSITIONAL[0]:-ios-framework/build/bin/iosArm64/releaseFramework/TvManiac.framework/TvManiac}"
 if [ ! -f "$F" ]; then
   echo "error: $F not found — run: ./gradlew :ios-framework:linkReleaseFrameworkIosArm64 -Papp.enableIos=true" >&2
   exit 1
@@ -20,6 +35,21 @@ if [ -z "$SECTIONS" ]; then
   echo "error: no __text or __objc_ sections found in $F" >&2
   exit 1
 fi
-printf '%s\n' "$SECTIONS"
-printf 'objc bridge symbols: '
-nm -arch arm64 "$F" | grep -cE 'objc2kotlin|kotlin2objc'
+
+BRIDGES="$(nm -arch arm64 "$F" | grep -cE 'objc2kotlin|kotlin2objc')"
+
+if [ "$CSV" -eq 1 ]; then
+  size -m "$F" | awk '
+    /Section \(/ {
+      name = $2 $3
+      gsub(/[(),:]/, "", name)
+      sub(/^__[A-Z_]+__/, "__", name)
+      value = $NF
+      if (value !~ /^[0-9]+$/) value = $(NF - 1)
+      if (!seen[name]++) printf "section/%s,%s\n", name, value
+    }'
+  printf 'bridge/symbols,%s\n' "$BRIDGES"
+else
+  printf '%s\n' "$SECTIONS"
+  printf 'objc bridge symbols: %s\n' "$BRIDGES"
+fi


### PR DESCRIPTION
## Description
This PR records the iOS framework size history in a Google Sheet. This will run on every merge to main and once every night. In turn, this will allow us to track size changes over time and catch a regression as soon as it occurs.

## Changes
- Add a machine readable mode to the framework size script that prints one line for each measurement, named so a future dashboard can group them into levels.
- Add a script that sizes the bridge code for each module.
- Update the size workflow to append the measurements to the sheet on merges to main and on a nightly run, using the official Google authentication action and one request to the Sheets API.
- Skip the sheet steps when the secrets are absent, so forks and branch runs are unaffected.
- Allow a manual run to append its rows on request, which proves the whole chain works before merging.
