### PR TITLE
chore: Restructure the iOS test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,29 +323,24 @@ jobs:
                 with:
                     mode: restore
 
-            -   name: 🗂️ Restore Compilation Cache
-                id: compilation-cache
+            -   name: 🗂️ Restore DerivedData
+                id: derived-data
                 uses: actions/cache/restore@v6
                 with:
-                    path: compilation_cache
-                    key: ${{ runner.os }}-xcode-cas-snapshot-${{ env.XCODE_VERSION }}-${{ github.sha }}
+                    path: derived_data
+                    key: ${{ runner.os }}-snapshot-derived-data-${{ hashFiles('ios/tv-maniac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'ios/Packages/**/Package.swift') }}
                     restore-keys: |
-                        ${{ runner.os }}-xcode-cas-snapshot-${{ env.XCODE_VERSION }}-
-                        ${{ runner.os }}-xcode-cas-
+                        ${{ runner.os }}-snapshot-derived-data-
 
             -   name: 📸 Run Snapshot Tests
                 run: bundle exec fastlane snapshot_tests
 
-            -   name: 📏 Compilation cache size
-                if: ${{ !cancelled() }}
-                run: du -sh compilation_cache || true
-
-            -   name: 🗂️ Save Compilation Cache
-                if: github.ref == 'refs/heads/main' && steps.compilation-cache.outputs.cache-hit != 'true'
+            -   name: 🗂️ Save DerivedData
+                if: github.ref == 'refs/heads/main' && steps.derived-data.outputs.cache-hit != 'true'
                 uses: actions/cache/save@v6
                 with:
-                    path: compilation_cache
-                    key: ${{ runner.os }}-xcode-cas-snapshot-${{ env.XCODE_VERSION }}-${{ github.sha }}
+                    path: derived_data
+                    key: ${{ runner.os }}-snapshot-derived-data-${{ hashFiles('ios/tv-maniac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'ios/Packages/**/Package.swift') }}
 
             -   name: Upload test results
                 uses: actions/upload-artifact@v7
@@ -380,29 +375,24 @@ jobs:
                 with:
                     mode: restore
 
-            -   name: 🗂️ Restore Compilation Cache
-                id: compilation-cache
+            -   name: 🗂️ Restore DerivedData
+                id: derived-data
                 uses: actions/cache/restore@v6
                 with:
-                    path: compilation_cache
-                    key: ${{ runner.os }}-xcode-cas-uitest-${{ env.XCODE_VERSION }}-${{ github.sha }}
+                    path: derived_data
+                    key: ${{ runner.os }}-uitest-derived-data-${{ hashFiles('ios/tv-maniac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'ios/Packages/**/Package.swift') }}
                     restore-keys: |
-                        ${{ runner.os }}-xcode-cas-uitest-${{ env.XCODE_VERSION }}-
-                        ${{ runner.os }}-xcode-cas-
+                        ${{ runner.os }}-uitest-derived-data-
 
             -   name: 🧭 Run UI Tests
                 run: bundle exec fastlane ui_tests
 
-            -   name: 📏 Compilation cache size
-                if: ${{ !cancelled() }}
-                run: du -sh compilation_cache || true
-
-            -   name: 🗂️ Save Compilation Cache
-                if: github.ref == 'refs/heads/main' && steps.compilation-cache.outputs.cache-hit != 'true'
+            -   name: 🗂️ Save DerivedData
+                if: github.ref == 'refs/heads/main' && steps.derived-data.outputs.cache-hit != 'true'
                 uses: actions/cache/save@v6
                 with:
-                    path: compilation_cache
-                    key: ${{ runner.os }}-xcode-cas-uitest-${{ env.XCODE_VERSION }}-${{ github.sha }}
+                    path: derived_data
+                    key: ${{ runner.os }}-uitest-derived-data-${{ hashFiles('ios/tv-maniac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'ios/Packages/**/Package.swift') }}
 
             -   name: Upload test results
                 uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
                     xcode-version: ${{ env.XCODE_VERSION }}
 
             -   name: 🧪 Run Kotlin/Native Tests
-                run: ./gradlew iosTest -Papp.enableIos=true -Papp.debugOnly=false --continue
+                run: ./gradlew iosTest -Papp.enableIos=true -Papp.debugOnly=false --continue --scan --console=plain
 
             -   name: Upload Test Reports
                 uses: actions/upload-artifact@v7

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,11 +10,14 @@ COMPILATION_CACHE_PATH = "#{PROJECT_DIR}/compilation_cache"
 SOURCE_PACKAGES_PATH = "#{PROJECT_DIR}/ios/SourcePackages"
 UI_TEST_ALLOWANCE_SECONDS = 600
 
-# The compilation cache defaults to a directory inside derived data, which the lanes
-# below delete. It has to live outside for anything to survive between runs.
+NO_INDEX_STORE_XCARGS = "COMPILER_INDEX_STORE_ENABLE=NO"
+
+# build_tvmaniac deletes derived data on every run, so its compilation cache has to sit
+# outside it to survive. The test lanes keep theirs at the default location inside derived
+# data, where it is cached along with the rest of the build.
 BUILD_CACHE_XCARGS = "COMPILATION_CACHE_CAS_PATH=#{COMPILATION_CACHE_PATH} " \
                      "COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS=YES " \
-                     "COMPILER_INDEX_STORE_ENABLE=NO"
+                     "#{NO_INDEX_STORE_XCARGS}"
 
 platform :ios do
 
@@ -55,7 +58,7 @@ platform :ios do
       skip_detect_devices: true,
       build_for_testing: true,
       cloned_source_packages_path: SOURCE_PACKAGES_PATH,
-      xcargs: "#{BUILD_CACHE_XCARGS} -skipPackagePluginValidation",
+      xcargs: "#{NO_INDEX_STORE_XCARGS} -skipPackagePluginValidation",
       xcodebuild_formatter: "",
       derived_data_path: DERIVED_DATA_PATH
     )
@@ -88,7 +91,7 @@ platform :ios do
       skip_detect_devices: true,
       result_bundle: true,
       cloned_source_packages_path: SOURCE_PACKAGES_PATH,
-      xcargs: "#{BUILD_CACHE_XCARGS} " \
+      xcargs: "#{NO_INDEX_STORE_XCARGS} " \
               "-skipPackagePluginValidation " \
               "-parallel-testing-enabled NO " \
               "-test-timeouts-enabled YES " \


### PR DESCRIPTION
This PR makes the `ios-test` job show where its time goes, and puts the two iOS test jobs back on the derived data cache.

This should allow us to view the plain output and debug the slow tasks, and undoes a cache change that did not help.
