### PR TITLE
chore: Update dev builds to twice a week and generate release notes

### DIFF
--- a/.github/workflows/dev-build-android.yml
+++ b/.github/workflows/dev-build-android.yml
@@ -3,7 +3,7 @@ name: Dev Build Android
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 * * 1-5'  # Weekdays at 1:00 AM UTC (3:00 AM Berlin summer, 2:00 winter)
+    - cron: '0 1 * * 1,4'  # Mon + Thu at 1:00 AM UTC (3:00 AM Berlin summer, 2:00 winter)
 
 permissions:
   contents: read

--- a/.github/workflows/dev-build-android.yml
+++ b/.github/workflows/dev-build-android.yml
@@ -1,4 +1,4 @@
-name: Daily Build Android
+name: Dev Build Android
 
 on:
   workflow_dispatch:
@@ -10,7 +10,7 @@ permissions:
   actions: read
 
 concurrency:
-  group: daily-build-android
+  group: dev-build-android
   cancel-in-progress: false
 
 env:
@@ -37,7 +37,7 @@ jobs:
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          last=$(gh run list --repo "${{ github.repository }}" --workflow daily-build-android.yml --status success --limit 1 --json headSha --jq '.[0].headSha // empty')
+          last=$(gh run list --repo "${{ github.repository }}" --workflow dev-build-android.yml --status success --limit 1 --json headSha --jq '.[0].headSha // empty')
           if [ "$last" = "${{ github.sha }}" ]; then
             echo "No new commits since the last successful nightly — skipping."
             echo "should_run=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dev-build-android.yml
+++ b/.github/workflows/dev-build-android.yml
@@ -150,10 +150,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           mv app-release.apk tvmaniac-nightly.apk
-          notes="Automated nightly build ${{ needs.build.outputs.version }}-dev (build ${{ needs.build.outputs.build }}) from ${GITHUB_SHA}."
+          notes="Nightly build ${{ needs.build.outputs.version }}-dev (build ${{ needs.build.outputs.build }}) from ${GITHUB_SHA:0:7}."
+          last=$(gh run list --repo "${{ github.repository }}" --workflow dev-build-android.yml --status success --limit 1 --json headSha --jq '.[0].headSha // empty')
+          if [ -n "$last" ] && [ "$last" != "$GITHUB_SHA" ]; then
+            changes=$(gh api "repos/${{ github.repository }}/compare/$last...$GITHUB_SHA" \
+              --jq '.commits[].commit.message | split("\n")[0] | select(startswith("Merge ") | not) | "- " + .')
+            if [ -n "$changes" ]; then
+              notes=$(printf "%s\n\n## What's Changed\n%s" "$notes" "$changes")
+            fi
+          fi
           if ! gh release view nightly --repo "${{ github.repository }}" > /dev/null 2>&1; then
-            gh release create nightly --repo "${{ github.repository }}" --prerelease --title "Nightly build" --notes "$notes"
+            gh release create nightly --repo "${{ github.repository }}" --prerelease --target "$GITHUB_SHA" --title "Nightly build" --notes "$notes"
           else
+            gh api -X PATCH "repos/${{ github.repository }}/git/refs/tags/nightly" -f sha="$GITHUB_SHA" -F force=true
             gh release edit nightly --repo "${{ github.repository }}" --notes "$notes"
           fi
           gh release upload nightly tvmaniac-nightly.apk --clobber --repo "${{ github.repository }}"

--- a/.github/workflows/dev-build-ios.yml
+++ b/.github/workflows/dev-build-ios.yml
@@ -3,7 +3,7 @@ name: Dev Build iOS
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 * * 1-5'  # Weekdays at 1:00 AM UTC (3:00 AM Berlin summer, 2:00 winter)
+    - cron: '0 1 * * 1,4'  # Mon + Thu at 1:00 AM UTC (3:00 AM Berlin summer, 2:00 winter)
 
 permissions:
   contents: read

