### PR TITLE
feat: Add Quick Rate setting on Android

### DIFF
--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/journey/UnauthenticatedUserJourneyTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/journey/UnauthenticatedUserJourneyTest.kt
@@ -132,6 +132,17 @@ internal class UnauthenticatedUserJourneyTest : BaseAppFlowTest() {
 
         rootRobot.assertNotificationRationaleDoesNotExist()
 
+        // Turn quick rate on and off
+        settingsRobot
+            .clickBackButton()
+            .openBehaviorPage()
+            .scrollToQuickRateToggle()
+            .assertQuickRateDisabled()
+            .clickQuickRateToggle()
+            .assertQuickRateEnabled()
+            .clickQuickRateToggle()
+            .assertQuickRateDisabled()
+
         // Follow show locally
         settingsRobot
             .clickBackButton()

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/robot/SettingsRobot.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/robot/SettingsRobot.kt
@@ -163,6 +163,25 @@ internal class SettingsRobot(composeUi: ComposeUiTest) : BaseRobot<SettingsRobot
         click(SettingsTestTags.EPISODE_NOTIFICATIONS_TOGGLE_TEST_TAG)
     }
 
+    fun scrollToQuickRateToggle() = apply {
+        scrollToListTag(
+            SettingsTestTags.LIST_TEST_TAG,
+            SettingsTestTags.QUICK_RATE_TOGGLE_TEST_TAG,
+        )
+    }
+
+    fun assertQuickRateEnabled() = apply {
+        assertChecked(SettingsTestTags.QUICK_RATE_TOGGLE_TEST_TAG)
+    }
+
+    fun assertQuickRateDisabled() = apply {
+        assertUnchecked(SettingsTestTags.QUICK_RATE_TOGGLE_TEST_TAG)
+    }
+
+    fun clickQuickRateToggle() = apply {
+        click(SettingsTestTags.QUICK_RATE_TOGGLE_TEST_TAG)
+    }
+
     fun scrollToSwitchProviderButton() = apply {
         scrollToListTag(SettingsTestTags.LIST_TEST_TAG, SettingsTestTags.SWITCH_PROVIDER_BUTTON_TEST_TAG)
     }

--- a/features/settings/ui/src/main/kotlin/com/thomaskioko/tvmaniac/settings/ui/SettingsPreviewParameterProvider.kt
+++ b/features/settings/ui/src/main/kotlin/com/thomaskioko/tvmaniac/settings/ui/SettingsPreviewParameterProvider.kt
@@ -212,6 +212,13 @@ internal val appearanceLockedState = appearanceState.copy(
     ),
 )
 internal val behaviorState = loggedInState.copy(currentPage = SettingsPage.BEHAVIOR, currentPageTitle = "Behavior")
+internal val behaviorLockedState = behaviorState.copy(
+    locks = SettingsLocks(
+        quickRateLocked = true,
+        badgeText = "Premium",
+        lockedContentDescription = "Locked",
+    ),
+)
 internal val notificationsState = loggedInState.copy(currentPage = SettingsPage.NOTIFICATIONS, currentPageTitle = "Notifications")
 internal val notificationsLockedState = notificationsState.copy(
     locks = SettingsLocks(

--- a/features/settings/ui/src/main/kotlin/com/thomaskioko/tvmaniac/settings/ui/components/BehaviorPage.kt
+++ b/features/settings/ui/src/main/kotlin/com/thomaskioko/tvmaniac/settings/ui/components/BehaviorPage.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.StarRate
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.Tv
 import androidx.compose.material.icons.filled.VideoLibrary
@@ -17,11 +18,13 @@ import com.thomaskioko.tvmaniac.compose.components.TvManiacPreviewWrapperProvide
 import com.thomaskioko.tvmaniac.compose.theme.TvManiacSpacing
 import com.thomaskioko.tvmaniac.settings.presenter.BackgroundSyncToggled
 import com.thomaskioko.tvmaniac.settings.presenter.IncludeSpecialsToggled
+import com.thomaskioko.tvmaniac.settings.presenter.QuickRateToggled
 import com.thomaskioko.tvmaniac.settings.presenter.SettingsActions
 import com.thomaskioko.tvmaniac.settings.presenter.SettingsState
 import com.thomaskioko.tvmaniac.settings.presenter.YoutubeToggled
 import com.thomaskioko.tvmaniac.settings.ui.SettingsGroup
 import com.thomaskioko.tvmaniac.settings.ui.SettingsGroupDivider
+import com.thomaskioko.tvmaniac.settings.ui.behaviorLockedState
 import com.thomaskioko.tvmaniac.settings.ui.behaviorState
 import com.thomaskioko.tvmaniac.testtags.settings.SettingsTestTags
 
@@ -61,6 +64,17 @@ internal fun BehaviorPage(
                 )
                 SettingsGroupDivider()
                 SwitchRow(
+                    modifier = Modifier.testTag(SettingsTestTags.QUICK_RATE_TOGGLE_TEST_TAG),
+                    icon = Icons.Filled.StarRate,
+                    title = state.labels.quickRateTitle,
+                    description = state.labels.quickRateDescription,
+                    checked = state.quickRateEnabled,
+                    onCheckedChange = { onAction(QuickRateToggled(it)) },
+                    locked = state.locks.quickRateLocked,
+                    lockedBadgeText = state.locks.badgeText,
+                )
+                SettingsGroupDivider()
+                SwitchRow(
                     icon = Icons.Filled.Tv,
                     title = state.labels.youtubeTitle,
                     description = state.labels.youtubeDescription,
@@ -80,6 +94,16 @@ internal fun BehaviorPage(
 private fun BehaviorPagePreview() {
     BehaviorPage(
         state = behaviorState,
+        onAction = {},
+    )
+}
+
+@ThemePreviews
+@PreviewWrapper(TvManiacPreviewWrapperProvider::class)
+@Composable
+private fun BehaviorPageLockedPreview() {
+    BehaviorPage(
+        state = behaviorLockedState,
         onAction = {},
     )
 }

--- a/features/settings/ui/src/test/kotlin/com/thomaskioko/tvmaniac/seasondetails/roborrazi/SettingsScreenshotTest.kt
+++ b/features/settings/ui/src/test/kotlin/com/thomaskioko/tvmaniac/seasondetails/roborrazi/SettingsScreenshotTest.kt
@@ -16,6 +16,7 @@ import com.thomaskioko.tvmaniac.settings.ui.accountSwitchState
 import com.thomaskioko.tvmaniac.settings.ui.accountSwitchingState
 import com.thomaskioko.tvmaniac.settings.ui.appearanceLockedState
 import com.thomaskioko.tvmaniac.settings.ui.appearanceState
+import com.thomaskioko.tvmaniac.settings.ui.behaviorLockedState
 import com.thomaskioko.tvmaniac.settings.ui.behaviorState
 import com.thomaskioko.tvmaniac.settings.ui.defaultState
 import com.thomaskioko.tvmaniac.settings.ui.discoverSectionsState
@@ -194,6 +195,18 @@ class SettingsScreenshotTest {
             TvManiacBackground {
                 SettingsScreen(
                     state = behaviorState,
+                    onAction = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun settingsScreenBehaviorPageLocked() {
+        composeTestRule.captureMultiDevice("SettingsScreenBehaviorPageLocked") {
+            TvManiacBackground {
+                SettingsScreen(
+                    state = behaviorLockedState,
                     onAction = {},
                 )
             }


### PR DESCRIPTION
## Description
This PR adds the Quick Rate setting to the Behavior page on Android. The row shows a Premium badge when the subscription does not cover it.
