### PR TITLE
fix: Fix Watch status breakdown

### DIFF
--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/ShowWatchStatus.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/ShowWatchStatus.sq
@@ -40,12 +40,18 @@ FROM (
     SELECT status
     FROM show_watch_status
     WHERE status IS NOT NULL
+      AND status != 'WATCHLIST'
 
     UNION ALL
 
     SELECT 'WATCHLIST' AS status
     FROM followed_shows
     WHERE pending_action != 'DELETE'
-      AND show_id NOT IN (SELECT show_id FROM show_watch_status WHERE status IS NOT NULL)
+      AND show_id NOT IN (
+          SELECT show_id
+          FROM show_watch_status
+          WHERE status IS NOT NULL
+            AND status != 'WATCHLIST'
+      )
 )
 GROUP BY status;

--- a/data/watch-status/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/watchstatus/implementation/DefaultShowWatchStatusDaoTest.kt
+++ b/data/watch-status/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/watchstatus/implementation/DefaultShowWatchStatusDaoTest.kt
@@ -106,6 +106,69 @@ internal class DefaultShowWatchStatusDaoTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun `should count a followed show with no status as watchlist`() = runTest {
+        follow(showId)
+
+        dao.observeStatusCounts().test {
+            awaitItem() shouldBe mapOf(WatchStatus.WATCHLIST to 1L)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `should count a followed show once given it also has a watchlist status`() = runTest {
+        follow(showId)
+        dao.upsert(showId, WatchStatus.WATCHLIST, null, null)
+
+        dao.observeStatusCounts().test {
+            awaitItem() shouldBe mapOf(WatchStatus.WATCHLIST to 1L)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `should leave out a watchlist status given the show is being unfollowed`() = runTest {
+        follow(showId, pendingAction = "DELETE")
+        dao.upsert(showId, WatchStatus.WATCHLIST, null, null)
+
+        dao.observeStatusCounts().test {
+            awaitItem() shouldBe emptyMap()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `should leave out a watchlist status given the show is no longer followed`() = runTest {
+        dao.upsert(showId, WatchStatus.WATCHLIST, null, null)
+
+        dao.observeStatusCounts().test {
+            awaitItem() shouldBe emptyMap()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `should keep a completed status given the show is no longer followed`() = runTest {
+        dao.upsert(showId, WatchStatus.COMPLETED, null, null)
+
+        dao.observeStatusCounts().test {
+            awaitItem() shouldBe mapOf(WatchStatus.COMPLETED to 1L)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `should count a followed show once given it is part way through`() = runTest {
+        follow(showId)
+        dao.upsert(showId, WatchStatus.WATCHING, null, null)
+
+        dao.observeStatusCounts().test {
+            awaitItem() shouldBe mapOf(WatchStatus.WATCHING to 1L)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `should return zero watch progress for a show with no episodes`() {
         dao.getWatchProgress(showId) shouldBe ShowWatchProgress(watchedCount = 0, totalCount = 0)
     }
@@ -113,6 +176,15 @@ internal class DefaultShowWatchStatusDaoTest : BaseDatabaseTest() {
     @Test
     fun `should return null watch progress for an unknown show`() {
         dao.getWatchProgress(Id(999_999L)).shouldBeNull()
+    }
+
+    private fun follow(showId: Id<ShowId>, pendingAction: String = "NOTHING") {
+        database.followedShowsQueries.upsert(
+            showId = showId,
+            tmdbId = null,
+            followedAt = 1_000L,
+            pendingAction = pendingAction,
+        )
     }
 
     private fun seedShow(traktId: Long): Id<ShowId> {

--- a/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/SyncStatisticsInteractor.kt
+++ b/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/SyncStatisticsInteractor.kt
@@ -7,6 +7,7 @@ import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeSyncRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
 
 @Inject
@@ -19,8 +20,18 @@ public class SyncStatisticsInteractor(
 
     override suspend fun doWork(params: Params) {
         withContext(dispatchers.io) {
-            watchedEpisodeSyncRepository.syncAllWatchedEpisodes(forceRefresh = params.forceRefresh)
+            val episodeFailure = try {
+                watchedEpisodeSyncRepository.syncAllWatchedEpisodes(forceRefresh = params.forceRefresh)
+                null
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (throwable: Throwable) {
+                throwable
+            }
+
             ratingsRepository.syncUserRatings()
+
+            if (episodeFailure != null) throw episodeFailure
         }
     }
 

--- a/domain/statistics/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/statistics/SyncStatisticsInteractorTest.kt
+++ b/domain/statistics/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/statistics/SyncStatisticsInteractorTest.kt
@@ -3,6 +3,7 @@ package com.thomaskioko.tvmaniac.domain.statistics
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.data.ratings.testing.FakeRatingsRepository
 import com.thomaskioko.tvmaniac.episodes.testing.FakeWatchedEpisodeSyncRepository
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -42,5 +43,16 @@ internal class SyncStatisticsInteractorTest {
         interactor.executeSync(SyncStatisticsInteractor.Params(forceRefresh = false))
 
         watchedEpisodeSyncRepository.syncAllInvocations() shouldBe listOf(false)
+    }
+
+    @Test
+    fun `should read the ratings given the watch sync failed`() = runTest(testDispatcher) {
+        watchedEpisodeSyncRepository.setSyncAllError(IllegalStateException("no connection"))
+
+        shouldThrow<IllegalStateException> {
+            interactor.executeSync(SyncStatisticsInteractor.Params(forceRefresh = true))
+        }
+
+        ratingsRepository.syncUserRatingsCount shouldBe 1
     }
 }

--- a/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/components/ActivityChartSection.kt
+++ b/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/components/ActivityChartSection.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
@@ -129,7 +131,8 @@ private fun ActivityBarColumn(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null,
                 onClick = onClick,
-            ),
+            )
+            .semantics { contentDescription = "${bar.label}, ${bar.caption}" },
         contentAlignment = Alignment.BottomCenter,
     ) {
         Box(

--- a/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/components/WatchHeatMapSection.kt
+++ b/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/components/WatchHeatMapSection.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
 import com.thomaskioko.tvmaniac.compose.components.CollapsibleSection
@@ -43,7 +44,8 @@ internal fun WatchHeatMapSection(
         Row(
             modifier = Modifier
                 .horizontalScroll(rememberScrollState())
-                .padding(horizontal = TvManiacSpacing.medium),
+                .padding(horizontal = TvManiacSpacing.medium)
+                .clearAndSetSemantics {},
             horizontalArrangement = Arrangement.spacedBy(TvManiacSpacing.xxxSmall),
         ) {
             heatMap.toColumns().forEach { column ->

--- a/ios/Packages/Statistics/Sources/Statistics/ActivityChartSectionView.swift
+++ b/ios/Packages/Statistics/Sources/Statistics/ActivityChartSectionView.swift
@@ -69,6 +69,10 @@ struct ActivityChartSectionView: View {
         .frame(maxWidth: .infinity)
         .contentShape(Rectangle())
         .onTapGesture { selectedLabel = isSelected ? nil : bar.label }
+        .accessibilityElement()
+        .accessibilityLabel("\(bar.label), \(bar.caption)")
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction { selectedLabel = isSelected ? nil : bar.label }
         .testTag(StatisticsTestTags.shared.activityBar(section: sectionName, label: bar.label))
     }
 

--- a/ios/Packages/Statistics/Sources/Statistics/WatchHeatMapSectionView.swift
+++ b/ios/Packages/Statistics/Sources/Statistics/WatchHeatMapSectionView.swift
@@ -29,6 +29,7 @@ struct WatchHeatMapSectionView: View {
                     }
                 }
                 .padding(.horizontal, theme.spacing.medium)
+                .accessibilityHidden(true)
             }
         }
         .screenTag(StatisticsTestTags.shared.HEAT_MAP_TEST_TAG)


### PR DESCRIPTION
## Description
This PR fixes the watch status breakdown on the statistics screen, which counted shows on the watchlist that were no longer there. It also stops a failed watch sync from skipping the ratings that are read after it, and names the activity chart bars for a screen reader.

## Bug Fixes
- Count the watchlist from the shows you follow. A show could also be marked as being on the watchlist by the sync, and nothing ever cleared that mark, so a show you removed kept counting and a show that only ever came in through your watch history counted without having been added. The statuses that stand for watch history are left as they are, so a show you finished and later removed still counts as finished.
- Read the ratings even when reading your watches fails. The two run one after the other and have nothing to do with each other, so a single show failing used to leave your ratings unread until the next launch.
- Give every activity chart bar a name a screen reader can read, so it says which day, month or year it stands for and how many episodes. The cells of the watching grid are left out of the reading order instead, since a year of them would be several hundred stops that say nothing.