--- a/.github/workflows/dev-build-ios.yml
+++ b/.github/workflows/dev-build-ios.yml
@@ -1,4 +1,4 @@
-name: Daily Build iOS
+name: Dev Build iOS
 
 on:
   workflow_dispatch:
@@ -10,7 +10,7 @@ permissions:
   actions: read
 
 concurrency:
-  group: daily-build-ios
+  group: dev-build-ios
   cancel-in-progress: false
 
 env:
@@ -38,7 +38,7 @@ jobs:
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          last=$(gh run list --repo "${{ github.repository }}" --workflow daily-build-ios.yml --status success --limit 1 --json headSha --jq '.[0].headSha // empty')
+          last=$(gh run list --repo "${{ github.repository }}" --workflow dev-build-ios.yml --status success --limit 1 --json headSha --jq '.[0].headSha // empty')
           if [ "$last" = "${{ github.sha }}" ]; then
             echo "No new commits since the last successful nightly — skipping."
             echo "should_run=false" >> "$GITHUB_OUTPUT"

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -1,13 +1,13 @@
 # Release Process
 
-TvManiac uses an automated release pipeline that builds, signs, and deploys to both Google Play Store and Apple App Store. Production releases are triggered by tags pushed from the local release task and roll out through approval gates. Daily builds run on a weekday schedule; beta releases are triggered manually.
+TvManiac uses an automated release pipeline that builds, signs, and deploys to both Google Play Store and Apple App Store. Production releases are triggered by tags pushed from the local release task and roll out through approval gates. Dev builds run on a Monday and Thursday schedule; beta releases are triggered manually.
 
 ## Table of Contents
 
 - [Prerequisites](#prerequisites)
 - [Create a Production Release](#create-a-production-release)
 - [Trigger Beta Release on CI](#trigger-beta-release-on-ci)
-- [Daily Builds](#daily-builds)
+- [Dev Builds](#dev-builds)
 - [Gradual Rollout](#gradual-rollout)
 - [Promote a Release Locally](#promote-a-release-locally)
 - [Version Bumping](#version-bumping)
@@ -67,7 +67,7 @@ Platform workflows are independent. If one platform fails, the other still deplo
 
 ## Trigger Beta Release on CI
 
-Beta releases deploy builds to the Play Store open testing track and TestFlight for wider testing. Nothing is committed or pushed — the build number is derived the same way as daily builds.
+Beta releases deploy builds to the Play Store open testing track and TestFlight for wider testing. Nothing is committed or pushed — the build number is derived the same way as dev builds.
 
 Go to **Actions > Beta Release > Run workflow**, or use the CLI:
 
@@ -87,20 +87,20 @@ gh workflow run beta-release.yml -f skip_ios=true
 2. **Build**: Per-platform build jobs produce the signed artifacts (Android with a `-beta` suffix) and upload them as workflow artifacts.
 3. **Deploy**: Separate jobs publish them — Android to the Play Store open testing track and Firebase App Distribution, iOS to TestFlight.
 
-A beta and a daily build cut from the same commit derive the same build number, and the stores reject the duplicate upload. Land a commit first, or rerun after one lands.
+A beta and a dev build cut from the same commit derive the same build number, and the stores reject the duplicate upload. Land a commit first, or rerun after one lands.
 
-## Daily Builds
+## Dev Builds
 
-Daily builds run per platform on weekdays at 1:00 AM UTC (3:00 AM Berlin in summer, 2:00 AM in winter), and can also be triggered manually. Each workflow is self-contained, so a failed platform reruns alone.
+Dev builds run per platform on Mondays and Thursdays at 1:00 AM UTC (3:00 AM Berlin in summer, 2:00 AM in winter), and can also be triggered manually. Each workflow is self-contained, so a failed platform reruns alone.
 
 ```bash
-gh workflow run daily-build-android.yml
-gh workflow run daily-build-ios.yml
+gh workflow run dev-build-android.yml
+gh workflow run dev-build-ios.yml
 ```
 
 **What happens:**
 
-1. **Check**: Scheduled runs skip when `main` has no new commits since the last successful daily build. Manual runs always build.
+1. **Check**: Scheduled runs skip when `main` has no new commits since the last successful dev build. Manual runs always build.
 2. **Version**: `scripts/ci/write-build-number.sh` derives the build number as `base(version) + commits since the release tag` and writes it to `version.txt` in the runner's workspace only — nothing is committed or pushed.
 3. **Build**: One job builds the signed artifacts with a `-dev` suffix (Android AAB and APK, iOS IPA) and uploads them as workflow artifacts.
 4. **Deploy**: Separate jobs download the artifacts and publish them — Android to the Play Store internal track, Firebase App Distribution, and the rolling `nightly` GitHub release in parallel, iOS to TestFlight. The nightly release keeps one stable download URL whose APK is replaced on every run.
@@ -162,7 +162,7 @@ bundle exec fastlane ios deploy_app_store
 ./gradlew :app:bumpVersion -Ptype=major   # 0.1.2 > 1.0.0, BUILD = 10000000
 ```
 
-`-Ptype=beta` still exists but is legacy: CI derives beta and daily build numbers from git instead. Don't commit beta bumps — a raised `BUILD_NUMBER` floor can block derived builds until enough commits land.
+`-Ptype=beta` still exists but is legacy: CI derives beta and dev build numbers from git instead. Don't commit beta bumps — a raised `BUILD_NUMBER` floor can block derived builds until enough commits land.
 
 ---
 
@@ -170,12 +170,12 @@ bundle exec fastlane ios deploy_app_store
 
 Beta builds let you upload multiple test versions to Play Store and TestFlight without burning version numbers. This is useful for internal testing before a production release.
 
-Beta and daily build numbers are derived, not committed: `base(version) + commits since the release tag`. The committed `BUILD_NUMBER` in `version.txt` only changes on production releases.
+Beta and dev build numbers are derived, not committed: `base(version) + commits since the release tag`. The committed `BUILD_NUMBER` in `version.txt` only changes on production releases.
 
 **Example lifecycle:**
 
 ```
-0.1.2 / 102000 released  >  40 commits land   >  daily/beta builds derive 102001…102040
+0.1.2 / 102000 released  >  40 commits land   >  dev/beta builds derive 102001…102040
 patch release            >  0.1.3 / 103000     >  derivation continues from v0.1.3
 ```
 
@@ -189,7 +189,7 @@ All versioning is driven by `version.txt` at the project root, which contains `V
 
 **Build number formula:** `(major * 10,000,000) + (minor * 100,000) + (patch * 1,000)`
 
-|              | Production                | Beta                     | Daily                    |
+|              | Production                | Beta                     | Dev                    |
 |--------------|---------------------------|--------------------------|--------------------------|
 | Version name | `0.1.3`                   | `0.1.2-beta`             | `0.1.2-dev`              |
 | Build number | `103000` (committed)      | derived `102001`–`102999` | derived `102001`–`102999` |
@@ -198,7 +198,7 @@ All versioning is driven by `version.txt` at the project root, which contains `V
 | Firebase     | Yes                       | Yes                      | Yes                      |
 | Trigger      | Tag push                  | `workflow_dispatch`      | Schedule / manual        |
 
-Version-name suffixes are passed per workflow: production overrides to empty, daily builds use `-dev`, betas use `-beta`. Local builds default to `-debug` via `gradle.properties`.
+Version-name suffixes are passed per workflow: production overrides to empty, dev builds use `-dev`, betas use `-beta`. Local builds default to `-debug` via `gradle.properties`.
 
 ---
 


### PR DESCRIPTION
## Description
This PR renames the daily build workflows to dev builds and schedules them for Monday and Thursday. The nightly release now lists the commits that went into each build instead of a single plain sentence.
