### PR TITLE
feat: Add the activity sections to the Android statistics screen

### DIFF
--- a/core/test-tags/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testtags/statistics/StatisticsTestTags.kt
+++ b/core/test-tags/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testtags/statistics/StatisticsTestTags.kt
@@ -13,8 +13,13 @@ public object StatisticsTestTags {
     public const val MOST_WATCHED_ROW_TEST_TAG: String = "statistics_most_watched_row"
     public const val WATCH_STATUS_SECTION_TEST_TAG: String = "statistics_watch_status_section"
     public const val RATINGS_SECTION_TEST_TAG: String = "statistics_ratings_section"
+    public const val HEAT_MAP_TEST_TAG: String = "statistics_heat_map"
+    public const val YEARLY_ACTIVITY_TEST_TAG: String = "statistics_yearly_activity"
+    public const val MONTHLY_ACTIVITY_TEST_TAG: String = "statistics_monthly_activity"
+    public const val WEEKDAY_ACTIVITY_TEST_TAG: String = "statistics_weekday_activity"
     public fun tile(id: String): String = "statistics_tile_$id"
     public fun mostWatchedShowCard(showId: Long): String = "statistics_most_watched_show_$showId"
     public fun watchStatusRow(id: String): String = "statistics_watch_status_row_$id"
     public fun ratingRow(rating: Int): String = "statistics_rating_row_$rating"
+    public fun activityBar(section: String, label: String): String = "statistics_${section}_bar_$label"
 }

