### PR TITLE
feat: Log network errors

### DIFF
--- a/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklHttpClient.kt
+++ b/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklHttpClient.kt
@@ -2,6 +2,7 @@ package com.thomaskioko.tvmaniac.simkl.implementation
 
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthError
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
+import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.ApiErrorReportingPlugin
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.IsAuthenticated
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.HttpExceptions
 import com.thomaskioko.tvmaniac.oauth.api.AuthStateHolder
@@ -40,6 +41,10 @@ internal fun simklHttpClient(
 ): HttpClient {
     val client = HttpClient(httpClientEngine) {
         install(ContentNegotiation) { json(json = json) }
+
+        install(ApiErrorReportingPlugin) {
+            onError = { message, throwable -> kermitLogger.error("Network Error : SimklApi", message, throwable) }
+        }
 
         install(HttpRequestRetry) {
             retryIf(5) { _, httpResponse ->

--- a/api/tmdb/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/TmdbClient.kt
+++ b/api/tmdb/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/tmdb/implementation/TmdbClient.kt
@@ -1,6 +1,7 @@
 package com.thomaskioko.tvmaniac.tmdb.implementation
 
 import com.thomaskioko.tvmaniac.core.connectivity.api.InternetConnectionChecker
+import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.ApiErrorReportingPlugin
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.InternetConnectionPlugin
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
@@ -32,6 +33,10 @@ internal fun tmdbHttpClient(
 ) =
     HttpClient(httpClientEngine) {
         install(ContentNegotiation) { json(json = json) }
+
+        install(ApiErrorReportingPlugin) {
+            onError = { message, throwable -> kermitLogger.error("Network Error : TmdbApi", message, throwable) }
+        }
 
         install(InternetConnectionPlugin) {
             this.internetConnectionChecker = internetConnectionChecker

--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/TraktHttpClient.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/TraktHttpClient.kt
@@ -2,6 +2,7 @@ package com.thomaskioko.trakt.service.implementation
 
 import com.thomaskioko.tvmaniac.accountmanager.api.TokenRefreshResult
 import com.thomaskioko.tvmaniac.core.connectivity.api.InternetConnectionChecker
+import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.ApiErrorReportingPlugin
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.InternetConnectionPlugin
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.IsAuthenticated
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.HttpExceptions
@@ -47,6 +48,10 @@ internal fun traktHttpClient(
 ): HttpClient {
     val client = HttpClient(httpClientEngine) {
         install(ContentNegotiation) { json(json = json) }
+
+        install(ApiErrorReportingPlugin) {
+            onError = { message, throwable -> kermitLogger.error("Network Error : TraktApi", message, throwable) }
+        }
 
         install(InternetConnectionPlugin) {
             this.internetConnectionChecker = internetConnectionChecker

--- a/core/network-util/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/networkutil/api/extensions/ApiErrorReportingPlugin.kt
+++ b/core/network-util/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/networkutil/api/extensions/ApiErrorReportingPlugin.kt
@@ -1,0 +1,81 @@
+package com.thomaskioko.tvmaniac.core.networkutil.api.extensions
+
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiHttpException
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.AuthenticationException
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.NoInternetException
+import io.ktor.client.plugins.ResponseException
+import io.ktor.client.plugins.api.ClientPlugin
+import io.ktor.client.plugins.api.Send
+import io.ktor.client.plugins.api.createClientPlugin
+import io.ktor.client.request.HttpRequest
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.HttpResponsePipeline
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.encodedPath
+import io.ktor.http.isSuccess
+import io.ktor.serialization.ContentConvertException
+import kotlinx.serialization.SerializationException
+import kotlin.coroutines.cancellation.CancellationException
+
+public class ApiErrorReportingPluginConfig {
+    public var onError: (message: String, throwable: Throwable) -> Unit = { _, _ -> }
+}
+
+public val ApiErrorReportingPlugin: ClientPlugin<ApiErrorReportingPluginConfig> = createClientPlugin(
+    "ApiErrorReportingPlugin",
+    ::ApiErrorReportingPluginConfig,
+) {
+    val onError = pluginConfig.onError
+
+    on(Send) { request ->
+        val call = try {
+            proceed(request)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: NoInternetException) {
+            throw e
+        } catch (e: AuthenticationException) {
+            throw e
+        } catch (e: Throwable) {
+            val body = (e as? ResponseException)?.response?.errorBody()
+            onError(withBody("${request.requestLabel} failed", body), e)
+            throw e
+        }
+
+        val status = call.response.status
+        if (!status.isSuccess()) {
+            val message = withBody("HTTP ${status.value} ${request.requestLabel}", call.response.errorBody())
+            onError(message, ApiHttpException(status.value, message))
+        }
+        call
+    }
+
+    client.responsePipeline.intercept(HttpResponsePipeline.Receive) {
+        try {
+            proceed()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: ContentConvertException) {
+            onError(withBody("Deserialization failed for ${context.request.requestLabel}", context.response.errorBody()), e)
+            throw e
+        } catch (e: SerializationException) {
+            onError(withBody("Deserialization failed for ${context.request.requestLabel}", context.response.errorBody()), e)
+            throw e
+        }
+    }
+}
+
+private const val ERROR_BODY_LIMIT = 500
+
+private val HttpRequestBuilder.requestLabel: String
+    get() = "${method.value} ${url.host}${url.encodedPath}"
+
+private val HttpRequest.requestLabel: String
+    get() = "${method.value} ${url.host}${url.encodedPath}"
+
+private suspend fun HttpResponse.errorBody(): String? =
+    runCatching { bodyAsText() }.getOrNull()?.take(ERROR_BODY_LIMIT)?.takeIf { it.isNotBlank() }
+
+private fun withBody(message: String, body: String?): String =
+    if (body == null) message else "$message: $body"

--- a/core/network-util/api/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/core/networkutil/api/extensions/ApiErrorReportingPluginTest.kt
+++ b/core/network-util/api/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/core/networkutil/api/extensions/ApiErrorReportingPluginTest.kt
@@ -1,0 +1,235 @@
+package com.thomaskioko.tvmaniac.core.networkutil.api.extensions
+
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiHttpException
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.AuthenticationException
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.HttpExceptions
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.NoInternetException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.HttpResponseValidator
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.http.isSuccess
+import io.ktor.http.path
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.test.Test
+
+class ApiErrorReportingPluginTest {
+
+    private val reported = mutableListOf<Pair<String, Throwable>>()
+
+    private fun createClient(engine: MockEngine, maxRetries: Int = 0): HttpClient = HttpClient(engine) {
+        install(ContentNegotiation) { json() }
+
+        install(ApiErrorReportingPlugin) {
+            onError = { message, throwable -> reported.add(message to throwable) }
+        }
+
+        if (maxRetries > 0) {
+            install(HttpRequestRetry) {
+                retryIf(maxRetries) { _, httpResponse -> httpResponse.status.value in 500..599 }
+                constantDelay(millis = 1)
+            }
+        }
+    }
+
+    private suspend fun HttpClient.requestTestPath(): ApiResponse<JsonObject> = safeRequest {
+        url { path("test") }
+        method = HttpMethod.Get
+    }
+
+    @Test
+    fun `should not report failure given successful response`() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = loadJson("success_response.json"),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+
+        createClient(engine).requestTestPath()
+
+        reported.shouldBeEmpty()
+    }
+
+    @Test
+    fun `should report failure given error response`() = runTest {
+        val engine = MockEngine { _ ->
+            respondError(
+                status = HttpStatusCode.BadRequest,
+                content = loadJson("error_response.json"),
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+
+        createClient(engine).requestTestPath()
+
+        reported.size shouldBe 1
+        reported.first().first shouldContain "HTTP 400"
+        reported.first().first shouldContain "bad request"
+        val throwable = reported.first().second.shouldBeInstanceOf<ApiHttpException>()
+        throwable.code shouldBe 400
+    }
+
+    @Test
+    fun `should report failure given response validator throws`() = runTest {
+        val engine = MockEngine { _ ->
+            respondError(
+                status = HttpStatusCode.InternalServerError,
+                content = loadJson("error_response.json"),
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json() }
+
+            install(ApiErrorReportingPlugin) {
+                onError = { message, throwable -> reported.add(message to throwable) }
+            }
+
+            HttpResponseValidator {
+                validateResponse { response ->
+                    if (!response.status.isSuccess()) {
+                        throw HttpExceptions(
+                            response = response,
+                            failureReason = "${response.status.value} Server Error",
+                            cachedResponseText = response.bodyAsText(),
+                        )
+                    }
+                }
+            }
+        }
+
+        val result = client.requestTestPath()
+
+        result.shouldBeInstanceOf<ApiResponse.Error.HttpError<JsonObject>>()
+        reported.size shouldBe 1
+        reported.first().first shouldContain "bad request"
+    }
+
+    @Test
+    fun `should report failure once given retries are exhausted`() = runTest {
+        val engine = MockEngine { _ ->
+            respondError(
+                status = HttpStatusCode.InternalServerError,
+                content = loadJson("error_response.json"),
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+
+        createClient(engine, maxRetries = 2).requestTestPath()
+
+        reported.size shouldBe 1
+        reported.first().first shouldContain "HTTP 500"
+    }
+
+    @Test
+    fun `should not report failure given response recovers after retry`() = runTest {
+        var attempts = 0
+        val engine = MockEngine { _ ->
+            attempts++
+            if (attempts == 1) {
+                respondError(
+                    status = HttpStatusCode.InternalServerError,
+                    content = loadJson("error_response.json"),
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            } else {
+                respond(
+                    content = loadJson("success_response.json"),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            }
+        }
+
+        val result = createClient(engine, maxRetries = 2).requestTestPath()
+
+        result.shouldBeInstanceOf<ApiResponse.Success<JsonObject>>()
+        reported.shouldBeEmpty()
+    }
+
+    @Test
+    fun `should report failure given request times out`() = runTest {
+        val engine = MockEngine { _ ->
+            throw HttpRequestTimeoutException(url = "http://test/test", timeoutMillis = 1_000L)
+        }
+
+        val result = createClient(engine).requestTestPath()
+
+        result.shouldBeInstanceOf<ApiResponse.Error.NetworkFailure>()
+        reported.size shouldBe 1
+        reported.first().second.shouldBeInstanceOf<HttpRequestTimeoutException>()
+    }
+
+    @Test
+    fun `should report failure given malformed response body`() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = """not json""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+
+        val result = createClient(engine).requestTestPath()
+
+        result.shouldBeInstanceOf<ApiResponse.Error.SerializationError>()
+        reported.size shouldBe 1
+        reported.first().first shouldContain "Deserialization failed"
+        reported.first().first shouldContain "not json"
+    }
+
+    @Test
+    fun `should not report failure given device is offline`() = runTest {
+        val engine = MockEngine { _ -> throw NoInternetException }
+
+        val result = createClient(engine).requestTestPath()
+
+        result.shouldBeInstanceOf<ApiResponse.Error.OfflineError>()
+        reported.shouldBeEmpty()
+    }
+
+    @Test
+    fun `should not report failure given user is not authenticated`() = runTest {
+        val engine = MockEngine { _ -> throw AuthenticationException(message = "User is not authenticated") }
+
+        val result = createClient(engine).requestTestPath()
+
+        result.shouldBeInstanceOf<ApiResponse.Unauthenticated>()
+        reported.shouldBeEmpty()
+    }
+
+    @Test
+    fun `should not report failure given request is cancelled`() = runTest {
+        val engine = MockEngine { _ -> throw CancellationException("cancelled by test") }
+        val client = createClient(engine)
+
+        shouldThrow<CancellationException> {
+            client.safeRequest<JsonObject> {
+                url { path("test") }
+                method = HttpMethod.Get
+            }
+        }
+
+        reported.shouldBeEmpty()
+    }
+}


### PR DESCRIPTION
## Description
This PR adds a Ktor plugin that reports API and network failures to Firebase.

## Changes
- Add `ApiErrorReportingPlugin` to report failed responses, timeouts, and deserialization failures as non-fatal Crashlytics issues.
- Install the plugin in the TMDB, Trakt, and Simkl clients with a tag for each provider.
- Include the failing endpoint, status code, and response body in every report.
- Skip cancelled requests, offline errors, and signed out sessions so expected failures stay out of the reports.
