### PR TITLE
chore: Build the iOS app once for each CI run

### DIFF
--- a/.github/actions/setup-ios/action.yml
+++ b/.github/actions/setup-ios/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Forwarded to setup-gradle. Defaults to read-only on pull requests; set false for the cache-writing job.'
     required: false
     default: ${{ github.event_name == 'pull_request' }}
+  kotlin-tooling:
+    description: 'Set false for jobs that never call Gradle, so they skip the Kotlin/Native and Gradle caches.'
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -45,6 +49,7 @@ runs:
           ${{ runner.os }}-spm-
 
     - name: 🗂️ Cache Kotlin/Native (konan)
+      if: inputs.kotlin-tooling == 'true'
       uses: actions/cache@v6
       with:
         path: ~/.konan
@@ -53,6 +58,7 @@ runs:
           ${{ runner.os }}-konan-
 
     - name: 🐘 Setup Gradle
+      if: inputs.kotlin-tooling == 'true'
       uses: ./.github/actions/setup-gradle
       with:
         gradle-cache-read-only: ${{ inputs.gradle-cache-read-only }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,15 +290,23 @@ jobs:
                     path: compilation_cache
                     key: ${{ runner.os }}-xcode-cas-app-${{ env.XCODE_VERSION }}-${{ github.sha }}
 
+            -   name: 📦 Pack the build products
+                if: ${{ !cancelled() }}
+                run: tar -cf ios-build.tar -C derived_data/Build Products
+
             -   name: Upload build artifacts
                 uses: actions/upload-artifact@v7
                 if: ${{ !cancelled() }}
                 with:
                     name: ios-build
-                    path: |
-                        derived_data/Build/Products/
-                        fastlane/logs
-                        !derived_data/Build/Products/**/*.bundle/**
+                    path: ios-build.tar
+
+            -   name: Upload build logs
+                uses: actions/upload-artifact@v7
+                if: ${{ !cancelled() }}
+                with:
+                    name: ios-build-logs
+                    path: fastlane/logs
 
 
     ios-snapshot-test:
@@ -354,9 +362,9 @@ jobs:
 
 
     ios-ui-test:
-        needs: [build-ios-framework]
+        needs: [build-ios]
         runs-on: macos-26
-        timeout-minutes: 60
+        timeout-minutes: 30
         env:
             FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 60
             TVMANIAC_SKIP_FRAMEWORK_BUILD: '1'
@@ -369,30 +377,28 @@ jobs:
                 uses: ./.github/actions/setup-ios
                 with:
                     xcode-version: ${{ env.XCODE_VERSION }}
+                    kotlin-tooling: 'false'
 
+            # TvManiacFramework's Package.swift calls fatalError when the xcframework is
+            # absent, so every xcodebuild invocation needs it on disk, including one that
+            # only runs tests.
             -   name: 🗂️ Restore prebuilt KMP frameworks
                 uses: ./.github/actions/kmp-ios-framework
                 with:
                     mode: restore
 
-            -   name: 🗂️ Restore DerivedData
-                id: derived-data
-                uses: actions/cache/restore@v6
+            -   name: 📦 Download the prebuilt app and test bundle
+                uses: actions/download-artifact@v7
                 with:
-                    path: derived_data
-                    key: ${{ runner.os }}-uitest-derived-data-${{ hashFiles('ios/tv-maniac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'ios/Packages/**/Package.swift') }}
-                    restore-keys: |
-                        ${{ runner.os }}-uitest-derived-data-
+                    name: ios-build
+
+            -   name: 📦 Unpack the build products
+                run: |
+                    mkdir -p derived_data/Build
+                    tar -xf ios-build.tar -C derived_data/Build
 
             -   name: 🧭 Run UI Tests
-                run: bundle exec fastlane ui_tests
-
-            -   name: 🗂️ Save DerivedData
-                if: github.ref == 'refs/heads/main' && steps.derived-data.outputs.cache-hit != 'true'
-                uses: actions/cache/save@v6
-                with:
-                    path: derived_data
-                    key: ${{ runner.os }}-uitest-derived-data-${{ hashFiles('ios/tv-maniac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'ios/Packages/**/Package.swift') }}
+                run: bundle exec fastlane ui_tests prebuilt:true
 
             -   name: Upload test results
                 uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,7 +367,6 @@ jobs:
         timeout-minutes: 30
         env:
             FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 60
-            TVMANIAC_SKIP_FRAMEWORK_BUILD: '1'
 
         steps:
             -   name: 🚚 Checkout project
@@ -378,14 +377,6 @@ jobs:
                 with:
                     xcode-version: ${{ env.XCODE_VERSION }}
                     kotlin-tooling: 'false'
-
-            # TvManiacFramework's Package.swift calls fatalError when the xcframework is
-            # absent, so every xcodebuild invocation needs it on disk, including one that
-            # only runs tests.
-            -   name: 🗂️ Restore prebuilt KMP frameworks
-                uses: ./.github/actions/kmp-ios-framework
-                with:
-                    mode: restore
 
             -   name: 📦 Download the prebuilt app and test bundle
                 uses: actions/download-artifact@v7

--- a/docs/architecture/ios-testing.md
+++ b/docs/architecture/ios-testing.md
@@ -88,4 +88,6 @@ bundle exec fastlane ios ui_tests
 
 Both Fastlane lanes build the KMP framework first. Set `TVMANIAC_SKIP_FRAMEWORK_BUILD=1` to reuse an existing build.
 
+CI builds the app once, in `build-ios`, which runs `build_tvmaniac` and publishes the products. `ios-ui-test` downloads them and runs `fastlane ui_tests prebuilt:true`, which skips both the framework and the app build.
+
 `TvManiacFramework/Package.swift` calls `fatalError` when `TvManiac.xcframework` is missing, so `xcodebuild -list` fails on a fresh checkout until `./scripts/build-kmp-framework.sh` has run.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,6 +9,8 @@ DERIVED_DATA_PATH = "#{PROJECT_DIR}/derived_data"
 COMPILATION_CACHE_PATH = "#{PROJECT_DIR}/compilation_cache"
 SOURCE_PACKAGES_PATH = "#{PROJECT_DIR}/ios/SourcePackages"
 UI_TEST_ALLOWANCE_SECONDS = 600
+# Matches IPHONEOS_DEPLOYMENT_TARGET in ios/tv-maniac.xcodeproj.
+IOS_DEPLOYMENT_TARGET = "18.0"
 
 NO_INDEX_STORE_XCARGS = "COMPILER_INDEX_STORE_ENABLE=NO"
 
@@ -85,17 +87,39 @@ platform :ios do
     prebuilt = options[:prebuilt].to_s == "true"
     build_kmp_framework unless prebuilt
 
+    # Running the xctestrun on its own keeps xcodebuild away from the project, so it
+    # reads no build settings and resolves no packages. Reading them costs five minutes
+    # on CI and is the only reason a test-only job needs the KMP framework on disk.
+    # The file names the SDK it was built against, so it is found rather than spelled out.
+    source = if prebuilt
+               xctestrun = Dir["#{DERIVED_DATA_PATH}/Build/Products/*.xctestrun"].first
+               UI.user_error!("No xctestrun under #{DERIVED_DATA_PATH}. Run build_tvmaniac first.") if xctestrun.nil?
+               # scan still wants a project to satisfy its own checks, but it leaves
+               # -project and -scheme off the xcodebuild command once xctestrun is set.
+               # deployment_target_version is passed so it does not read the value out of
+               # the project, which is the call that costs the five minutes.
+               {
+                 xctestrun: xctestrun,
+                 test_without_building: true,
+                 skip_package_dependencies_resolution: true,
+                 deployment_target_version: IOS_DEPLOYMENT_TARGET
+               }
+             else
+               { cloned_source_packages_path: SOURCE_PACKAGES_PATH }
+             end
+
     run_tests(
+      **source,
       project: "ios/tv-maniac.xcodeproj",
       scheme: "tv-maniac",
+      # Naming the app keeps scan from reading WRAPPER_NAME out of the project, which is
+      # the last thing that would make it dump build settings.
+      app_name: "tv-maniac",
       destination: TEST_DESTINATION,
       devices: ["#{TEST_DEVICE} (#{TEST_OS})"],
       prelaunch_simulator: true,
       skip_detect_devices: true,
-      test_without_building: prebuilt,
-      skip_package_dependencies_resolution: prebuilt,
       result_bundle: true,
-      cloned_source_packages_path: SOURCE_PACKAGES_PATH,
       xcargs: "#{NO_INDEX_STORE_XCARGS} " \
               "-skipPackagePluginValidation " \
               "-parallel-testing-enabled NO " \

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,8 +13,8 @@ UI_TEST_ALLOWANCE_SECONDS = 600
 NO_INDEX_STORE_XCARGS = "COMPILER_INDEX_STORE_ENABLE=NO"
 
 # build_tvmaniac deletes derived data on every run, so its compilation cache has to sit
-# outside it to survive. The test lanes keep theirs at the default location inside derived
-# data, where it is cached along with the rest of the build.
+# outside it to survive. snapshot_tests keeps its own at the default location inside
+# derived data, where it is cached along with the rest of the build.
 BUILD_CACHE_XCARGS = "COMPILATION_CACHE_CAS_PATH=#{COMPILATION_CACHE_PATH} " \
                      "COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS=YES " \
                      "#{NO_INDEX_STORE_XCARGS}"
@@ -79,8 +79,11 @@ platform :ios do
   end
 
   desc "Run UI Tests"
-  lane :ui_tests do
-    build_kmp_framework
+  # prebuilt:true runs the products build_tvmaniac left in derived data instead of
+  # building again. CI passes it so the app is compiled once per run, in build-ios.
+  lane :ui_tests do |options|
+    prebuilt = options[:prebuilt].to_s == "true"
+    build_kmp_framework unless prebuilt
 
     run_tests(
       project: "ios/tv-maniac.xcodeproj",
@@ -89,6 +92,8 @@ platform :ios do
       devices: ["#{TEST_DEVICE} (#{TEST_OS})"],
       prelaunch_simulator: true,
       skip_detect_devices: true,
+      test_without_building: prebuilt,
+      skip_package_dependencies_resolution: prebuilt,
       result_bundle: true,
       cloned_source_packages_path: SOURCE_PACKAGES_PATH,
       xcargs: "#{NO_INDEX_STORE_XCARGS} " \
@@ -132,23 +137,22 @@ platform :ios do
     )
   end
 
-  desc "Build iOS App (Debug, simulator)"
+  desc "Build iOS App and its UI test bundle (Debug, simulator)"
   lane :build_tvmaniac do
     build_kmp_framework
 
-    build_ios_app(
+    run_tests(
       project: "ios/tv-maniac.xcodeproj",
       scheme: "tv-maniac",
       configuration: "Debug",
       destination: TEST_DESTINATION,
+      skip_detect_devices: true,
+      build_for_testing: true,
       derived_data_path: DERIVED_DATA_PATH,
       cloned_source_packages_path: SOURCE_PACKAGES_PATH,
       xcargs: "#{BUILD_CACHE_XCARGS} -skipPackagePluginValidation",
       buildlog_path: "fastlane/logs",
-      clean: true,
-      skip_archive: true,
-      skip_codesigning: true,
-      skip_package_ipa: true
+      clean: true
     )
   end
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -45,7 +45,7 @@ Re-record snapshot baselines
 [bundle exec] fastlane ios build_tvmaniac
 ```
 
-Build iOS App (Debug, simulator)
+Build iOS App and its UI test bundle (Debug, simulator)
 
 ### ios certs
 


### PR DESCRIPTION

## Description

This PR builds the iOS app once for each CI run and has the UI test job run those products instead of compiling the same app a second time. This should allow us to see pull request results sooner, because the UI test job no longer spends fifteen minutes repeating a build that already finished.

## Changes

- Update `build_tvmaniac` to build for testing, so it produces the app, the UI test bundle and the `.xctestrun` beside them.
- Add a `prebuilt` option to `ui_tests` that runs products built earlier instead of building them again. Without the option the lane behaves as it did before, so the documented local command still works.
- Publish the build products from `build-ios` as a tar and download them in `ios-ui-test`. The artifact archive does not keep the executable bit, and an app whose binary is not executable cannot launch.
- Run the tests from the `.xctestrun` file on its own, so xcodebuild never opens the Xcode project. Nothing reads build settings or resolves Swift packages, and the job no longer needs the Kotlin framework on disk.
- Remove the derived data cache from `ios-ui-test`. It matched its key exactly and took 38 seconds to restore, and Xcode then rebuilt everything regardless.
- Add a `kotlin-tooling` option to the iOS setup action so jobs that never call Gradle skip the Kotlin/Native and Gradle caches, which is 1.28 GB of a 10 GB cache budget.