--- a/core/test-tags/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testtags/statistics/StatisticsTestTags.kt
+++ b/core/test-tags/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testtags/statistics/StatisticsTestTags.kt
@@ -17,6 +17,7 @@ public object StatisticsTestTags {
     public const val YEARLY_ACTIVITY_TEST_TAG: String = "statistics_yearly_activity"
     public const val MONTHLY_ACTIVITY_TEST_TAG: String = "statistics_monthly_activity"
     public const val WEEKDAY_ACTIVITY_TEST_TAG: String = "statistics_weekday_activity"
+    public const val ACTIVITY_TOOLTIP_TEST_TAG: String = "statistics_activity_tooltip"
     public fun tile(id: String): String = "statistics_tile_$id"
     public fun mostWatchedShowCard(showId: Long): String = "statistics_most_watched_show_$showId"
     public fun watchStatusRow(id: String): String = "statistics_watch_status_row_$id"

--- a/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/WatchStatisticsCalculator.kt
+++ b/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/WatchStatisticsCalculator.kt
@@ -91,7 +91,7 @@ public class WatchStatisticsCalculator(
 
     private fun calculateDailyCounts(watchedDays: List<WatchedDay>, today: LocalDate): List<DailyWatchCount> {
         val byDate = watchedDays.groupBy { it.date }
-        val firstDay = today.plus(-(HEAT_MAP_DAYS - 1), DateTimeUnit.DAY)
+        val firstDay = LocalDate(today.year, 1, 1)
         return generateSequence(firstDay) { day ->
             if (day == today) null else day.plus(1, DateTimeUnit.DAY)
         }.map { day ->
@@ -228,7 +228,6 @@ public class WatchStatisticsCalculator(
     private data class WatchedDay(val date: LocalDate, val minutes: Long)
 
     private companion object {
-        const val HEAT_MAP_DAYS = 365
         const val LAST_PERIOD_DAYS = 30
         const val LOWEST_RATING = 1
         const val HIGHEST_RATING = 10

--- a/domain/statistics/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/statistics/WatchStatisticsCalculatorTest.kt
+++ b/domain/statistics/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/statistics/WatchStatisticsCalculatorTest.kt
@@ -24,6 +24,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.Month
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.daysUntil
 import kotlinx.datetime.toInstant
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -67,7 +68,8 @@ internal class WatchStatisticsCalculatorTest : BaseDatabaseTest() {
 
         statistics.hasWatchHistory shouldBe false
         statistics.hasRuntimeData shouldBe false
-        statistics.dailyCounts.size shouldBe 365
+        statistics.dailyCounts.first().date shouldBe FIRST_OF_YEAR
+        statistics.dailyCounts.last().date shouldBe TODAY
         statistics.dailyCounts.all { it.episodeCount == 0 } shouldBe true
         statistics.ratingDistribution.map { it.rating } shouldBe (1..10).toList()
         statistics.ratingDistribution.all { it.count == 0L } shouldBe true
@@ -129,16 +131,16 @@ internal class WatchStatisticsCalculatorTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun `should end the daily series on today and cover a year`() = runTest(testDispatcher) {
+    fun `should run the daily series from the first of the year up to today`() = runTest(testDispatcher) {
         insertShow(tmdbId = BREAKING_BAD)
         markWatched(BREAKING_BAD, episodeNumber = 1, watchedAt = epochMillis(2026, 8, 3))
 
         val days = calculate().dailyCounts
 
-        days.size shouldBe 365
-        days.last().date shouldBe LocalDate(2026, 8, 3)
+        days.size shouldBe FIRST_OF_YEAR.daysUntil(TODAY) + 1
+        days.last().date shouldBe TODAY
         days.last().episodeCount shouldBe 1
-        days.first().date shouldBe LocalDate(2025, 8, 4)
+        days.first().date shouldBe FIRST_OF_YEAR
     }
 
     @Test
@@ -498,6 +500,9 @@ internal class WatchStatisticsCalculatorTest : BaseDatabaseTest() {
     }
 
     private companion object {
+        val TODAY = LocalDate(2026, 8, 3)
+        val FIRST_OF_YEAR = LocalDate(TODAY.year, 1, 1)
+
         const val BREAKING_BAD = 1396L
         const val THE_WIRE = 1438L
         const val SEASON_ID = 3572L

--- a/features/statistics/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/statistics/presenter/StatisticsPresenterTest.kt
+++ b/features/statistics/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/statistics/presenter/StatisticsPresenterTest.kt
@@ -99,7 +99,9 @@ internal class StatisticsPresenterTest {
             state.hasWatchHistory shouldBe true
             state.showContent shouldBe true
             state.showEmptyState shouldBe false
-            state.heatMap.shouldNotBeNull().cells.size shouldBe 365
+            val cells = state.heatMap.shouldNotBeNull().cells
+            cells.first().date shouldBe "2026-01-01"
+            cells.last().date shouldBe "2026-08-03"
         }
     }
 

--- a/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/StatisticsPreviewParameterProvider.kt
+++ b/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/StatisticsPreviewParameterProvider.kt
@@ -102,36 +102,36 @@ private val previewTiles: ImmutableList<StatisticTile> = persistentListOf(
 )
 
 private val previewYearlyActivity: ImmutableList<ActivityBar> = persistentListOf(
-    ActivityBar(label = "2022", episodeCount = 84, fraction = 0.27f),
-    ActivityBar(label = "2023", episodeCount = 312, fraction = 1f),
-    ActivityBar(label = "2024", episodeCount = 196, fraction = 0.63f),
-    ActivityBar(label = "2025", episodeCount = 148, fraction = 0.47f),
-    ActivityBar(label = "2026", episodeCount = 91, fraction = 0.29f),
+    ActivityBar(label = "2022", episodeCount = 84, caption = "84 episodes", fraction = 0.27f),
+    ActivityBar(label = "2023", episodeCount = 312, caption = "312 episodes", fraction = 1f),
+    ActivityBar(label = "2024", episodeCount = 196, caption = "196 episodes", fraction = 0.63f),
+    ActivityBar(label = "2025", episodeCount = 148, caption = "148 episodes", fraction = 0.47f),
+    ActivityBar(label = "2026", episodeCount = 91, caption = "91 episodes", fraction = 0.29f),
 )
 
 private val previewMonthlyActivity: ImmutableList<ActivityBar> = persistentListOf(
-    ActivityBar(label = "Jan", episodeCount = 24, fraction = 0.6f),
-    ActivityBar(label = "Feb", episodeCount = 18, fraction = 0.45f),
-    ActivityBar(label = "Mar", episodeCount = 31, fraction = 0.77f),
-    ActivityBar(label = "Apr", episodeCount = 12, fraction = 0.3f),
-    ActivityBar(label = "May", episodeCount = 40, fraction = 1f),
-    ActivityBar(label = "Jun", episodeCount = 22, fraction = 0.55f),
-    ActivityBar(label = "Jul", episodeCount = 8, fraction = 0.2f),
-    ActivityBar(label = "Aug", episodeCount = 27, fraction = 0.67f),
-    ActivityBar(label = "Sep", episodeCount = 15, fraction = 0.37f),
-    ActivityBar(label = "Oct", episodeCount = 33, fraction = 0.82f),
-    ActivityBar(label = "Nov", episodeCount = 19, fraction = 0.47f),
-    ActivityBar(label = "Dec", episodeCount = 29, fraction = 0.72f),
+    ActivityBar(label = "Jan", episodeCount = 24, caption = "24 episodes", fraction = 0.6f),
+    ActivityBar(label = "Feb", episodeCount = 18, caption = "18 episodes", fraction = 0.45f),
+    ActivityBar(label = "Mar", episodeCount = 31, caption = "31 episodes", fraction = 0.77f),
+    ActivityBar(label = "Apr", episodeCount = 12, caption = "12 episodes", fraction = 0.3f),
+    ActivityBar(label = "May", episodeCount = 40, caption = "40 episodes", fraction = 1f),
+    ActivityBar(label = "Jun", episodeCount = 22, caption = "22 episodes", fraction = 0.55f),
+    ActivityBar(label = "Jul", episodeCount = 8, caption = "8 episodes", fraction = 0.2f),
+    ActivityBar(label = "Aug", episodeCount = 27, caption = "27 episodes", fraction = 0.67f),
+    ActivityBar(label = "Sep", episodeCount = 15, caption = "15 episodes", fraction = 0.37f),
+    ActivityBar(label = "Oct", episodeCount = 33, caption = "33 episodes", fraction = 0.82f),
+    ActivityBar(label = "Nov", episodeCount = 19, caption = "19 episodes", fraction = 0.47f),
+    ActivityBar(label = "Dec", episodeCount = 29, caption = "29 episodes", fraction = 0.72f),
 )
 
 private val previewWeekdayActivity: ImmutableList<ActivityBar> = persistentListOf(
-    ActivityBar(label = "Mon", episodeCount = 12, fraction = 0.6f),
-    ActivityBar(label = "Tue", episodeCount = 8, fraction = 0.4f),
-    ActivityBar(label = "Wed", episodeCount = 14, fraction = 0.7f),
-    ActivityBar(label = "Thu", episodeCount = 6, fraction = 0.3f),
-    ActivityBar(label = "Fri", episodeCount = 17, fraction = 0.85f),
-    ActivityBar(label = "Sat", episodeCount = 20, fraction = 1f),
-    ActivityBar(label = "Sun", episodeCount = 16, fraction = 0.8f),
+    ActivityBar(label = "Mon", episodeCount = 12, caption = "12 episodes", fraction = 0.6f),
+    ActivityBar(label = "Tue", episodeCount = 8, caption = "8 episodes", fraction = 0.4f),
+    ActivityBar(label = "Wed", episodeCount = 14, caption = "14 episodes", fraction = 0.7f),
+    ActivityBar(label = "Thu", episodeCount = 6, caption = "6 episodes", fraction = 0.3f),
+    ActivityBar(label = "Fri", episodeCount = 17, caption = "17 episodes", fraction = 0.85f),
+    ActivityBar(label = "Sat", episodeCount = 20, caption = "20 episodes", fraction = 1f),
+    ActivityBar(label = "Sun", episodeCount = 16, caption = "16 episodes", fraction = 0.8f),
 )
 
 private val previewHeatMap: WatchHeatMap = WatchHeatMap(

--- a/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/StatisticsPreviewParameterProvider.kt
+++ b/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/StatisticsPreviewParameterProvider.kt
@@ -3,10 +3,13 @@ package com.thomaskioko.tvmaniac.statistics.ui
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.thomaskioko.tvmaniac.statistics.presenter.StatisticsLabels
 import com.thomaskioko.tvmaniac.statistics.presenter.StatisticsState
+import com.thomaskioko.tvmaniac.statistics.presenter.model.ActivityBar
+import com.thomaskioko.tvmaniac.statistics.presenter.model.HeatMap
 import com.thomaskioko.tvmaniac.statistics.presenter.model.MostWatchedShowItem
 import com.thomaskioko.tvmaniac.statistics.presenter.model.RatingBar
 import com.thomaskioko.tvmaniac.statistics.presenter.model.StatisticTile
 import com.thomaskioko.tvmaniac.statistics.presenter.model.StatisticTileId
+import com.thomaskioko.tvmaniac.statistics.presenter.model.WatchHeatMap
 import com.thomaskioko.tvmaniac.statistics.presenter.model.WatchStatusItem
 import com.thomaskioko.tvmaniac.statistics.presenter.model.WatchStatusItemId
 import com.thomaskioko.tvmaniac.statistics.presenter.model.WatchTime
@@ -25,6 +28,9 @@ internal val previewLabels: StatisticsLabels = StatisticsLabels(
     mostWatchedTitle = "Most watched shows",
     watchStatusTitle = "Shows by status",
     ratingsTitle = "Your ratings",
+    yearlyActivityTitle = "Episodes by year",
+    monthlyActivityTitle = "Episodes by month",
+    weekdayActivityTitle = "Episodes by day of the week",
     lockedTitle = "Statistics are a Premium feature",
     lockedMessage = "Upgrade to Premium to see how you watch.",
     lockedBadgeText = "Premium",
@@ -43,6 +49,12 @@ private val previewTiles: ImmutableList<StatisticTile> = persistentListOf(
         id = StatisticTileId.WatchDaysThisYear,
         label = "Watch days this year",
         value = "112/214",
+        caption = "days you watched something",
+    ),
+    StatisticTile(
+        id = StatisticTileId.WatchDaysThisMonth,
+        label = "Watch days this month",
+        value = "11/28",
         caption = "days you watched something",
     ),
     StatisticTile(
@@ -81,7 +93,61 @@ private val previewTiles: ImmutableList<StatisticTile> = persistentListOf(
         value = "9 days",
         caption = "longest run",
     ),
+    StatisticTile(
+        id = StatisticTileId.CurrentStreak,
+        label = "Current streak",
+        value = "3 days",
+        caption = "running now",
+    ),
 )
+
+private val previewYearlyActivity: ImmutableList<ActivityBar> = persistentListOf(
+    ActivityBar(label = "2022", episodeCount = 84, fraction = 0.27f),
+    ActivityBar(label = "2023", episodeCount = 312, fraction = 1f),
+    ActivityBar(label = "2024", episodeCount = 196, fraction = 0.63f),
+    ActivityBar(label = "2025", episodeCount = 148, fraction = 0.47f),
+    ActivityBar(label = "2026", episodeCount = 91, fraction = 0.29f),
+)
+
+private val previewMonthlyActivity: ImmutableList<ActivityBar> = persistentListOf(
+    ActivityBar(label = "Jan", episodeCount = 24, fraction = 0.6f),
+    ActivityBar(label = "Feb", episodeCount = 18, fraction = 0.45f),
+    ActivityBar(label = "Mar", episodeCount = 31, fraction = 0.77f),
+    ActivityBar(label = "Apr", episodeCount = 12, fraction = 0.3f),
+    ActivityBar(label = "May", episodeCount = 40, fraction = 1f),
+    ActivityBar(label = "Jun", episodeCount = 22, fraction = 0.55f),
+    ActivityBar(label = "Jul", episodeCount = 8, fraction = 0.2f),
+    ActivityBar(label = "Aug", episodeCount = 27, fraction = 0.67f),
+    ActivityBar(label = "Sep", episodeCount = 15, fraction = 0.37f),
+    ActivityBar(label = "Oct", episodeCount = 33, fraction = 0.82f),
+    ActivityBar(label = "Nov", episodeCount = 19, fraction = 0.47f),
+    ActivityBar(label = "Dec", episodeCount = 29, fraction = 0.72f),
+)
+
+private val previewWeekdayActivity: ImmutableList<ActivityBar> = persistentListOf(
+    ActivityBar(label = "Mon", episodeCount = 12, fraction = 0.6f),
+    ActivityBar(label = "Tue", episodeCount = 8, fraction = 0.4f),
+    ActivityBar(label = "Wed", episodeCount = 14, fraction = 0.7f),
+    ActivityBar(label = "Thu", episodeCount = 6, fraction = 0.3f),
+    ActivityBar(label = "Fri", episodeCount = 17, fraction = 0.85f),
+    ActivityBar(label = "Sat", episodeCount = 20, fraction = 1f),
+    ActivityBar(label = "Sun", episodeCount = 16, fraction = 0.8f),
+)
+
+private val previewHeatMap: WatchHeatMap = WatchHeatMap(
+    cells = List(HEAT_MAP_PREVIEW_DAYS) { index ->
+        HeatMap(
+            date = "2026-01-01",
+            level = (index * 7) % 5,
+            episodeCount = (index * 7) % 5,
+        )
+    },
+    leadingBlankCells = 3,
+    activeDays = 232,
+    quietDays = 133,
+)
+
+private const val HEAT_MAP_PREVIEW_DAYS = 365
 
 private val previewMostWatchedShows: ImmutableList<MostWatchedShowItem> = persistentListOf(
     MostWatchedShowItem(
@@ -142,6 +208,10 @@ internal val contentState: StatisticsState = StatisticsState(
     mostWatchedShows = previewMostWatchedShows,
     watchStatusBreakdown = previewWatchStatusBreakdown,
     ratingBreakdown = previewRatingBreakdown,
+    yearlyActivity = previewYearlyActivity,
+    monthlyActivity = previewMonthlyActivity,
+    weekdayActivity = previewWeekdayActivity,
+    heatMap = previewHeatMap,
     labels = previewLabels,
 )
 

--- a/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/StatisticsPreviewParameterProvider.kt
+++ b/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/StatisticsPreviewParameterProvider.kt
@@ -23,7 +23,7 @@ internal val previewLabels: StatisticsLabels = StatisticsLabels(
     daysLabel = "days",
     hoursLabel = "hours",
     minutesLabel = "minutes",
-    episodesOverTimeTitle = "Your last year of watching",
+    episodesOverTimeTitle = "Your year of watching",
     markedWatchedNote = "Dates show when episodes were marked as watched, not when you watched them.",
     mostWatchedTitle = "Most watched shows",
     watchStatusTitle = "Shows by status",
@@ -143,11 +143,11 @@ private val previewHeatMap: WatchHeatMap = WatchHeatMap(
         )
     },
     leadingBlankCells = 3,
-    activeDays = 232,
-    quietDays = 133,
+    activeDays = 138,
+    quietDays = 77,
 )
 
-private const val HEAT_MAP_PREVIEW_DAYS = 365
+private const val HEAT_MAP_PREVIEW_DAYS = 215
 
 private val previewMostWatchedShows: ImmutableList<MostWatchedShowItem> = persistentListOf(
     MostWatchedShowItem(

--- a/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/StatisticsScreen.kt
+++ b/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/StatisticsScreen.kt
@@ -257,6 +257,7 @@ private fun StatisticsContent(
                     title = state.labels.yearlyActivityTitle,
                     sectionTestTag = StatisticsTestTags.YEARLY_ACTIVITY_TEST_TAG,
                     sectionName = "yearly",
+                    showAxisLabels = true,
                 )
             }
         }

--- a/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/StatisticsScreen.kt
+++ b/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/StatisticsScreen.kt
@@ -43,9 +43,11 @@ import com.thomaskioko.tvmaniac.i18n.resolve
 import com.thomaskioko.tvmaniac.statistics.presenter.StatisticsAction
 import com.thomaskioko.tvmaniac.statistics.presenter.StatisticsPresenter
 import com.thomaskioko.tvmaniac.statistics.presenter.StatisticsState
+import com.thomaskioko.tvmaniac.statistics.ui.components.ActivityChartSection
 import com.thomaskioko.tvmaniac.statistics.ui.components.MostWatchedShowsSection
 import com.thomaskioko.tvmaniac.statistics.ui.components.RatingsSection
 import com.thomaskioko.tvmaniac.statistics.ui.components.StatisticTileGrid
+import com.thomaskioko.tvmaniac.statistics.ui.components.WatchHeatMapSection
 import com.thomaskioko.tvmaniac.statistics.ui.components.WatchStatusSection
 import com.thomaskioko.tvmaniac.statistics.ui.components.WatchTimeSection
 import com.thomaskioko.tvmaniac.testtags.statistics.StatisticsTestTags
@@ -235,6 +237,48 @@ private fun StatisticsContent(
                         .fillMaxWidth()
                         .padding(horizontal = TvManiacSpacing.medium)
                         .testTag(StatisticsTestTags.MARKED_WATCHED_NOTE_TEST_TAG),
+                )
+            }
+        }
+
+        state.heatMap?.let { heatMap ->
+            item(key = "heat_map") {
+                WatchHeatMapSection(
+                    heatMap = heatMap,
+                    title = state.labels.episodesOverTimeTitle,
+                )
+            }
+        }
+
+        if (state.yearlyActivity.isNotEmpty()) {
+            item(key = "yearly_activity") {
+                ActivityChartSection(
+                    bars = state.yearlyActivity,
+                    title = state.labels.yearlyActivityTitle,
+                    sectionTestTag = StatisticsTestTags.YEARLY_ACTIVITY_TEST_TAG,
+                    sectionName = "yearly",
+                )
+            }
+        }
+
+        if (state.monthlyActivity.isNotEmpty()) {
+            item(key = "monthly_activity") {
+                ActivityChartSection(
+                    bars = state.monthlyActivity,
+                    title = state.labels.monthlyActivityTitle,
+                    sectionTestTag = StatisticsTestTags.MONTHLY_ACTIVITY_TEST_TAG,
+                    sectionName = "monthly",
+                )
+            }
+        }
+
+        if (state.weekdayActivity.isNotEmpty()) {
+            item(key = "weekday_activity") {
+                ActivityChartSection(
+                    bars = state.weekdayActivity,
+                    title = state.labels.weekdayActivityTitle,
+                    sectionTestTag = StatisticsTestTags.WEEKDAY_ACTIVITY_TEST_TAG,
+                    sectionName = "weekday",
                 )
             }
         }

--- a/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/StatisticsScreen.kt
+++ b/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/StatisticsScreen.kt
@@ -208,6 +208,16 @@ private fun StatisticsContent(
         contentPadding = contentPadding,
         verticalArrangement = Arrangement.spacedBy(TvManiacSpacing.large),
     ) {
+        state.heatMap?.let { heatMap ->
+            item(key = "heat_map") {
+                WatchHeatMapSection(
+                    heatMap = heatMap,
+                    title = state.labels.episodesOverTimeTitle,
+                    modifier = Modifier.padding(top = TvManiacSpacing.small),
+                )
+            }
+        }
+
         state.totalWatchTime?.let { watchTime ->
             item(key = "watch_time_hero") {
                 WatchTimeSection(
@@ -216,7 +226,6 @@ private fun StatisticsContent(
                     daysLabel = state.labels.daysLabel,
                     hoursLabel = state.labels.hoursLabel,
                     minutesLabel = state.labels.minutesLabel,
-                    modifier = Modifier.padding(top = TvManiacSpacing.small),
                 )
             }
         }
@@ -237,15 +246,6 @@ private fun StatisticsContent(
                         .fillMaxWidth()
                         .padding(horizontal = TvManiacSpacing.medium)
                         .testTag(StatisticsTestTags.MARKED_WATCHED_NOTE_TEST_TAG),
-                )
-            }
-        }
-
-        state.heatMap?.let { heatMap ->
-            item(key = "heat_map") {
-                WatchHeatMapSection(
-                    heatMap = heatMap,
-                    title = state.labels.episodesOverTimeTitle,
                 )
             }
         }

--- a/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/components/ActivityChartSection.kt
+++ b/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/components/ActivityChartSection.kt
@@ -177,13 +177,18 @@ private fun AxisLabels(
     bars: ImmutableList<ActivityBar>,
     modifier: Modifier = Modifier,
 ) {
-    val step = ((bars.size - 1) / (AXIS_LABEL_COUNT - 1)).coerceAtLeast(1)
+    // Evenly spaced and always including both ends, so the axis names where it starts and stops.
+    val labelled = if (bars.lastIndex <= 0) {
+        setOf(0)
+    } else {
+        (0 until AXIS_LABEL_COUNT).map { it * bars.lastIndex / (AXIS_LABEL_COUNT - 1) }.toSet()
+    }
 
     Row(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        bars.filterIndexed { index, _ -> index % step == 0 }.forEach { bar ->
+        bars.filterIndexed { index, _ -> index in labelled }.forEach { bar ->
             Text(
                 text = bar.label,
                 style = MaterialTheme.typography.labelSmall,

--- a/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/components/ActivityChartSection.kt
+++ b/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/components/ActivityChartSection.kt
@@ -1,0 +1,123 @@
+package com.thomaskioko.tvmaniac.statistics.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewWrapper
+import androidx.compose.ui.unit.dp
+import com.thomaskioko.tvmaniac.compose.components.CollapsibleSection
+import com.thomaskioko.tvmaniac.compose.components.ThemePreviews
+import com.thomaskioko.tvmaniac.compose.components.TvManiacPreviewWrapperProvider
+import com.thomaskioko.tvmaniac.compose.theme.TvManiacSpacing
+import com.thomaskioko.tvmaniac.compose.theme.TvManiacTheme
+import com.thomaskioko.tvmaniac.statistics.presenter.model.ActivityBar
+import com.thomaskioko.tvmaniac.testtags.statistics.StatisticsTestTags
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+private val ChartHeight = 96.dp
+private val BarWidth = 8.dp
+private const val TRACK_ALPHA = 0.24f
+
+@Composable
+internal fun ActivityChartSection(
+    bars: ImmutableList<ActivityBar>,
+    title: String,
+    sectionTestTag: String,
+    sectionName: String,
+    modifier: Modifier = Modifier,
+) {
+    CollapsibleSection(
+        title = title,
+        modifier = modifier.testTag(sectionTestTag),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = TvManiacSpacing.medium),
+            horizontalArrangement = Arrangement.spacedBy(TvManiacSpacing.xxSmall),
+            verticalAlignment = Alignment.Bottom,
+        ) {
+            bars.forEach { bar ->
+                ActivityColumn(
+                    bar = bar,
+                    modifier = Modifier
+                        .weight(1f)
+                        .testTag(StatisticsTestTags.activityBar(sectionName, bar.label)),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActivityColumn(
+    bar: ActivityBar,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(TvManiacSpacing.xxSmall),
+    ) {
+        Box(
+            modifier = Modifier
+                .height(ChartHeight)
+                .width(BarWidth)
+                .clip(MaterialTheme.shapes.small)
+                .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = TRACK_ALPHA)),
+            contentAlignment = Alignment.BottomCenter,
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight(bar.fraction.coerceIn(0f, 1f))
+                    .fillMaxWidth()
+                    .clip(MaterialTheme.shapes.small)
+                    .background(TvManiacTheme.colorScheme.accent),
+            )
+        }
+
+        Text(
+            text = bar.label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            maxLines = 1,
+        )
+    }
+}
+
+@ThemePreviews
+@PreviewWrapper(TvManiacPreviewWrapperProvider::class)
+@Composable
+private fun ActivityChartSectionPreview() {
+    ActivityChartSection(
+        bars = persistentListOf(
+            ActivityBar(label = "Mon", episodeCount = 12, fraction = 1f),
+            ActivityBar(label = "Tue", episodeCount = 6, fraction = 0.5f),
+            ActivityBar(label = "Wed", episodeCount = 9, fraction = 0.75f),
+            ActivityBar(label = "Thu", episodeCount = 3, fraction = 0.25f),
+            ActivityBar(label = "Fri", episodeCount = 8, fraction = 0.66f),
+            ActivityBar(label = "Sat", episodeCount = 0, fraction = 0f),
+            ActivityBar(label = "Sun", episodeCount = 11, fraction = 0.91f),
+        ),
+        title = "Episodes by day of the week",
+        sectionTestTag = StatisticsTestTags.WEEKDAY_ACTIVITY_TEST_TAG,
+        sectionName = "weekday",
+    )
+}

--- a/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/components/ActivityChartSection.kt
+++ b/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/components/ActivityChartSection.kt
@@ -1,6 +1,9 @@
 package com.thomaskioko.tvmaniac.statistics.ui.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -8,11 +11,16 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -20,7 +28,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
-import com.thomaskioko.tvmaniac.compose.components.CollapsibleSection
+import androidx.compose.ui.unit.sp
 import com.thomaskioko.tvmaniac.compose.components.ThemePreviews
 import com.thomaskioko.tvmaniac.compose.components.TvManiacPreviewWrapperProvider
 import com.thomaskioko.tvmaniac.compose.theme.TvManiacSpacing
@@ -30,9 +38,17 @@ import com.thomaskioko.tvmaniac.testtags.statistics.StatisticsTestTags
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
-private val ChartHeight = 96.dp
-private val BarWidth = 8.dp
-private const val TRACK_ALPHA = 0.24f
+private val ChartHeight = 120.dp
+private val BarCorner = 4.dp
+private val TooltipCorner = 8.dp
+private val SectionTitleTracking = 1.sp
+
+/** A bar with no watches still shows a sliver so the axis reads as continuous. */
+private const val MIN_BAR_FRACTION = 0.02f
+
+/** The busiest bar is drawn at full strength and the quietest at this much of it. */
+private const val DIMMEST_BAR_ALPHA = 0.45f
+private const val AXIS_LABEL_COUNT = 4
 
 @Composable
 internal fun ActivityChartSection(
@@ -41,64 +57,145 @@ internal fun ActivityChartSection(
     sectionTestTag: String,
     sectionName: String,
     modifier: Modifier = Modifier,
+    showAxisLabels: Boolean = false,
 ) {
-    CollapsibleSection(
-        title = title,
-        modifier = modifier.testTag(sectionTestTag),
+    var selectedLabel by remember(bars) { mutableStateOf<String?>(null) }
+    val selected = bars.firstOrNull { it.label == selectedLabel }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = TvManiacSpacing.medium)
+            .testTag(sectionTestTag),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = TvManiacSpacing.medium),
-            horizontalArrangement = Arrangement.spacedBy(TvManiacSpacing.xxSmall),
-            verticalAlignment = Alignment.Bottom,
-        ) {
-            bars.forEach { bar ->
-                ActivityColumn(
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(ChartHeight),
+                horizontalArrangement = Arrangement.spacedBy(TvManiacSpacing.xxxSmall),
+                verticalAlignment = Alignment.Bottom,
+            ) {
+                bars.forEach { bar ->
+                    ActivityBarColumn(
+                        bar = bar,
+                        isSelected = bar.label == selectedLabel,
+                        onClick = { selectedLabel = if (bar.label == selectedLabel) null else bar.label },
+                        modifier = Modifier
+                            .weight(1f)
+                            .testTag(StatisticsTestTags.activityBar(sectionName, bar.label)),
+                    )
+                }
+            }
+
+            selected?.let { bar ->
+                ActivityTooltip(
                     bar = bar,
                     modifier = Modifier
-                        .weight(1f)
-                        .testTag(StatisticsTestTags.activityBar(sectionName, bar.label)),
+                        .align(Alignment.TopCenter)
+                        .testTag(StatisticsTestTags.ACTIVITY_TOOLTIP_TEST_TAG),
                 )
             }
         }
+
+        if (showAxisLabels) {
+            AxisLabels(bars = bars, modifier = Modifier.padding(top = TvManiacSpacing.xxSmall))
+        }
+
+        Text(
+            text = title.uppercase(),
+            style = MaterialTheme.typography.labelMedium,
+            letterSpacing = SectionTitleTracking,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = TvManiacSpacing.small),
+        )
     }
 }
 
 @Composable
-private fun ActivityColumn(
+private fun ActivityBarColumn(
+    bar: ActivityBar,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val strength = if (isSelected) 1f else DIMMEST_BAR_ALPHA + (1f - DIMMEST_BAR_ALPHA) * bar.fraction
+
+    Box(
+        modifier = modifier
+            .fillMaxHeight()
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onClick,
+            ),
+        contentAlignment = Alignment.BottomCenter,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(bar.fraction.coerceIn(MIN_BAR_FRACTION, 1f))
+                .clip(RoundedCornerShape(BarCorner))
+                .background(TvManiacTheme.colorScheme.accent.copy(alpha = strength)),
+        )
+    }
+}
+
+@Composable
+private fun ActivityTooltip(
     bar: ActivityBar,
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(TvManiacSpacing.xxSmall),
-    ) {
-        Box(
-            modifier = Modifier
-                .height(ChartHeight)
-                .width(BarWidth)
-                .clip(MaterialTheme.shapes.small)
-                .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = TRACK_ALPHA)),
-            contentAlignment = Alignment.BottomCenter,
-        ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxHeight(bar.fraction.coerceIn(0f, 1f))
-                    .fillMaxWidth()
-                    .clip(MaterialTheme.shapes.small)
-                    .background(TvManiacTheme.colorScheme.accent),
+        modifier = modifier
+            .clip(RoundedCornerShape(TooltipCorner))
+            .background(MaterialTheme.colorScheme.surface)
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
+                shape = RoundedCornerShape(TooltipCorner),
             )
-        }
-
+            .padding(horizontal = TvManiacSpacing.medium, vertical = TvManiacSpacing.small),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = bar.caption,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
         Text(
             text = bar.label,
-            style = MaterialTheme.typography.labelSmall,
+            style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-            maxLines = 1,
         )
+    }
+}
+
+@Composable
+private fun AxisLabels(
+    bars: ImmutableList<ActivityBar>,
+    modifier: Modifier = Modifier,
+) {
+    val step = ((bars.size - 1) / (AXIS_LABEL_COUNT - 1)).coerceAtLeast(1)
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(min = TvManiacSpacing.medium),
+        horizontalArrangement = Arrangement.spacedBy(TvManiacSpacing.xxxSmall),
+    ) {
+        bars.forEachIndexed { index, bar ->
+            Text(
+                text = if (index % step == 0) bar.label else "",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+                modifier = Modifier.weight(1f),
+            )
+        }
     }
 }
 
@@ -108,13 +205,13 @@ private fun ActivityColumn(
 private fun ActivityChartSectionPreview() {
     ActivityChartSection(
         bars = persistentListOf(
-            ActivityBar(label = "Mon", episodeCount = 12, fraction = 1f),
-            ActivityBar(label = "Tue", episodeCount = 6, fraction = 0.5f),
-            ActivityBar(label = "Wed", episodeCount = 9, fraction = 0.75f),
-            ActivityBar(label = "Thu", episodeCount = 3, fraction = 0.25f),
-            ActivityBar(label = "Fri", episodeCount = 8, fraction = 0.66f),
-            ActivityBar(label = "Sat", episodeCount = 0, fraction = 0f),
-            ActivityBar(label = "Sun", episodeCount = 11, fraction = 0.91f),
+            ActivityBar(label = "Mon", episodeCount = 12, caption = "12 episodes", fraction = 0.6f),
+            ActivityBar(label = "Tue", episodeCount = 8, caption = "8 episodes", fraction = 0.4f),
+            ActivityBar(label = "Wed", episodeCount = 14, caption = "14 episodes", fraction = 0.7f),
+            ActivityBar(label = "Thu", episodeCount = 6, caption = "6 episodes", fraction = 0.3f),
+            ActivityBar(label = "Fri", episodeCount = 17, caption = "17 episodes", fraction = 0.85f),
+            ActivityBar(label = "Sat", episodeCount = 20, caption = "20 episodes", fraction = 1f),
+            ActivityBar(label = "Sun", episodeCount = 0, caption = "0 episodes", fraction = 0f),
         ),
         title = "Episodes by day of the week",
         sectionTestTag = StatisticsTestTags.WEEKDAY_ACTIVITY_TEST_TAG,

--- a/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/components/ActivityChartSection.kt
+++ b/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/components/ActivityChartSection.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -181,19 +180,16 @@ private fun AxisLabels(
     val step = ((bars.size - 1) / (AXIS_LABEL_COUNT - 1)).coerceAtLeast(1)
 
     Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .heightIn(min = TvManiacSpacing.medium),
-        horizontalArrangement = Arrangement.spacedBy(TvManiacSpacing.xxxSmall),
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        bars.forEachIndexed { index, bar ->
+        bars.filterIndexed { index, _ -> index % step == 0 }.forEach { bar ->
             Text(
-                text = if (index % step == 0) bar.label else "",
+                text = bar.label,
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
                 maxLines = 1,
-                modifier = Modifier.weight(1f),
             )
         }
     }

--- a/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/components/WatchHeatMapSection.kt
+++ b/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/components/WatchHeatMapSection.kt
@@ -1,0 +1,106 @@
+package com.thomaskioko.tvmaniac.statistics.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.PreviewWrapper
+import androidx.compose.ui.unit.dp
+import com.thomaskioko.tvmaniac.compose.components.CollapsibleSection
+import com.thomaskioko.tvmaniac.compose.components.ThemePreviews
+import com.thomaskioko.tvmaniac.compose.components.TvManiacPreviewWrapperProvider
+import com.thomaskioko.tvmaniac.compose.theme.TvManiacSpacing
+import com.thomaskioko.tvmaniac.compose.theme.TvManiacTheme
+import com.thomaskioko.tvmaniac.statistics.presenter.model.HeatMap
+import com.thomaskioko.tvmaniac.statistics.presenter.model.WatchHeatMap
+import com.thomaskioko.tvmaniac.testtags.statistics.StatisticsTestTags
+
+private val CellSize = 10.dp
+private const val DAYS_IN_WEEK = 7
+private const val TRACK_ALPHA = 0.16f
+
+@Composable
+internal fun WatchHeatMapSection(
+    heatMap: WatchHeatMap,
+    title: String,
+    modifier: Modifier = Modifier,
+) {
+    CollapsibleSection(
+        title = title,
+        modifier = modifier.testTag(StatisticsTestTags.HEAT_MAP_TEST_TAG),
+    ) {
+        Row(
+            modifier = Modifier
+                .horizontalScroll(rememberScrollState())
+                .padding(horizontal = TvManiacSpacing.medium),
+            horizontalArrangement = Arrangement.spacedBy(TvManiacSpacing.xxxSmall),
+        ) {
+            heatMap.toColumns().forEach { column ->
+                Column(verticalArrangement = Arrangement.spacedBy(TvManiacSpacing.xxxSmall)) {
+                    column.forEach { cell -> HeatMapCell(cell = cell) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeatMapCell(
+    cell: HeatMap?,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .size(CellSize)
+            .clip(MaterialTheme.shapes.extraSmall)
+            .background(cell.color()),
+    )
+}
+
+@Composable
+private fun HeatMap?.color(): Color = when (this?.level) {
+    null -> Color.Transparent
+    0 -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = TRACK_ALPHA)
+    else -> TvManiacTheme.colorScheme.accent.copy(alpha = level / MAX_LEVEL)
+}
+
+/**
+ * Lays the dense day series out column by column so each row is the same weekday, padding the
+ * first column with the blanks the mapper counted.
+ */
+private fun WatchHeatMap.toColumns(): List<List<HeatMap?>> =
+    (List<HeatMap?>(leadingBlankCells) { null } + cells).chunked(DAYS_IN_WEEK)
+
+private const val MAX_LEVEL = 4f
+
+@ThemePreviews
+@PreviewWrapper(TvManiacPreviewWrapperProvider::class)
+@Composable
+private fun WatchHeatMapSectionPreview() {
+    WatchHeatMapSection(
+        heatMap = WatchHeatMap(
+            cells = List(70) { index ->
+                HeatMap(
+                    date = "2026-06-${(index % 28) + 1}",
+                    level = index % 5,
+                    episodeCount = index % 5,
+                )
+            },
+            leadingBlankCells = 3,
+            activeDays = 56,
+            quietDays = 14,
+        ),
+        title = "Your last year of watching",
+    )
+}

--- a/features/statistics/ui/src/test/kotlin/com/thomaskioko/tvmaniac/statistics/roborazzi/StatisticsScreenshotTest.kt
+++ b/features/statistics/ui/src/test/kotlin/com/thomaskioko/tvmaniac/statistics/roborazzi/StatisticsScreenshotTest.kt
@@ -4,12 +4,16 @@ import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import com.thomaskioko.tvmaniac.compose.components.TvManiacBackground
 import com.thomaskioko.tvmaniac.screenshottests.captureMultiDevice
+import com.thomaskioko.tvmaniac.statistics.presenter.model.ActivityBar
 import com.thomaskioko.tvmaniac.statistics.ui.StatisticsScreen
+import com.thomaskioko.tvmaniac.statistics.ui.components.ActivityChartSection
 import com.thomaskioko.tvmaniac.statistics.ui.contentState
 import com.thomaskioko.tvmaniac.statistics.ui.emptyState
 import com.thomaskioko.tvmaniac.statistics.ui.loadingState
 import com.thomaskioko.tvmaniac.statistics.ui.lockedState
 import com.thomaskioko.tvmaniac.statistics.ui.markedWatchedTimesState
+import com.thomaskioko.tvmaniac.testtags.statistics.StatisticsTestTags
+import kotlinx.collections.immutable.toImmutableList
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -26,6 +30,17 @@ internal class StatisticsScreenshotTest {
 
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    /** A long span so the axis has to leave most years unlabelled without clipping the ones it keeps. */
+    private val longRunOfYears = (2008..2026).mapIndexed { index, year ->
+        val episodeCount = (index * 7) % 40
+        ActivityBar(
+            label = year.toString(),
+            episodeCount = episodeCount,
+            caption = "$episodeCount episodes",
+            fraction = episodeCount / 40f,
+        )
+    }.toImmutableList()
 
     @Test
     fun statisticsScreenLoadingState() {
@@ -70,6 +85,21 @@ internal class StatisticsScreenshotTest {
                 StatisticsScreen(
                     state = markedWatchedTimesState,
                     onAction = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun statisticsYearChartLongRange() {
+        composeTestRule.captureMultiDevice("StatisticsYearChartLongRange") {
+            TvManiacBackground {
+                ActivityChartSection(
+                    bars = longRunOfYears,
+                    title = "Episodes by year",
+                    sectionTestTag = StatisticsTestTags.YEARLY_ACTIVITY_TEST_TAG,
+                    sectionName = "yearly",
+                    showAxisLabels = true,
                 )
             }
         }

--- a/features/statistics/ui/src/test/kotlin/com/thomaskioko/tvmaniac/statistics/ui/ActivityChartSectionTest.kt
+++ b/features/statistics/ui/src/test/kotlin/com/thomaskioko/tvmaniac/statistics/ui/ActivityChartSectionTest.kt
@@ -73,7 +73,23 @@ class ActivityChartSectionTest {
 
     @Test
     fun `should write the axis labels in full given a long run of years`() {
-        val years = (2008..2026).map { year ->
+        showYears(2008..2026)
+
+        listOf("2008", "2014", "2020", "2026").forEach { year ->
+            composeTestRule.onNodeWithText(year).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun `should label the first and last year given the span does not divide evenly`() {
+        showYears(2016..2026)
+
+        composeTestRule.onNodeWithText("2016").assertIsDisplayed()
+        composeTestRule.onNodeWithText("2026").assertIsDisplayed()
+    }
+
+    private fun showYears(years: IntRange) {
+        val bars = years.map { year ->
             ActivityBar(
                 label = year.toString(),
                 episodeCount = 1,
@@ -85,17 +101,13 @@ class ActivityChartSectionTest {
         composeTestRule.setContent {
             TvManiacBackground {
                 ActivityChartSection(
-                    bars = years,
+                    bars = bars,
                     title = "Episodes by year",
                     sectionTestTag = StatisticsTestTags.YEARLY_ACTIVITY_TEST_TAG,
                     sectionName = "yearly",
                     showAxisLabels = true,
                 )
             }
-        }
-
-        listOf("2008", "2014", "2020", "2026").forEach { year ->
-            composeTestRule.onNodeWithText(year).assertIsDisplayed()
         }
     }
 

--- a/features/statistics/ui/src/test/kotlin/com/thomaskioko/tvmaniac/statistics/ui/ActivityChartSectionTest.kt
+++ b/features/statistics/ui/src/test/kotlin/com/thomaskioko/tvmaniac/statistics/ui/ActivityChartSectionTest.kt
@@ -11,6 +11,7 @@ import com.thomaskioko.tvmaniac.statistics.presenter.model.ActivityBar
 import com.thomaskioko.tvmaniac.statistics.ui.components.ActivityChartSection
 import com.thomaskioko.tvmaniac.testtags.statistics.StatisticsTestTags
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -68,6 +69,34 @@ class ActivityChartSectionTest {
         composeTestRule.onNodeWithTag(StatisticsTestTags.activityBar("weekday", "Sat")).performClick()
 
         composeTestRule.onNodeWithTag(StatisticsTestTags.ACTIVITY_TOOLTIP_TEST_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun `should write the axis labels in full given a long run of years`() {
+        val years = (2008..2026).map { year ->
+            ActivityBar(
+                label = year.toString(),
+                episodeCount = 1,
+                caption = "1 episode",
+                fraction = 0.5f,
+            )
+        }.toImmutableList()
+
+        composeTestRule.setContent {
+            TvManiacBackground {
+                ActivityChartSection(
+                    bars = years,
+                    title = "Episodes by year",
+                    sectionTestTag = StatisticsTestTags.YEARLY_ACTIVITY_TEST_TAG,
+                    sectionName = "yearly",
+                    showAxisLabels = true,
+                )
+            }
+        }
+
+        listOf("2008", "2014", "2020", "2026").forEach { year ->
+            composeTestRule.onNodeWithText(year).assertIsDisplayed()
+        }
     }
 
     private fun showChart() {

--- a/features/statistics/ui/src/test/kotlin/com/thomaskioko/tvmaniac/statistics/ui/ActivityChartSectionTest.kt
+++ b/features/statistics/ui/src/test/kotlin/com/thomaskioko/tvmaniac/statistics/ui/ActivityChartSectionTest.kt
@@ -1,0 +1,85 @@
+package com.thomaskioko.tvmaniac.statistics.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.thomaskioko.tvmaniac.compose.components.TvManiacBackground
+import com.thomaskioko.tvmaniac.statistics.presenter.model.ActivityBar
+import com.thomaskioko.tvmaniac.statistics.ui.components.ActivityChartSection
+import com.thomaskioko.tvmaniac.testtags.statistics.StatisticsTestTags
+import kotlinx.collections.immutable.persistentListOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import org.robolectric.annotation.LooperMode
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@LooperMode(LooperMode.Mode.PAUSED)
+class ActivityChartSectionTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val bars = persistentListOf(
+        ActivityBar(label = "Mon", episodeCount = 12, caption = "12 episodes", fraction = 0.6f),
+        ActivityBar(label = "Sat", episodeCount = 20, caption = "20 episodes", fraction = 1f),
+    )
+
+    @Test
+    fun `should show no tooltip until a bar is tapped`() {
+        showChart()
+
+        composeTestRule.onNodeWithTag(StatisticsTestTags.ACTIVITY_TOOLTIP_TEST_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun `should name the count and the bar given a bar is tapped`() {
+        showChart()
+
+        composeTestRule.onNodeWithTag(StatisticsTestTags.activityBar("weekday", "Sat")).performClick()
+
+        composeTestRule.onNodeWithTag(StatisticsTestTags.ACTIVITY_TOOLTIP_TEST_TAG).assertIsDisplayed()
+        composeTestRule.onNodeWithText("20 episodes").assertIsDisplayed()
+    }
+
+    @Test
+    fun `should move the tooltip given another bar is tapped`() {
+        showChart()
+
+        composeTestRule.onNodeWithTag(StatisticsTestTags.activityBar("weekday", "Sat")).performClick()
+        composeTestRule.onNodeWithTag(StatisticsTestTags.activityBar("weekday", "Mon")).performClick()
+
+        composeTestRule.onNodeWithText("12 episodes").assertIsDisplayed()
+    }
+
+    @Test
+    fun `should hide the tooltip given the same bar is tapped again`() {
+        showChart()
+
+        composeTestRule.onNodeWithTag(StatisticsTestTags.activityBar("weekday", "Sat")).performClick()
+        composeTestRule.onNodeWithTag(StatisticsTestTags.activityBar("weekday", "Sat")).performClick()
+
+        composeTestRule.onNodeWithTag(StatisticsTestTags.ACTIVITY_TOOLTIP_TEST_TAG).assertDoesNotExist()
+    }
+
+    private fun showChart() {
+        composeTestRule.setContent {
+            TvManiacBackground {
+                ActivityChartSection(
+                    bars = bars,
+                    title = "Episodes by day of the week",
+                    sectionTestTag = StatisticsTestTags.WEEKDAY_ACTIVITY_TEST_TAG,
+                    sectionName = "weekday",
+                )
+            }
+        }
+    }
+}

--- a/i18n/generator/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/base/strings.xml
@@ -526,7 +526,7 @@
     <string name="label_statistics_locked_title">Statistics are a Premium feature</string>
     <string name="label_statistics_locked_message">Upgrade to Premium to see how you watch.</string>
     <string name="label_statistics_empty">Mark an episode as watched to start building your statistics.</string>
-    <string name="label_statistics_activity">Your last year of watching</string>
+    <string name="label_statistics_activity">Your year of watching</string>
     <string name="label_statistics_marked_watched_note">Dates show when episodes were marked as watched, not when you watched them.</string>
     <string name="label_statistics_watch_time">Total time watched</string>
     <string name="label_statistics_days">days</string>

--- a/i18n/generator/src/commonMain/moko-resources/de/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/de/strings.xml
@@ -518,7 +518,7 @@
     <string name="label_statistics_locked_title">Statistiken sind eine Premium-Funktion</string>
     <string name="label_statistics_locked_message">Upgraden Sie auf Premium, um zu sehen, wie Sie schauen.</string>
     <string name="label_statistics_empty">Markieren Sie eine Episode als gesehen, um Ihre Statistiken aufzubauen.</string>
-    <string name="label_statistics_activity">Ihr letztes Jahr im Überblick</string>
+    <string name="label_statistics_activity">Ihr Jahr im Überblick</string>
     <string name="label_statistics_marked_watched_note">Die Daten zeigen, wann Episoden als gesehen markiert wurden, nicht wann Sie sie geschaut haben.</string>
     <string name="label_statistics_watch_time">Gesamte Sehdauer</string>
     <string name="label_statistics_days">Tage</string>

--- a/i18n/generator/src/commonMain/moko-resources/fr/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/fr/strings.xml
@@ -515,7 +515,7 @@
     <string name="label_statistics_locked_title">Les statistiques sont une fonctionnalité Premium</string>
     <string name="label_statistics_locked_message">Passez à Premium pour voir comment vous regardez.</string>
     <string name="label_statistics_empty">Marquez un épisode comme vu pour commencer vos statistiques.</string>
-    <string name="label_statistics_activity">Votre dernière année de visionnage</string>
+    <string name="label_statistics_activity">Votre année de visionnage</string>
     <string name="label_statistics_marked_watched_note">Les dates indiquent quand les épisodes ont été marqués comme vus, pas quand vous les avez regardés.</string>
     <string name="label_statistics_watch_time">Temps total de visionnage</string>
     <string name="label_statistics_days">jours</string>


### PR DESCRIPTION
## Description
This PR adds the activity sections to the Android statistics screen. It adds year of watching drawn as a grid of days, and adds three charts covering how your watching splits by year, by month, and by day of the week. Tapping a bar tells you how many episodes it stands for.

## Screenshots
 <table>
   <tr>
     <th>Overview</th>
     <th>Charts</th>
   </tr>
   <tr>
     <td><img width="300" height="700" alt="The statistics screen opening with the year of watching, the total time watched and the tiles" src="https://github.com/user-attachments/assets/7694f974-7a0f-4f1b-889f-6a219030bcd5" /></td>
     <td><img width="300" height="700" alt="The yearly, monthly and weekday charts above the most watched shows" src="https://github.com/user-attachments/assets/fb393f8b-edce-4604-8960-e0d10558a9c9" /></td>
   </tr>
 </table>

## Changes
- Add a heat map for the year and lead the screen with it.
- Add a bar chart section reused by the yearly, monthly and weekday charts.
- Name the count and the bar when someone taps it.
- Draw the busiest bar brightest and the quietest faintest.

