### PR TITLE
feat: Add offline banner

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1432,6 +1432,7 @@ graph TB
   :features:rating-sheet:ui --> :navigation:ui
   :features:root:nav --> :domain:theme
   :features:root:presenter --> :core:base
+  :features:root:presenter --> :core:connectivity:api
   :features:root:presenter --> :core:logger:api
   :features:root:presenter --> :core:syncstate:api
   :features:root:presenter -.-> :core:view

--- a/core/connectivity/api/build.gradle.kts
+++ b/core/connectivity/api/build.gradle.kts
@@ -1,3 +1,11 @@
 plugins {
     alias(libs.plugins.app.kmp)
 }
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            api(libs.coroutines.core)
+        }
+    }
+}

--- a/core/connectivity/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/connectivity/api/InternetConnectionChecker.kt
+++ b/core/connectivity/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/connectivity/api/InternetConnectionChecker.kt
@@ -1,5 +1,9 @@
 package com.thomaskioko.tvmaniac.core.connectivity.api
 
+import kotlinx.coroutines.flow.Flow
+
 public interface InternetConnectionChecker {
     public fun isConnected(): Boolean
+
+    public fun observeConnection(): Flow<Boolean>
 }

--- a/core/connectivity/implementation/src/androidMain/kotlin/com/thomaskioko/tvmaniac/core/connectivity/implementation/PlatformInternetConnectionChecker.android.kt
+++ b/core/connectivity/implementation/src/androidMain/kotlin/com/thomaskioko/tvmaniac/core/connectivity/implementation/PlatformInternetConnectionChecker.android.kt
@@ -2,18 +2,42 @@ package com.thomaskioko.tvmaniac.core.connectivity.implementation
 
 import android.content.Context
 import android.net.ConnectivityManager
+import android.net.Network
 import android.net.NetworkCapabilities
 import com.thomaskioko.tvmaniac.core.base.ApplicationContext
 import com.thomaskioko.tvmaniac.core.connectivity.api.InternetConnectionChecker
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 public actual class PlatformInternetConnectionChecker(
     @ApplicationContext private val context: Context,
 ) : InternetConnectionChecker {
+
+    private val connectionState = MutableStateFlow(isConnected())
+
+    init {
+        val connectivityManager =
+            context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+        connectivityManager?.registerDefaultNetworkCallback(
+            object : ConnectivityManager.NetworkCallback() {
+                override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
+                    connectionState.value =
+                        networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+                        networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+                }
+
+                override fun onLost(network: Network) {
+                    connectionState.value = isConnected()
+                }
+            },
+        )
+    }
+
     public actual override fun isConnected(): Boolean {
         val connectivityManager =
             context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
@@ -23,4 +47,6 @@ public actual class PlatformInternetConnectionChecker(
         return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
             capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
     }
+
+    public actual override fun observeConnection(): Flow<Boolean> = connectionState
 }

--- a/core/connectivity/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/connectivity/implementation/PlatformInternetConnectionChecker.kt
+++ b/core/connectivity/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/connectivity/implementation/PlatformInternetConnectionChecker.kt
@@ -1,7 +1,10 @@
 package com.thomaskioko.tvmaniac.core.connectivity.implementation
 
 import com.thomaskioko.tvmaniac.core.connectivity.api.InternetConnectionChecker
+import kotlinx.coroutines.flow.Flow
 
 public expect class PlatformInternetConnectionChecker : InternetConnectionChecker {
     override fun isConnected(): Boolean
+
+    override fun observeConnection(): Flow<Boolean>
 }

--- a/core/connectivity/implementation/src/iosMain/kotlin/com/thomaskioko/tvmaniac/core/connectivity/implementation/PlatformInternetConnectionChecker.ios.kt
+++ b/core/connectivity/implementation/src/iosMain/kotlin/com/thomaskioko/tvmaniac/core/connectivity/implementation/PlatformInternetConnectionChecker.ios.kt
@@ -4,6 +4,8 @@ import com.thomaskioko.tvmaniac.core.connectivity.api.InternetConnectionChecker
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import platform.Network.nw_path_get_status
 import platform.Network.nw_path_monitor_create
 import platform.Network.nw_path_monitor_set_queue
@@ -11,7 +13,6 @@ import platform.Network.nw_path_monitor_set_update_handler
 import platform.Network.nw_path_monitor_start
 import platform.Network.nw_path_status_satisfied
 import platform.darwin.dispatch_queue_create
-import kotlin.concurrent.Volatile
 
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
@@ -23,16 +24,17 @@ public actual class PlatformInternetConnectionChecker : InternetConnectionChecke
     )
     private val monitor = nw_path_monitor_create()
 
-    @Volatile
-    private var connected: Boolean = true
+    private val connectionState = MutableStateFlow(true)
 
     init {
         nw_path_monitor_set_queue(monitor, monitorQueue)
         nw_path_monitor_set_update_handler(monitor) { path ->
-            connected = path != null && nw_path_get_status(path) == nw_path_status_satisfied
+            connectionState.value = path != null && nw_path_get_status(path) == nw_path_status_satisfied
         }
         nw_path_monitor_start(monitor)
     }
 
-    public actual override fun isConnected(): Boolean = connected
+    public actual override fun isConnected(): Boolean = connectionState.value
+
+    public actual override fun observeConnection(): Flow<Boolean> = connectionState
 }

--- a/core/connectivity/implementation/src/jvmMain/kotlin/com/thomaskioko/tvmaniac/core/connectivity/implementation/PlatformInternetConnectionChecker.jvm.kt
+++ b/core/connectivity/implementation/src/jvmMain/kotlin/com/thomaskioko/tvmaniac/core/connectivity/implementation/PlatformInternetConnectionChecker.jvm.kt
@@ -4,9 +4,16 @@ import com.thomaskioko.tvmaniac.core.connectivity.api.InternetConnectionChecker
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 public actual class PlatformInternetConnectionChecker : InternetConnectionChecker {
+
+    private val connectionState = MutableStateFlow(true)
+
     public actual override fun isConnected(): Boolean = true
+
+    public actual override fun observeConnection(): Flow<Boolean> = connectionState
 }

--- a/core/connectivity/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/connectivity/testing/FakeInternetConnectionChecker.kt
+++ b/core/connectivity/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/connectivity/testing/FakeInternetConnectionChecker.kt
@@ -1,10 +1,20 @@
 package com.thomaskioko.tvmaniac.core.connectivity.testing
 
 import com.thomaskioko.tvmaniac.core.connectivity.api.InternetConnectionChecker
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 
 public class FakeInternetConnectionChecker(
-    private val connected: Boolean = true,
+    connected: Boolean = true,
 ) : InternetConnectionChecker {
 
-    override fun isConnected(): Boolean = connected
+    private val connectionState = MutableStateFlow(connected)
+
+    override fun isConnected(): Boolean = connectionState.value
+
+    override fun observeConnection(): Flow<Boolean> = connectionState
+
+    public fun setConnected(value: Boolean) {
+        connectionState.value = value
+    }
 }

--- a/core/integration/infra/README.md
+++ b/core/integration/infra/README.md
@@ -748,6 +748,7 @@ graph TB
   :features:progress:nav --> :navigation:api
   :features:root:nav --> :domain:theme
   :features:root:presenter --> :core:base
+  :features:root:presenter --> :core:connectivity:api
   :features:root:presenter --> :core:logger:api
   :features:root:presenter --> :core:syncstate:api
   :features:root:presenter -.-> :core:view

--- a/core/integration/infra/src/iosMain/kotlin/com/thomaskioko/tvmaniac/testing/di/TestGraph.kt
+++ b/core/integration/infra/src/iosMain/kotlin/com/thomaskioko/tvmaniac/testing/di/TestGraph.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.testing.di
 
+import com.thomaskioko.tvmaniac.core.connectivity.testing.FakeInternetConnectionChecker
 import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
 import com.thomaskioko.tvmaniac.featureflags.FeatureFlag
 import com.thomaskioko.tvmaniac.featureflags.RemoteConfigBridge
@@ -25,6 +26,7 @@ public interface TestGraph {
     public val syncObserver: SyncObserver
     public val featureFlags: Set<FeatureFlag<Boolean>>
     public val subscriptionManager: SubscriptionManager
+    public val fakeInternetConnectionChecker: FakeInternetConnectionChecker
 
     @DependencyGraph.Factory
     public fun interface Factory {

--- a/core/integration/infra/src/jvmAndIosMain/kotlin/com/thomaskioko/tvmaniac/testing/di/TestPlatformFakesBindingContainer.kt
+++ b/core/integration/infra/src/jvmAndIosMain/kotlin/com/thomaskioko/tvmaniac/testing/di/TestPlatformFakesBindingContainer.kt
@@ -1,5 +1,8 @@
 package com.thomaskioko.tvmaniac.testing.di
 
+import com.thomaskioko.tvmaniac.core.connectivity.api.InternetConnectionChecker
+import com.thomaskioko.tvmaniac.core.connectivity.implementation.PlatformInternetConnectionChecker
+import com.thomaskioko.tvmaniac.core.connectivity.testing.FakeInternetConnectionChecker
 import com.thomaskioko.tvmaniac.core.logger.CrashReporter
 import com.thomaskioko.tvmaniac.core.logger.fixture.FakeCrashReporter
 import com.thomaskioko.tvmaniac.core.notifications.api.NotificationManager
@@ -15,7 +18,10 @@ import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
 
 @BindingContainer
-@ContributesTo(AppScope::class)
+@ContributesTo(
+    AppScope::class,
+    replaces = [PlatformInternetConnectionChecker::class],
+)
 public object TestPlatformFakesBindingContainer {
 
     @Provides
@@ -33,4 +39,13 @@ public object TestPlatformFakesBindingContainer {
     @Provides
     @SingleIn(AppScope::class)
     public fun provideFormatterUtil(): FormatterUtil = FakeFormatterUtil()
+
+    @Provides
+    @SingleIn(AppScope::class)
+    public fun provideFakeInternetConnectionChecker(): FakeInternetConnectionChecker = FakeInternetConnectionChecker()
+
+    @Provides
+    public fun provideInternetConnectionChecker(
+        fake: FakeInternetConnectionChecker,
+    ): InternetConnectionChecker = fake
 }

--- a/core/integration/infra/src/jvmMain/kotlin/com/thomaskioko/tvmaniac/testing/di/TestGraph.kt
+++ b/core/integration/infra/src/jvmMain/kotlin/com/thomaskioko/tvmaniac/testing/di/TestGraph.kt
@@ -2,6 +2,7 @@ package com.thomaskioko.tvmaniac.testing.di
 
 import com.thomaskioko.tvmaniac.core.base.IoCoroutineScope
 import com.thomaskioko.tvmaniac.core.base.MainCoroutineScope
+import com.thomaskioko.tvmaniac.core.connectivity.testing.FakeInternetConnectionChecker
 import com.thomaskioko.tvmaniac.core.tasks.api.WorkerFactory
 import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
 import com.thomaskioko.tvmaniac.featureflags.FeatureFlag
@@ -28,6 +29,7 @@ public interface TestGraph {
     public val workerFactory: WorkerFactory
     public val featureFlags: Set<FeatureFlag<Boolean>>
     public val subscriptionManager: SubscriptionManager
+    public val fakeInternetConnectionChecker: FakeInternetConnectionChecker
 
     @IoCoroutineScope
     public val ioCoroutineScope: CoroutineScope

--- a/core/network-util/api/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/core/networkutil/api/extensions/InternetConnectionPluginTest.kt
+++ b/core/network-util/api/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/core/networkutil/api/extensions/InternetConnectionPluginTest.kt
@@ -17,11 +17,19 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.http.path
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.Test
 
 class InternetConnectionPluginTest {
+
+    private fun internetConnectionChecker(connected: Boolean) = object : InternetConnectionChecker {
+        override fun isConnected(): Boolean = connected
+
+        override fun observeConnection(): Flow<Boolean> = flowOf(connected)
+    }
 
     private fun createClient(checker: InternetConnectionChecker? = null): HttpClient {
         val engine = MockEngine { _ ->
@@ -41,10 +49,7 @@ class InternetConnectionPluginTest {
 
     @Test
     fun `should proceed with request given device is connected`() = runTest {
-        val checker = object : InternetConnectionChecker {
-            override fun isConnected(): Boolean = true
-        }
-        val client = createClient(checker)
+        val client = createClient(internetConnectionChecker(connected = true))
 
         val response = client.get("/test")
 
@@ -53,10 +58,7 @@ class InternetConnectionPluginTest {
 
     @Test
     fun `should throw NoInternetException given device is disconnected`() = runTest {
-        val checker = object : InternetConnectionChecker {
-            override fun isConnected(): Boolean = false
-        }
-        val client = createClient(checker)
+        val client = createClient(internetConnectionChecker(connected = false))
 
         shouldThrow<NoInternetException> {
             client.get("/test")
@@ -74,9 +76,6 @@ class InternetConnectionPluginTest {
 
     @Test
     fun `should return OfflineError given NoInternetException is thrown`() = runTest {
-        val checker = object : InternetConnectionChecker {
-            override fun isConnected(): Boolean = false
-        }
         val engine = MockEngine { _ ->
             respond(
                 content = """{"id":1,"name":"test"}""",
@@ -87,7 +86,7 @@ class InternetConnectionPluginTest {
         val client = HttpClient(engine) {
             install(ContentNegotiation) { json() }
             install(InternetConnectionPlugin) {
-                internetConnectionChecker = checker
+                internetConnectionChecker = internetConnectionChecker(connected = false)
             }
         }
 

--- a/features/root/presenter/README.md
+++ b/features/root/presenter/README.md
@@ -333,6 +333,7 @@ graph TB
   :features:progress:nav --> :navigation:api
   :features:root:nav --> :domain:theme
   :features:root:presenter --> :core:base
+  :features:root:presenter --> :core:connectivity:api
   :features:root:presenter --> :core:logger:api
   :features:root:presenter --> :core:syncstate:api
   :features:root:presenter -.-> :core:view

--- a/features/root/presenter/build.gradle.kts
+++ b/features/root/presenter/build.gradle.kts
@@ -19,6 +19,7 @@ kotlin {
         commonMain {
             dependencies {
                 api(projects.core.base)
+                api(projects.core.connectivity.api)
                 api(projects.core.logger.api)
                 api(projects.core.syncstate.api)
                 api(projects.data.accountManager.api)

--- a/features/root/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenter.kt
+++ b/features/root/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenter.kt
@@ -17,6 +17,7 @@ import com.thomaskioko.tvmaniac.core.base.extensions.combine
 import com.thomaskioko.tvmaniac.core.base.extensions.componentCoroutineScope
 import com.thomaskioko.tvmaniac.core.base.extensions.coroutineScope
 import com.thomaskioko.tvmaniac.core.base.extensions.minTrueDuration
+import com.thomaskioko.tvmaniac.core.connectivity.api.InternetConnectionChecker
 import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.core.view.ObservableLoadingCounter
 import com.thomaskioko.tvmaniac.core.view.UiMessage
@@ -36,6 +37,7 @@ import com.thomaskioko.tvmaniac.navigation.SheetChild
 import com.thomaskioko.tvmaniac.navigation.SheetDestination
 import com.thomaskioko.tvmaniac.presenter.home.HomePresenter
 import com.thomaskioko.tvmaniac.presenter.home.di.HomeChildGraph
+import com.thomaskioko.tvmaniac.presenter.root.model.ConnectivityBannerState
 import com.thomaskioko.tvmaniac.presenter.root.model.ToastState
 import com.thomaskioko.tvmaniac.presenter.root.model.ToastType
 import com.thomaskioko.tvmaniac.seasondetails.nav.SeasonDetailsRoute
@@ -48,9 +50,11 @@ import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
 import io.github.thomaskioko.codegen.annotations.AppRoot
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -83,6 +87,7 @@ public class DefaultRootPresenter(
     private val datastoreRepository: DatastoreRepository,
     private val syncObserver: SyncObserver,
     private val localizer: Localizer,
+    private val internetConnectionChecker: InternetConnectionChecker,
 ) : RootPresenter, ComponentContext by componentContext {
 
     private val coroutineScope = coroutineScope()
@@ -91,6 +96,7 @@ public class DefaultRootPresenter(
     private val uiMessageManager = UiMessageManager()
     private val syncErrorMessages = UiMessageManager()
     private val uiState = MutableStateFlow(RootUiState())
+    private val connectivityBanner = MutableStateFlow(ConnectivityBannerState.Hidden)
 
     init {
         coroutineScope.launch {
@@ -119,6 +125,23 @@ public class DefaultRootPresenter(
                 .filter { it }
                 .take(1)
                 .collect { notificationRationale.showIfNeeded() }
+        }
+
+        coroutineScope.launch {
+            internetConnectionChecker.observeConnection()
+                .debounce(CONNECTIVITY_DEBOUNCE)
+                .distinctUntilChanged()
+                .collectLatest { connected ->
+                    if (connected) {
+                        if (connectivityBanner.value == ConnectivityBannerState.Offline) {
+                            connectivityBanner.value = ConnectivityBannerState.BackOnline
+                            delay(MIN_STATUS_DISPLAY)
+                        }
+                        connectivityBanner.value = ConnectivityBannerState.Hidden
+                    } else {
+                        connectivityBanner.value = ConnectivityBannerState.Offline
+                    }
+                }
         }
 
         coroutineScope.launch {
@@ -248,6 +271,11 @@ public class DefaultRootPresenter(
     override val accountLimitBannerVisibleValue: Value<Boolean> =
         accountLimitBannerVisible.asValue(coroutineScope)
 
+    override val connectivityBannerState: StateFlow<ConnectivityBannerState> = connectivityBanner.asStateFlow()
+
+    override val connectivityBannerStateValue: Value<ConnectivityBannerState> =
+        connectivityBannerState.asValue(coroutineScope)
+
     override fun onRationaleAccepted() {
         coroutineScope.launch {
             datastoreRepository.setShowNotificationRationale(false)
@@ -328,6 +356,10 @@ public class DefaultRootPresenter(
         uiState.update { it.copy(accountLimitBannerDismissed = true) }
     }
 
+    override fun onDismissOfflineBanner() {
+        connectivityBanner.value = ConnectivityBannerState.Hidden
+    }
+
     @AssistedFactory
     public fun interface Factory {
         public fun create(componentContext: ComponentContext): DefaultRootPresenter
@@ -335,6 +367,7 @@ public class DefaultRootPresenter(
 
     private companion object {
         private val MIN_STATUS_DISPLAY = 2_500.milliseconds
+        private val CONNECTIVITY_DEBOUNCE = 300.milliseconds
     }
 }
 

--- a/features/root/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/root/RootPresenter.kt
+++ b/features/root/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/root/RootPresenter.kt
@@ -8,6 +8,7 @@ import com.thomaskioko.root.model.DeepLinkDestination
 import com.thomaskioko.root.model.NotificationPermissionState
 import com.thomaskioko.tvmaniac.navigation.SheetChild
 import com.thomaskioko.tvmaniac.presenter.home.HomePresenter
+import com.thomaskioko.tvmaniac.presenter.root.model.ConnectivityBannerState
 import com.thomaskioko.tvmaniac.presenter.root.model.ToastState
 import kotlinx.coroutines.flow.StateFlow
 
@@ -42,6 +43,10 @@ public interface RootPresenter {
 
     public val accountLimitBannerVisibleValue: Value<Boolean>
 
+    public val connectivityBannerState: StateFlow<ConnectivityBannerState>
+
+    public val connectivityBannerStateValue: Value<ConnectivityBannerState>
+
     public fun onRationaleAccepted()
 
     public fun onRationaleDismissed()
@@ -53,4 +58,6 @@ public interface RootPresenter {
     public fun onToastShown(id: Long)
 
     public fun onDismissAccountLimitBanner()
+
+    public fun onDismissOfflineBanner()
 }

--- a/features/root/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/root/model/ConnectivityBannerState.kt
+++ b/features/root/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/root/model/ConnectivityBannerState.kt
@@ -1,0 +1,7 @@
+package com.thomaskioko.tvmaniac.presenter.root.model
+
+public enum class ConnectivityBannerState {
+    Hidden,
+    Offline,
+    BackOnline,
+}

--- a/features/root/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenterTest.kt
+++ b/features/root/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenterTest.kt
@@ -9,6 +9,7 @@ import com.arkivanov.essenty.lifecycle.resume
 import com.thomaskioko.root.model.AppUiState
 import com.thomaskioko.root.model.DeepLinkDestination
 import com.thomaskioko.root.model.NotificationPermissionState
+import com.thomaskioko.tvmaniac.core.connectivity.testing.FakeInternetConnectionChecker
 import com.thomaskioko.tvmaniac.datastore.api.AppTheme
 import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
 import com.thomaskioko.tvmaniac.domain.theme.Theme
@@ -17,6 +18,7 @@ import com.thomaskioko.tvmaniac.i18n.testing.util.getString
 import com.thomaskioko.tvmaniac.moreshows.nav.MoreShowsRoute
 import com.thomaskioko.tvmaniac.navigation.Navigator
 import com.thomaskioko.tvmaniac.navigation.RootChild
+import com.thomaskioko.tvmaniac.presenter.root.model.ConnectivityBannerState
 import com.thomaskioko.tvmaniac.presenter.root.model.ToastState
 import com.thomaskioko.tvmaniac.presenter.root.model.ToastType
 import com.thomaskioko.tvmaniac.seasondetails.nav.SeasonDetailsRoute
@@ -50,6 +52,7 @@ abstract class DefaultRootPresenterTest {
     abstract val datastoreRepository: DatastoreRepository
     abstract val navigator: Navigator
     abstract val syncObserver: SyncObserver
+    abstract val internetConnectionChecker: FakeInternetConnectionChecker
 
     private val lifecycle = LifecycleRegistry()
     private val testDispatcher = StandardTestDispatcher()
@@ -497,4 +500,109 @@ abstract class DefaultRootPresenterTest {
                 presenter.accountLimitBannerVisible.value shouldBe false
             }
         }
+
+    @Test
+    fun `should show offline banner given connection is lost`() = runTest(testDispatcher) {
+        presenter.connectivityBannerState.test {
+            awaitItem() shouldBe ConnectivityBannerState.Hidden
+
+            internetConnectionChecker.setConnected(false)
+            advanceTimeBy(301.milliseconds)
+            runCurrent()
+
+            awaitItem() shouldBe ConnectivityBannerState.Offline
+        }
+    }
+
+    @Test
+    fun `should hide offline banner given it is dismissed`() = runTest(testDispatcher) {
+        presenter.connectivityBannerState.test {
+            awaitItem() shouldBe ConnectivityBannerState.Hidden
+
+            internetConnectionChecker.setConnected(false)
+            advanceTimeBy(301.milliseconds)
+            runCurrent()
+            awaitItem() shouldBe ConnectivityBannerState.Offline
+
+            presenter.onDismissOfflineBanner()
+
+            awaitItem() shouldBe ConnectivityBannerState.Hidden
+        }
+    }
+
+    @Test
+    fun `should show offline banner again given device goes offline after a dismissed reconnect`() =
+        runTest(testDispatcher) {
+            presenter.connectivityBannerState.test {
+                awaitItem() shouldBe ConnectivityBannerState.Hidden
+
+                internetConnectionChecker.setConnected(false)
+                advanceTimeBy(301.milliseconds)
+                runCurrent()
+                awaitItem() shouldBe ConnectivityBannerState.Offline
+
+                presenter.onDismissOfflineBanner()
+                awaitItem() shouldBe ConnectivityBannerState.Hidden
+
+                internetConnectionChecker.setConnected(true)
+                advanceTimeBy(301.milliseconds)
+                runCurrent()
+                expectNoEvents()
+
+                internetConnectionChecker.setConnected(false)
+                advanceTimeBy(301.milliseconds)
+                runCurrent()
+
+                awaitItem() shouldBe ConnectivityBannerState.Offline
+            }
+        }
+
+    @Test
+    fun `should flash back online given connection returns while banner is visible`() = runTest(testDispatcher) {
+        presenter.connectivityBannerState.test {
+            awaitItem() shouldBe ConnectivityBannerState.Hidden
+
+            internetConnectionChecker.setConnected(false)
+            advanceTimeBy(301.milliseconds)
+            runCurrent()
+            awaitItem() shouldBe ConnectivityBannerState.Offline
+
+            internetConnectionChecker.setConnected(true)
+            advanceTimeBy(301.milliseconds)
+            runCurrent()
+            awaitItem() shouldBe ConnectivityBannerState.BackOnline
+
+            advanceTimeBy(2_501.milliseconds)
+            runCurrent()
+
+            awaitItem() shouldBe ConnectivityBannerState.Hidden
+        }
+    }
+
+    @Test
+    fun `should keep banner hidden given app starts online`() = runTest(testDispatcher) {
+        presenter.connectivityBannerState.test {
+            awaitItem() shouldBe ConnectivityBannerState.Hidden
+
+            advanceTimeBy(400.milliseconds)
+            runCurrent()
+
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `should keep banner hidden given connection flaps within the debounce window`() = runTest(testDispatcher) {
+        presenter.connectivityBannerState.test {
+            awaitItem() shouldBe ConnectivityBannerState.Hidden
+
+            internetConnectionChecker.setConnected(false)
+            advanceTimeBy(100.milliseconds)
+            internetConnectionChecker.setConnected(true)
+            advanceTimeBy(400.milliseconds)
+            runCurrent()
+
+            expectNoEvents()
+        }
+    }
 }

--- a/features/root/presenter/src/iosTest/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenterIosTest.kt
+++ b/features/root/presenter/src/iosTest/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenterIosTest.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.presenter.root
 
+import com.thomaskioko.tvmaniac.core.connectivity.testing.FakeInternetConnectionChecker
 import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
 import com.thomaskioko.tvmaniac.featureflags.testing.FakeRemoteConfigBridge
 import com.thomaskioko.tvmaniac.navigation.Navigator
@@ -23,4 +24,7 @@ internal class DefaultRootPresenterIosTest : DefaultRootPresenterTest() {
 
     override val syncObserver: SyncObserver
         get() = testGraph.syncObserver
+
+    override val internetConnectionChecker: FakeInternetConnectionChecker
+        get() = testGraph.fakeInternetConnectionChecker
 }

--- a/features/root/presenter/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenterJvmTest.kt
+++ b/features/root/presenter/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenterJvmTest.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.presenter.root
 
+import com.thomaskioko.tvmaniac.core.connectivity.testing.FakeInternetConnectionChecker
 import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
 import com.thomaskioko.tvmaniac.navigation.Navigator
 import com.thomaskioko.tvmaniac.syncstate.api.SyncObserver
@@ -22,4 +23,7 @@ internal class DefaultRootPresenterJvmTest : DefaultRootPresenterTest() {
 
     override val syncObserver: SyncObserver
         get() = testComponent.syncObserver
+
+    override val internetConnectionChecker: FakeInternetConnectionChecker
+        get() = testComponent.fakeInternetConnectionChecker
 }

--- a/features/root/ui/README.md
+++ b/features/root/ui/README.md
@@ -351,6 +351,7 @@ graph TB
   :features:progress:nav --> :navigation:api
   :features:root:nav --> :domain:theme
   :features:root:presenter --> :core:base
+  :features:root:presenter --> :core:connectivity:api
   :features:root:presenter --> :core:logger:api
   :features:root:presenter --> :core:syncstate:api
   :features:root:presenter -.-> :core:view

--- a/features/root/ui/src/main/kotlin/com/thomaskioko/tvmaniac/app/ui/OfflineBanner.kt
+++ b/features/root/ui/src/main/kotlin/com/thomaskioko/tvmaniac/app/ui/OfflineBanner.kt
@@ -1,0 +1,50 @@
+package com.thomaskioko.tvmaniac.app.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewWrapper
+import com.thomaskioko.tvmaniac.compose.components.BannerStyle
+import com.thomaskioko.tvmaniac.compose.components.ThemePreviews
+import com.thomaskioko.tvmaniac.compose.components.TvManiacBanner
+import com.thomaskioko.tvmaniac.compose.components.TvManiacPreviewWrapperProvider
+import com.thomaskioko.tvmaniac.i18n.MR.strings.cd_dismiss
+import com.thomaskioko.tvmaniac.i18n.MR.strings.status_connected
+import com.thomaskioko.tvmaniac.i18n.MR.strings.status_no_connection
+import com.thomaskioko.tvmaniac.presenter.root.model.ConnectivityBannerState
+import dev.icerock.moko.resources.compose.stringResource
+
+@Composable
+internal fun OfflineBanner(
+    state: ConnectivityBannerState,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var displayState by remember { mutableStateOf(state) }
+    if (state != ConnectivityBannerState.Hidden) {
+        displayState = state
+    }
+    val backOnline = displayState == ConnectivityBannerState.BackOnline
+
+    TvManiacBanner(
+        message = stringResource(if (backOnline) status_connected else status_no_connection),
+        onDismiss = onDismiss,
+        modifier = modifier,
+        visible = state != ConnectivityBannerState.Hidden,
+        style = if (backOnline) BannerStyle.Success else BannerStyle.Warning,
+        dismissContentDescription = stringResource(cd_dismiss),
+    )
+}
+
+@ThemePreviews
+@PreviewWrapper(TvManiacPreviewWrapperProvider::class)
+@Composable
+private fun OfflineBannerPreview() {
+    OfflineBanner(
+        state = ConnectivityBannerState.Offline,
+        onDismiss = {},
+    )
+}

--- a/features/root/ui/src/main/kotlin/com/thomaskioko/tvmaniac/app/ui/RootScreen.kt
+++ b/features/root/ui/src/main/kotlin/com/thomaskioko/tvmaniac/app/ui/RootScreen.kt
@@ -42,6 +42,7 @@ import com.thomaskioko.tvmaniac.navigation.ui.LocalScreenContents
 import com.thomaskioko.tvmaniac.navigation.ui.ScreenContent
 import com.thomaskioko.tvmaniac.navigation.ui.SheetContent
 import com.thomaskioko.tvmaniac.presenter.root.RootPresenter
+import com.thomaskioko.tvmaniac.presenter.root.model.ConnectivityBannerState
 import com.thomaskioko.tvmaniac.presenter.root.model.ToastState
 import com.thomaskioko.tvmaniac.presenter.root.model.ToastType
 import io.github.thomaskioko.codegen.annotations.AppRootUi
@@ -73,6 +74,7 @@ public fun RootScreen(
     val toastState by rootPresenter.toastState.collectAsStateWithLifecycle()
     val syncIndicatorVisible by rootPresenter.syncIndicatorVisible.collectAsStateWithLifecycle()
     val accountLimitBannerVisible by rootPresenter.accountLimitBannerVisible.collectAsStateWithLifecycle()
+    val connectivityBannerState by rootPresenter.connectivityBannerState.collectAsStateWithLifecycle()
 
     val permissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission(),
@@ -98,10 +100,12 @@ public fun RootScreen(
         notificationPermissionState = notificationPermissionState,
         episodeSheetSlot = episodeSheetSlot,
         accountLimitBannerVisible = accountLimitBannerVisible,
+        connectivityBannerState = connectivityBannerState,
         onRationaleAccepted = { rootPresenter.onRationaleAccepted() },
         onRationaleDismissed = { rootPresenter.onRationaleDismissed() },
         onDismissToast = { toastState.id?.let(rootPresenter::onToastShown) },
         onDismissAccountLimitBanner = { rootPresenter.onDismissAccountLimitBanner() },
+        onDismissOfflineBanner = { rootPresenter.onDismissOfflineBanner() },
         modifier = modifier,
     ) {
         HomeScreen(
@@ -120,10 +124,12 @@ internal fun RootContent(
     notificationPermissionState: NotificationPermissionState,
     episodeSheetSlot: ChildSlot<*, SheetChild>,
     accountLimitBannerVisible: Boolean,
+    connectivityBannerState: ConnectivityBannerState,
     onRationaleAccepted: () -> Unit,
     onRationaleDismissed: () -> Unit,
     onDismissToast: () -> Unit,
     onDismissAccountLimitBanner: () -> Unit,
+    onDismissOfflineBanner: () -> Unit,
     modifier: Modifier = Modifier,
     content: @Composable ColumnScope.() -> Unit,
 ) {
@@ -171,6 +177,12 @@ internal fun RootContent(
                     visible = accountLimitBannerVisible,
                     modifier = Modifier.align(Alignment.TopCenter),
                 )
+
+                OfflineBanner(
+                    state = connectivityBannerState,
+                    onDismiss = onDismissOfflineBanner,
+                    modifier = Modifier.align(Alignment.TopCenter),
+                )
             }
 
             TvManiacSnackBarHost(
@@ -197,10 +209,12 @@ private fun RootScreenPreview(
         notificationPermissionState = state.notificationPermissionState,
         episodeSheetSlot = ChildSlot<Nothing, Nothing>(),
         accountLimitBannerVisible = state.accountLimitBannerVisible,
+        connectivityBannerState = state.connectivityBannerState,
         onRationaleAccepted = {},
         onRationaleDismissed = {},
         onDismissToast = {},
         onDismissAccountLimitBanner = {},
+        onDismissOfflineBanner = {},
     ) {
         Box(modifier = Modifier.fillMaxSize())
     }
@@ -211,6 +225,7 @@ internal data class RootPreviewState(
     val syncIndicatorVisible: Boolean = false,
     val notificationPermissionState: NotificationPermissionState = NotificationPermissionState(),
     val accountLimitBannerVisible: Boolean = false,
+    val connectivityBannerState: ConnectivityBannerState = ConnectivityBannerState.Hidden,
 )
 
 internal class RootPreviewParameterProvider : PreviewParameterProvider<RootPreviewState> {
@@ -228,5 +243,7 @@ internal class RootPreviewParameterProvider : PreviewParameterProvider<RootPrevi
             ),
             RootPreviewState(syncIndicatorVisible = true),
             RootPreviewState(accountLimitBannerVisible = true),
+            RootPreviewState(connectivityBannerState = ConnectivityBannerState.Offline),
+            RootPreviewState(connectivityBannerState = ConnectivityBannerState.BackOnline),
         )
 }

--- a/features/root/ui/src/test/kotlin/com/thomaskioko/tvmaniac/app/ui/roborrazi/OfflineBannerScreenshotTest.kt
+++ b/features/root/ui/src/test/kotlin/com/thomaskioko/tvmaniac/app/ui/roborrazi/OfflineBannerScreenshotTest.kt
@@ -1,0 +1,56 @@
+package com.thomaskioko.tvmaniac.app.ui.roborrazi
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import com.thomaskioko.tvmaniac.app.ui.OfflineBanner
+import com.thomaskioko.tvmaniac.presenter.root.model.ConnectivityBannerState
+import com.thomaskioko.tvmaniac.screenshottests.captureMultiDevice
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import org.robolectric.annotation.LooperMode
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@LooperMode(LooperMode.Mode.PAUSED)
+internal class OfflineBannerScreenshotTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun offlineBanner() {
+        composeTestRule.captureMultiDevice("OfflineBanner") {
+            Surface(modifier = Modifier.fillMaxSize()) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    OfflineBanner(
+                        state = ConnectivityBannerState.Offline,
+                        onDismiss = {},
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun backOnlineBanner() {
+        composeTestRule.captureMultiDevice("BackOnlineBanner") {
+            Surface(modifier = Modifier.fillMaxSize()) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    OfflineBanner(
+                        state = ConnectivityBannerState.BackOnline,
+                        onDismiss = {},
+                    )
+                }
+            }
+        }
+    }
+}

--- a/ios-framework/README.md
+++ b/ios-framework/README.md
@@ -1130,6 +1130,7 @@ graph TB
   :features:rating-sheet:presenter --> :navigation:api
   :features:root:nav --> :domain:theme
   :features:root:presenter --> :core:base
+  :features:root:presenter --> :core:connectivity:api
   :features:root:presenter --> :core:logger:api
   :features:root:presenter --> :core:syncstate:api
   :features:root:presenter -.-> :core:view

--- a/ios/Packages/Root/Sources/Root/OfflineBanner.swift
+++ b/ios/Packages/Root/Sources/Root/OfflineBanner.swift
@@ -1,0 +1,29 @@
+//
+//  OfflineBanner.swift
+//  tv-maniac
+//
+
+import Components
+import SwiftUI
+import TvManiacKit
+
+struct OfflineBanner: View {
+    let isBackOnline: Bool
+    let onDismiss: () -> Void
+
+    var body: some View {
+        TvManiacBanner(
+            message: isBackOnline ? String(\.status_connected) : String(\.status_no_connection),
+            style: isBackOnline ? .success : .warning,
+            dismissAccessibilityLabel: String(\.cd_dismiss),
+            onDismiss: onDismiss
+        )
+    }
+}
+
+#Preview {
+    VStack {
+        OfflineBanner(isBackOnline: false, onDismiss: {})
+        OfflineBanner(isBackOnline: true, onDismiss: {})
+    }
+}

--- a/ios/Packages/Root/Sources/Root/RootNavigationView.swift
+++ b/ios/Packages/Root/Sources/Root/RootNavigationView.swift
@@ -14,6 +14,7 @@ public struct RootNavigationView: View {
     @StateValue private var notificationPermissionState: NotificationPermissionState
     @StateValue private var episodeSheetSlot: ChildSlot<AnyObject, SheetChild>
     @StateValue private var accountLimitBannerVisible: KotlinBoolean
+    @StateValue private var connectivityBannerState: ConnectivityBannerState
     @StateObject private var store = SettingsAppStorage.shared
     @EnvironmentObject private var appDelegate: AppDelegate
     @State private var rationaleActionTaken = false
@@ -26,6 +27,7 @@ public struct RootNavigationView: View {
         _notificationPermissionState = .init(rootPresenter.notificationPermissionStateValue)
         _episodeSheetSlot = .init(rootPresenter.episodeSheetSlotValue)
         _accountLimitBannerVisible = .init(rootPresenter.accountLimitBannerVisibleValue)
+        _connectivityBannerState = .init(rootPresenter.connectivityBannerStateValue)
     }
 
     public var body: some View {
@@ -42,6 +44,16 @@ public struct RootNavigationView: View {
                 }
             }
             .animation(.spring(), value: accountLimitBannerVisible.boolValue)
+            .overlay(alignment: .top) {
+                if connectivityBannerState != ConnectivityBannerState.hidden {
+                    OfflineBanner(
+                        isBackOnline: connectivityBannerState == ConnectivityBannerState.backonline,
+                        onDismiss: { rootPresenter.onDismissOfflineBanner() }
+                    )
+                    .transition(.move(edge: .top).combined(with: .opacity))
+                }
+            }
+            .animation(.spring(), value: connectivityBannerState)
         }
         .appTheme()
         .hapticFeedbackEnabled(appUiState.hapticFeedbackEnabled)


### PR DESCRIPTION
## Description

This PR adds a banner that appears while the device has no internet connection and briefly confirms when the connection returns.

## Changes

- Add a connection stream to InternetConnectionChecker on every platform
- Add a banner state machine to the root presenter with a dismiss action and a short Back Online confirmation
- Show the banner on the Android root screen and add a screenshot test for it
- Show the banner on the iOS root view
