### PR TITLE
feat: Add the genre and release year counts for watched shows

### DIFF
--- a/android-designsystem/src/test/kotlin/com/thomaskioko/tvmaniac/compose/theme/TvManiacColorSchemeTest.kt
+++ b/android-designsystem/src/test/kotlin/com/thomaskioko/tvmaniac/compose/theme/TvManiacColorSchemeTest.kt
@@ -32,7 +32,7 @@ internal class TvManiacColorSchemeTest {
     }
 
     @Test
-    fun `should seed buttonBackground and onButtonBackground from the material secondary roles`() {
+    fun `should take buttonBackground and onButtonBackground from the material secondary roles`() {
         allThemes.forEach { scheme ->
             scheme.buttonBackground shouldBe scheme.material.secondary
             scheme.onButtonBackground shouldBe scheme.material.onSecondary

--- a/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklEpisodeWatchesDataSource.kt
+++ b/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklEpisodeWatchesDataSource.kt
@@ -90,6 +90,7 @@ private fun SimklWatchedShow.toBatch(): WatchedShowBatch {
         providerShowId = ids.simkl?.toString(),
         episodes = episodes,
         runtime = show.runtime?.toLong(),
+        year = show.year?.toString(),
     )
 }
 

--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktEpisodeWatchesDataSource.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktEpisodeWatchesDataSource.kt
@@ -3,9 +3,9 @@ package com.thomaskioko.trakt.service.implementation.sync
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.episodes.api.EpisodeWatchesDataSource
-import com.thomaskioko.tvmaniac.episodes.api.ShowRuntime
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeEntry
 import com.thomaskioko.tvmaniac.episodes.api.WatchedShowBatch
+import com.thomaskioko.tvmaniac.episodes.api.WatchedShowMetadata
 import com.thomaskioko.tvmaniac.followedshows.api.FollowedShowsDao
 import com.thomaskioko.tvmaniac.followedshows.api.PendingAction
 import com.thomaskioko.tvmaniac.trakt.api.TraktEpisodeHistoryRemoteDataSource
@@ -67,7 +67,7 @@ public class TraktEpisodeWatchesDataSource(
         }
     }
 
-    override suspend fun getWatchedShowRuntimes(page: Int, limit: Int): List<ShowRuntime> {
+    override suspend fun getWatchedShowMetadata(page: Int, limit: Int): List<WatchedShowMetadata> {
         val response = syncRemoteDataSource.getWatchedShows(
             page = page,
             limit = limit,
@@ -76,8 +76,14 @@ public class TraktEpisodeWatchesDataSource(
         return when (response) {
             is ApiResponse.Success -> response.body.mapNotNull { entry ->
                 val tmdbId = entry.show.ids.tmdb ?: return@mapNotNull null
-                val runtime = entry.show.runtime ?: return@mapNotNull null
-                ShowRuntime(tmdbId = tmdbId, runtimeMinutes = runtime)
+                WatchedShowMetadata(
+                    tmdbId = tmdbId,
+                    runtimeMinutes = entry.show.runtime,
+                    year = entry.show.year?.toString(),
+                    genres = entry.show.genres
+                        ?.takeIf { it.isNotEmpty() }
+                        ?.map { genre -> genre.replaceFirstChar { char -> char.uppercase() } },
+                )
             }
             is ApiResponse.Unauthenticated -> emptyList()
             is ApiResponse.Error -> emptyList()

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/BaseAppFlowTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/BaseAppFlowTest.kt
@@ -73,7 +73,7 @@ internal abstract class BaseAppFlowTest {
 
     /**
      * Runs [block] inside `runAndroidComposeUiTest<TvManiacTestActivity>`, providing an
-     * [AppFlowScope] with all robots, the dependency graph, and pre-seeded scenarios.
+     * [AppFlowScope] with all robots, the dependency graph, and ready-made scenarios.
      *
      * The scope is rebuilt on every call. The application graph is reset before the activity
      * launches so the [kotlinx.coroutines.test.TestDispatcher] installed by

--- a/data/calendar/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/calendar/implementation/DefaultCalendarRepositoryTest.kt
+++ b/data/calendar/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/calendar/implementation/DefaultCalendarRepositoryTest.kt
@@ -57,7 +57,7 @@ internal class DefaultCalendarRepositoryTest : BaseDatabaseTest() {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         calendarDao = DefaultCalendarDao(database, showIdResolver, dispatchers)
-        seedShow()
+        addShow()
     }
 
     @AfterTest
@@ -172,7 +172,7 @@ internal class DefaultCalendarRepositoryTest : BaseDatabaseTest() {
         followedAt = Instant.fromEpochMilliseconds(0),
     )
 
-    private fun seedShow() {
+    private fun addShow() {
         database.tvShowQueries.upsert(
             tmdb_id = Id(TMDB_ID),
             name = "Breaking Bad",

--- a/data/cast/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/cast/implementation/ShowCastStoreTest.kt
+++ b/data/cast/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/cast/implementation/ShowCastStoreTest.kt
@@ -82,7 +82,7 @@ internal class ShowCastStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should persist cast from trakt and tmdb given trakt id is present`() = runTest(testDispatcher) {
-        seedShow(tmdbId = SHOW_TMDB_ID)
+        addShow(tmdbId = SHOW_TMDB_ID)
         showIdForTraktId(traktId = SHOW_TRAKT_ID, tmdbId = SHOW_TMDB_ID)
 
         traktSource.setPeople(
@@ -130,7 +130,7 @@ internal class ShowCastStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should persist cast from tmdb only given no trakt id`() = runTest(testDispatcher) {
-        seedShow(tmdbId = SHOW_TMDB_ID)
+        addShow(tmdbId = SHOW_TMDB_ID)
 
         tmdbSource.setCredits(
             ApiResponse.Success(
@@ -163,7 +163,7 @@ internal class ShowCastStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should persist empty cast given no trakt id and tmdb credits are empty`() = runTest(testDispatcher) {
-        seedShow(tmdbId = SHOW_TMDB_ID)
+        addShow(tmdbId = SHOW_TMDB_ID)
 
         tmdbSource.setCredits(
             ApiResponse.Success(CreditsResponse(cast = arrayListOf())),
@@ -181,7 +181,7 @@ internal class ShowCastStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should persist empty cast given no trakt id and tmdb credits return error`() = runTest(testDispatcher) {
-        seedShow(tmdbId = SHOW_TMDB_ID)
+        addShow(tmdbId = SHOW_TMDB_ID)
 
         tmdbSource.setCredits(
             ApiResponse.Error.HttpError(code = 500, errorBody = null, errorMessage = "error"),
@@ -197,7 +197,7 @@ internal class ShowCastStoreTest : BaseDatabaseTest() {
         cast shouldHaveSize 0
     }
 
-    private fun seedShow(tmdbId: Long) {
+    private fun addShow(tmdbId: Long) {
         database.tvShowQueries.upsert(
             tmdb_id = Id<TmdbId>(tmdbId),
             name = "Test Show",

--- a/data/continue-watching/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/DefaultContinueWatchingDaoTest.kt
+++ b/data/continue-watching/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/DefaultContinueWatchingDaoTest.kt
@@ -137,7 +137,7 @@ internal class DefaultContinueWatchingDaoTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun `should seed continue watching membership from live watched episodes`() {
+    fun `should fill continue watching membership from live watched episodes`() {
         insertWatchedEpisode(tmdbId = BREAKING_BAD_TMDB_ID, season = 1L, episode = 1L, watchedAt = EARLIER)
         insertWatchedEpisode(tmdbId = BREAKING_BAD_TMDB_ID, season = 1L, episode = 2L, watchedAt = LATER)
 

--- a/data/continue-watching/implementation/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/ContinueWatchingFetcherTest.kt
+++ b/data/continue-watching/implementation/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/implementation/ContinueWatchingFetcherTest.kt
@@ -69,7 +69,7 @@ internal class ContinueWatchingFetcherTest {
 
     @BeforeTest
     fun setUp() {
-        seedBaselineFixtures()
+        addBaselineRows()
         nitroFetcher = NitroContinueWatchingFetcher(
             traktSyncDataSource = syncDataSource,
             traktUserDataSource = userDataSource,
@@ -242,7 +242,7 @@ internal class ContinueWatchingFetcherTest {
         return continueWatchingDao.entries()
     }
 
-    private fun seedBaselineFixtures() {
+    private fun addBaselineRows() {
         val playback: List<TraktPlaybackEpisodeResponse> = json.decodeFromString(load("playback_episodes.json"))
         val hidden: List<TraktHiddenItemResponse> = json.decodeFromString(load("hidden_progress.json"))
         val nitro: List<TraktUpNextNitroResponse> = json.decodeFromString(load("nitro_up_next.json"))

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/TvShow.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/TvShow.sq
@@ -60,9 +60,18 @@ ON CONFLICT(tmdb_id) DO UPDATE SET
 updateRuntime:
 UPDATE tvshow SET runtime = :runtime WHERE tmdb_id = :tmdbId;
 
-countWatchedShowsMissingRuntime:
+updateWatchedShowMetadata:
+UPDATE tvshow
+SET runtime = COALESCE(:runtime, runtime),
+    year = COALESCE(:year, year)
+WHERE tmdb_id = :tmdbId;
+
+updateWatchedShowGenres:
+UPDATE tvshow SET genres = :genres WHERE tmdb_id = :tmdbId;
+
+countWatchedShowsMissingMetadata:
 SELECT COUNT(*) FROM tvshow
-WHERE runtime IS NULL
+WHERE (runtime IS NULL OR year IS NULL OR genres IS NULL)
   AND id IN (
     SELECT DISTINCT show_id FROM watched_episodes
     WHERE pending_action NOT IN ('DELETE', 'SYNCED_DELETE')

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/WatchedEpisodes.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/WatchedEpisodes.sq
@@ -301,6 +301,16 @@ LEFT JOIN episode ON episode.id = watched_episodes.episode_id
 WHERE watched_episodes.pending_action NOT IN ('DELETE', 'SYNCED_DELETE')
 ORDER BY watched_episodes.watched_at;
 
+watchedShowComposition:
+SELECT
+    tvshow.year,
+    tvshow.genres
+FROM tvshow
+WHERE tvshow.id IN (
+    SELECT DISTINCT show_id FROM watched_episodes
+    WHERE pending_action NOT IN ('DELETE', 'SYNCED_DELETE')
+);
+
 mostWatchedShows:
 SELECT
     tvshow.tmdb_id AS show_id,

--- a/data/database/sqldelight/src/iosTest/kotlin/com/thomaskioko/tvmaniac/db/ForeignKeyMigrationProbeTest.kt
+++ b/data/database/sqldelight/src/iosTest/kotlin/com/thomaskioko/tvmaniac/db/ForeignKeyMigrationProbeTest.kt
@@ -14,7 +14,7 @@ class ForeignKeyMigrationProbeTest {
     @Test
     fun `migration preserves children when run through the fk safe driver`() {
         val name = uniqueName("fk-safe")
-        seedVersionOne(name)
+        createVersionOneDatabase(name)
 
         val driver = createNativeSqliteDriver(schema = schemaV2, name = name)
         val childCount = driver.countRows("child")
@@ -41,7 +41,7 @@ class ForeignKeyMigrationProbeTest {
     @Test
     fun `naive fk on migration cascade wipes children`() {
         val name = uniqueName("fk-naive")
-        seedVersionOne(name)
+        createVersionOneDatabase(name)
 
         // The pre-fix behavior: open with foreign keys enforced while the migration runs.
         val naive = NativeSqliteDriver(
@@ -53,7 +53,7 @@ class ForeignKeyMigrationProbeTest {
         childCount shouldBe 0L
     }
 
-    private fun seedVersionOne(name: String) {
+    private fun createVersionOneDatabase(name: String) {
         val driver = createNativeSqliteDriver(schema = schemaV1, name = name)
         driver.execute(identifier = null, sql = "INSERT INTO parent (id, name) VALUES (1, 'p')", parameters = 0)
         driver.execute(identifier = null, sql = "INSERT INTO child (id, parent_id) VALUES (10, 1)", parameters = 0)

--- a/data/database/sqldelight/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/db/Migration35Test.kt
+++ b/data/database/sqldelight/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/db/Migration35Test.kt
@@ -15,7 +15,7 @@ import kotlin.test.Test
 class Migration35Test {
 
     @Test
-    fun `should add an internal id and seed a TRAKT external id per show`() {
+    fun `should add an internal id and a TRAKT external id per show`() {
         openSnapshot(version = 35).use { driver ->
             driver.insertShow(traktId = 100, tmdbId = 200, ratings = 8.5, voteCount = 1234)
             driver.insertShow(traktId = 101, tmdbId = 201, ratings = 9.1, voteCount = 99)

--- a/data/database/sqldelight/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/db/Migration39Test.kt
+++ b/data/database/sqldelight/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/db/Migration39Test.kt
@@ -61,9 +61,9 @@ class Migration39Test {
     @Test
     fun `should convert show_trakt_id to internal show_id when mapping exists`() {
         openSnapshot(version = 38).use { driver ->
-            driver.seedTvshow(internalId = 1L, tmdbId = 200L)
-            driver.seedExternalId(internalId = 1L, traktId = 100L)
-            driver.seedCalendarEntry(showTraktId = 100L, episodeTraktId = 500L)
+            driver.addTvshow(internalId = 1L, tmdbId = 200L)
+            driver.addExternalId(internalId = 1L, traktId = 100L)
+            driver.addCalendarEntry(showTraktId = 100L, episodeTraktId = 500L)
 
             migrateToVersion(driver, oldVersion = 38, newVersion = 39)
 
@@ -74,7 +74,7 @@ class Migration39Test {
     @Test
     fun `should delete calendar_entry when no mapping exists for show_trakt_id`() {
         openSnapshot(version = 38).use { driver ->
-            driver.seedCalendarEntry(showTraktId = 999L, episodeTraktId = 501L)
+            driver.addCalendarEntry(showTraktId = 999L, episodeTraktId = 501L)
 
             migrateToVersion(driver, oldVersion = 38, newVersion = 39)
 
@@ -83,7 +83,7 @@ class Migration39Test {
     }
 }
 
-private fun SqlDriver.seedTvshow(internalId: Long, tmdbId: Long) {
+private fun SqlDriver.addTvshow(internalId: Long, tmdbId: Long) {
     execute(
         identifier = null,
         sql = """
@@ -94,7 +94,7 @@ private fun SqlDriver.seedTvshow(internalId: Long, tmdbId: Long) {
     )
 }
 
-private fun SqlDriver.seedExternalId(internalId: Long, traktId: Long) {
+private fun SqlDriver.addExternalId(internalId: Long, traktId: Long) {
     execute(
         identifier = null,
         sql = """
@@ -105,7 +105,7 @@ private fun SqlDriver.seedExternalId(internalId: Long, traktId: Long) {
     )
 }
 
-private fun SqlDriver.seedCalendarEntry(showTraktId: Long, episodeTraktId: Long) {
+private fun SqlDriver.addCalendarEntry(showTraktId: Long, episodeTraktId: Long) {
     execute(
         identifier = null,
         sql = """

--- a/data/database/sqldelight/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/db/Migration40Test.kt
+++ b/data/database/sqldelight/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/db/Migration40Test.kt
@@ -12,8 +12,8 @@ class Migration40Test {
     @Test
     fun `should clear last_requests on migration`() {
         openSnapshot(version = 39).use { driver ->
-            driver.seedLastRequest(entityId = 101L, requestType = "SHOW_DETAILS")
-            driver.seedLastRequest(entityId = 202L, requestType = "SHOW_CAST")
+            driver.addLastRequest(entityId = 101L, requestType = "SHOW_DETAILS")
+            driver.addLastRequest(entityId = 202L, requestType = "SHOW_CAST")
 
             migrateToVersion(driver, oldVersion = 39, newVersion = 40)
 
@@ -31,7 +31,7 @@ class Migration40Test {
     }
 }
 
-private fun SqlDriver.seedLastRequest(entityId: Long, requestType: String) {
+private fun SqlDriver.addLastRequest(entityId: Long, requestType: String) {
     execute(
         identifier = null,
         sql = """

--- a/data/database/sqldelight/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/db/Migration41Test.kt
+++ b/data/database/sqldelight/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/db/Migration41Test.kt
@@ -27,7 +27,7 @@ class Migration41Test {
     @Test
     fun `should preserve existing rows given calendar entries with non-zero trakt_id`() {
         openSnapshot(version = 40).use { driver ->
-            driver.seedCalendarEntry(
+            driver.addCalendarEntry(
                 showTitle = "Breaking Bad",
                 episodeTraktId = 73640L,
                 seasonNumber = 1,
@@ -46,7 +46,7 @@ class Migration41Test {
     @Test
     fun `should convert zero sentinel to null given calendar entries with trakt_id zero`() {
         openSnapshot(version = 40).use { driver ->
-            driver.seedCalendarEntry(
+            driver.addCalendarEntry(
                 showTitle = "Simkl Show",
                 episodeTraktId = 0L,
                 seasonNumber = 1,
@@ -88,7 +88,7 @@ class Migration41Test {
 
 private data class CalendarRow(val traktId: Long?, val showTitle: String)
 
-private fun SqlDriver.seedCalendarEntry(
+private fun SqlDriver.addCalendarEntry(
     showTitle: String,
     episodeTraktId: Long,
     seasonNumber: Long,

--- a/data/database/sqldelight/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/db/Migration42Test.kt
+++ b/data/database/sqldelight/src/jvmTest/kotlin/com/thomaskioko/tvmaniac/db/Migration42Test.kt
@@ -55,7 +55,7 @@ class Migration42Test {
     fun `should default pending_action to NOTHING given a new show rating row`() {
         openSnapshot(version = 41).use { driver ->
             migrateToVersion(driver, oldVersion = 41, newVersion = 42)
-            driver.seedShow(showId = 1L)
+            driver.addShow(showId = 1L)
 
             driver.execute(
                 identifier = null,
@@ -72,7 +72,7 @@ class Migration42Test {
         openSnapshot(version = 41).use { driver ->
             migrateToVersion(driver, oldVersion = 41, newVersion = 42)
             driver.enableForeignKeys()
-            driver.seedShow(showId = 1L)
+            driver.addShow(showId = 1L)
             driver.execute(
                 identifier = null,
                 sql = "INSERT INTO show_ratings (show_id, user_rating) VALUES (1, 8)",
@@ -89,7 +89,7 @@ class Migration42Test {
     fun `should reject pending_action value outside allowed set`() {
         openSnapshot(version = 41).use { driver ->
             migrateToVersion(driver, oldVersion = 41, newVersion = 42)
-            driver.seedShow(showId = 1L)
+            driver.addShow(showId = 1L)
 
             val result = runCatching {
                 driver.execute(
@@ -104,7 +104,7 @@ class Migration42Test {
     }
 }
 
-private fun SqlDriver.seedShow(showId: Long) {
+private fun SqlDriver.addShow(showId: Long) {
     execute(
         identifier = null,
         sql = """

--- a/data/database/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/database/test/BaseDatabaseTest.kt
+++ b/data/database/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/database/test/BaseDatabaseTest.kt
@@ -24,12 +24,12 @@ public abstract class BaseDatabaseTest {
     protected val showIdResolver: ShowIdResolver by lazy { DefaultShowIdResolver(database) }
 
     /**
-     * Links an already-seeded `tvshow` row to the identity layer and returns its internal
-     * `show_id`. Tests seed `tvshow` via `tvShowQueries.upsert` and then call this to create the
+     * Links a `tvshow` row that is already stored to the identity layer and returns its internal
+     * `show_id`. Tests store `tvshow` via `tvShowQueries.upsert` and then call this to create the
      * `TRAKT` `tvshow_external_id` row that [showIdResolver] reads, mirroring what
      * `DefaultTvShowsDao.upsert` does in production.
      *
-     * Pass [tmdbId] when the Trakt and TMDB ids differ (the test seeded the row by [tmdbId]).
+     * Pass [tmdbId] when the Trakt and TMDB ids differ (the test stored the row by [tmdbId]).
      * When omitted, [traktId] is used for the lookup (tests that use the same value for both).
      */
     protected fun showIdForTraktId(traktId: Long, tmdbId: Long = traktId): Id<ShowId> {

--- a/data/datastore/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/datastore/testing/FakeDatastoreRepository.kt
+++ b/data/datastore/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/datastore/testing/FakeDatastoreRepository.kt
@@ -42,7 +42,7 @@ public class FakeDatastoreRepository : DatastoreRepository {
      * before the activity launches. The interface counterpart [setNotificationPermissionAsked] is
      * suspend, which deadlocks under `runBlocking` when the Compose Robolectric harness installs a
      * `TestDispatcher` as `Dispatchers.Main` (every dispatcher role binds to Main via
-     * `IntegrationTestDispatcherBindings`). Use this from `@Before` to seed state synchronously.
+     * `IntegrationTestDispatcherBindings`). Use this from `@Before` to store state synchronously.
      */
     public fun setNotificationPermissionAskedNow(asked: Boolean) {
         notificationPermissionAskedFlow.value = asked

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/EpisodeRepository.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/EpisodeRepository.kt
@@ -8,6 +8,7 @@ import com.thomaskioko.tvmaniac.episodes.api.model.ShowMetadataSyncInfo
 import com.thomaskioko.tvmaniac.episodes.api.model.ShowWatchProgress
 import com.thomaskioko.tvmaniac.episodes.api.model.UpcomingEpisode
 import com.thomaskioko.tvmaniac.episodes.api.model.WatchedEpisodeRuntime
+import com.thomaskioko.tvmaniac.episodes.api.model.WatchedShowComposition
 import kotlinx.coroutines.flow.Flow
 import kotlin.time.Duration
 
@@ -19,6 +20,8 @@ public interface EpisodeRepository {
     public fun observeRecentlyWatched(limit: Long): Flow<List<RecentlyWatchedEpisode>>
 
     public fun observeWatchedEpisodeRuntimes(): Flow<List<WatchedEpisodeRuntime>>
+
+    public fun observeWatchedShowComposition(): Flow<List<WatchedShowComposition>>
 
     public fun observeMostWatchedShows(limit: Long): Flow<List<MostWatchedShow>>
 

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/EpisodeWatchesDataSource.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/EpisodeWatchesDataSource.kt
@@ -9,10 +9,10 @@ public interface EpisodeWatchesDataSource : SyncProvider {
     public suspend fun getAllWatchedShows(page: Int = 1, limit: Int = 100): List<WatchedShowBatch>
 
     /**
-     * Show runtimes for the user's watched shows. Providers that already return runtime from
-     * [getAllWatchedShows] keep the default and cost no extra request.
+     * Runtime, release year and genres for the user's watched shows. Providers that already return
+     * these from [getAllWatchedShows] keep the default and cost no extra request.
      */
-    public suspend fun getWatchedShowRuntimes(page: Int = 1, limit: Int = 100): List<ShowRuntime> = emptyList()
+    public suspend fun getWatchedShowMetadata(page: Int = 1, limit: Int = 100): List<WatchedShowMetadata> = emptyList()
 
     public suspend fun addEpisodeEntries(entries: List<WatchedEpisodeEntry>)
 

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/ShowRuntime.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/ShowRuntime.kt
@@ -1,6 +1,0 @@
-package com.thomaskioko.tvmaniac.episodes.api
-
-public data class ShowRuntime(
-    public val tmdbId: Long,
-    public val runtimeMinutes: Long,
-)

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeDao.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeDao.kt
@@ -8,6 +8,7 @@ import com.thomaskioko.tvmaniac.episodes.api.model.RecentlyWatchedEpisode
 import com.thomaskioko.tvmaniac.episodes.api.model.SeasonWatchProgress
 import com.thomaskioko.tvmaniac.episodes.api.model.ShowWatchProgress
 import com.thomaskioko.tvmaniac.episodes.api.model.WatchedEpisodeRuntime
+import com.thomaskioko.tvmaniac.episodes.api.model.WatchedShowComposition
 import com.thomaskioko.tvmaniac.followedshows.api.PendingAction
 import kotlinx.coroutines.flow.Flow
 
@@ -24,6 +25,8 @@ public interface WatchedEpisodeDao {
     public fun observeAllSeasonsWatchProgress(showId: Long): Flow<List<SeasonWatchProgress>>
 
     public fun observeWatchedAtWithRuntime(): Flow<List<WatchedEpisodeRuntime>>
+
+    public fun observeWatchedShowComposition(): Flow<List<WatchedShowComposition>>
 
     public fun observeMostWatchedShows(limit: Long): Flow<List<MostWatchedShow>>
 

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeDao.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeDao.kt
@@ -27,9 +27,14 @@ public interface WatchedEpisodeDao {
 
     public fun observeMostWatchedShows(limit: Long): Flow<List<MostWatchedShow>>
 
-    public suspend fun updateShowRuntime(tmdbId: Long, runtime: Long)
+    public suspend fun updateShowMetadata(
+        tmdbId: Long,
+        runtime: Long? = null,
+        year: String? = null,
+        genres: List<String>? = null,
+    )
 
-    public suspend fun countWatchedShowsMissingRuntime(): Long
+    public suspend fun countWatchedShowsMissingMetadata(): Long
 
     public suspend fun markAsWatched(
         showId: Long,

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedShowBatch.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedShowBatch.kt
@@ -10,4 +10,5 @@ public data class WatchedShowBatch(
     public val episodes: List<WatchedEpisodeEntry>,
     public val lastUpdatedAt: Instant? = null,
     public val runtime: Long? = null,
+    public val year: String? = null,
 )

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedShowMetadata.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedShowMetadata.kt
@@ -1,0 +1,8 @@
+package com.thomaskioko.tvmaniac.episodes.api
+
+public data class WatchedShowMetadata(
+    public val tmdbId: Long,
+    public val runtimeMinutes: Long? = null,
+    public val year: String? = null,
+    public val genres: List<String>? = null,
+)

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/model/WatchedShowComposition.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/model/WatchedShowComposition.kt
@@ -1,0 +1,6 @@
+package com.thomaskioko.tvmaniac.episodes.api.model
+
+public data class WatchedShowComposition(
+    val year: String?,
+    val genres: List<String>?,
+)

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepository.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepository.kt
@@ -18,6 +18,7 @@ import com.thomaskioko.tvmaniac.episodes.api.model.ShowMetadataSyncInfo
 import com.thomaskioko.tvmaniac.episodes.api.model.ShowWatchProgress
 import com.thomaskioko.tvmaniac.episodes.api.model.UpcomingEpisode
 import com.thomaskioko.tvmaniac.episodes.api.model.WatchedEpisodeRuntime
+import com.thomaskioko.tvmaniac.episodes.api.model.WatchedShowComposition
 import com.thomaskioko.tvmaniac.syncstate.api.SyncError
 import com.thomaskioko.tvmaniac.syncstate.api.SyncObserver
 import dev.zacsweers.metro.AppScope
@@ -54,6 +55,10 @@ public class DefaultEpisodeRepository(
 
     override fun observeWatchedEpisodeRuntimes(): Flow<List<WatchedEpisodeRuntime>> =
         watchedEpisodeDao.observeWatchedAtWithRuntime()
+            .distinctUntilChanged()
+
+    override fun observeWatchedShowComposition(): Flow<List<WatchedShowComposition>> =
+        watchedEpisodeDao.observeWatchedShowComposition()
             .distinctUntilChanged()
 
     override fun observeMostWatchedShows(limit: Long): Flow<List<MostWatchedShow>> =

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepository.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepository.kt
@@ -203,7 +203,7 @@ public class DefaultWatchedEpisodeSyncRepository(
 
         logger.debug(TAG, "Bulk watched-shows sync drained $totalShows shows across $page page(s)")
 
-        fetchMissingShowRuntimes()
+        fetchMissingShowMetadata()
 
         firstFailure?.let { failure ->
             logger.error(TAG, "Bulk watched-shows sync failed for $failedShows of $totalShows shows")
@@ -211,28 +211,33 @@ public class DefaultWatchedEpisodeSyncRepository(
         }
     }
 
-    private suspend fun fetchMissingShowRuntimes() {
+    private suspend fun fetchMissingShowMetadata() {
         val source = activeSource() ?: return
-        val missing = dao.countWatchedShowsMissingRuntime()
+        val missing = dao.countWatchedShowsMissingMetadata()
         if (missing == 0L) return
 
-        logger.debug(TAG, "Fetching runtime for $missing watched show(s)")
+        logger.debug(TAG, "Fetching metadata for $missing watched show(s)")
         var page = 1
         var updated = 0
         while (true) {
             currentCoroutineContext().ensureActive()
-            val runtimes = source.getWatchedShowRuntimes(page = page, limit = PAGE_LIMIT)
-            if (runtimes.isEmpty()) break
+            val metadata = source.getWatchedShowMetadata(page = page, limit = PAGE_LIMIT)
+            if (metadata.isEmpty()) break
 
-            runtimes.forEach { showRuntime ->
-                dao.updateShowRuntime(tmdbId = showRuntime.tmdbId, runtime = showRuntime.runtimeMinutes)
+            metadata.forEach { show ->
+                dao.updateShowMetadata(
+                    tmdbId = show.tmdbId,
+                    runtime = show.runtimeMinutes,
+                    year = show.year,
+                    genres = show.genres,
+                )
             }
-            updated += runtimes.size
+            updated += metadata.size
 
-            if (runtimes.size < PAGE_LIMIT) break
+            if (metadata.size < PAGE_LIMIT) break
             page++
         }
-        logger.debug(TAG, "Stored runtime for $updated show(s)")
+        logger.debug(TAG, "Stored metadata for $updated show(s)")
     }
 
     private suspend fun upsertBatch(batch: WatchedShowBatch, includeSpecials: Boolean) {
@@ -252,7 +257,9 @@ public class DefaultWatchedEpisodeSyncRepository(
             is ShowResolveOutcome.Skipped -> return
         }
 
-        batch.runtime?.let { runtime -> dao.updateShowRuntime(tmdbId = tmdbId, runtime = runtime) }
+        if (batch.runtime != null || batch.year != null) {
+            dao.updateShowMetadata(tmdbId = tmdbId, runtime = batch.runtime, year = batch.year)
+        }
 
         val remoteUpdatedAt = batch.lastUpdatedAt?.toEpochMilliseconds()
         if (remoteUpdatedAt != null &&

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/dao/DefaultWatchedEpisodeDao.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/dao/DefaultWatchedEpisodeDao.kt
@@ -18,6 +18,7 @@ import com.thomaskioko.tvmaniac.episodes.api.model.RecentlyWatchedEpisode
 import com.thomaskioko.tvmaniac.episodes.api.model.SeasonWatchProgress
 import com.thomaskioko.tvmaniac.episodes.api.model.ShowWatchProgress
 import com.thomaskioko.tvmaniac.episodes.api.model.WatchedEpisodeRuntime
+import com.thomaskioko.tvmaniac.episodes.api.model.WatchedShowComposition
 import com.thomaskioko.tvmaniac.followedshows.api.PendingAction
 import com.thomaskioko.tvmaniac.util.api.DateTimeProvider
 import dev.zacsweers.metro.AppScope
@@ -78,6 +79,18 @@ public class DefaultWatchedEpisodeDao(
             .map { rows ->
                 rows.map { row ->
                     WatchedEpisodeRuntime(watchedAt = row.watched_at, runtimeMinutes = row.runtime)
+                }
+            }
+            .catch { emit(emptyList()) }
+
+    override fun observeWatchedShowComposition(): Flow<List<WatchedShowComposition>> =
+        database.watchedEpisodesQueries
+            .watchedShowComposition()
+            .asFlow()
+            .mapToList(dispatchers.databaseRead)
+            .map { rows ->
+                rows.map { row ->
+                    WatchedShowComposition(year = row.year, genres = row.genres)
                 }
             }
             .catch { emit(emptyList()) }

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/dao/DefaultWatchedEpisodeDao.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/dao/DefaultWatchedEpisodeDao.kt
@@ -82,15 +82,27 @@ public class DefaultWatchedEpisodeDao(
             }
             .catch { emit(emptyList()) }
 
-    override suspend fun updateShowRuntime(tmdbId: Long, runtime: Long) {
+    override suspend fun updateShowMetadata(
+        tmdbId: Long,
+        runtime: Long?,
+        year: String?,
+        genres: List<String>?,
+    ) {
         withContext(dispatchers.databaseWrite) {
-            database.tvShowQueries.updateRuntime(runtime = runtime, tmdbId = Id(tmdbId))
+            database.tvShowQueries.updateWatchedShowMetadata(
+                runtime = runtime,
+                year = year,
+                tmdbId = Id(tmdbId),
+            )
+            if (genres != null) {
+                database.tvShowQueries.updateWatchedShowGenres(genres = genres, tmdbId = Id(tmdbId))
+            }
         }
     }
 
-    override suspend fun countWatchedShowsMissingRuntime(): Long =
+    override suspend fun countWatchedShowsMissingMetadata(): Long =
         withContext(dispatchers.databaseRead) {
-            database.tvShowQueries.countWatchedShowsMissingRuntime().executeAsOne()
+            database.tvShowQueries.countWatchedShowsMissingMetadata().executeAsOne()
         }
 
     override fun observeMostWatchedShows(limit: Long): Flow<List<MostWatchedShow>> =

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/ContinueTrackingTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/ContinueTrackingTest.kt
@@ -47,7 +47,7 @@ internal class ContinueTrackingTest : BaseDatabaseTest() {
         fakeDateTimeProvider.setCurrentTimeMillis(now)
         watchedEpisodeDao = DefaultWatchedEpisodeDao(database, showIdResolver, dispatchers, fakeDateTimeProvider)
         episodesDao = DefaultEpisodesDao(database, showIdResolver, dispatchers, fakeDateTimeProvider)
-        seedShow()
+        addShow()
     }
 
     @AfterTest
@@ -100,7 +100,7 @@ internal class ContinueTrackingTest : BaseDatabaseTest() {
     @Test
     fun `should advance next episode given show is watched but not followed`() = runTest {
         val unfollowedShowId = 4L
-        seedShowWithSecondEpisodeAt(
+        addShowWithSecondEpisodeAt(
             showId = unfollowedShowId,
             seasonId = 41L,
             airedEpisodeId = 401L,
@@ -132,7 +132,7 @@ internal class ContinueTrackingTest : BaseDatabaseTest() {
     @Test
     fun `should return unaired episode given all aired episodes watched`() = runTest {
         val futureShowId = 2L
-        seedShowWithSecondEpisodeAt(
+        addShowWithSecondEpisodeAt(
             showId = futureShowId,
             seasonId = 21L,
             airedEpisodeId = 201L,
@@ -158,7 +158,7 @@ internal class ContinueTrackingTest : BaseDatabaseTest() {
     @Test
     fun `should return episode without air date given all aired episodes watched`() = runTest {
         val tbdShowId = 3L
-        seedShowWithSecondEpisodeAt(
+        addShowWithSecondEpisodeAt(
             showId = tbdShowId,
             seasonId = 31L,
             airedEpisodeId = 301L,
@@ -184,7 +184,7 @@ internal class ContinueTrackingTest : BaseDatabaseTest() {
     @Test
     fun `should return null given all episodes watched`() = runTest {
         val completedShowId = 5L
-        seedShowWithSecondEpisodeAt(
+        addShowWithSecondEpisodeAt(
             showId = completedShowId,
             seasonId = 51L,
             airedEpisodeId = 501L,
@@ -234,7 +234,7 @@ internal class ContinueTrackingTest : BaseDatabaseTest() {
         }
     }
 
-    private fun seedShowWithSecondEpisodeAt(
+    private fun addShowWithSecondEpisodeAt(
         showId: Long,
         seasonId: Long,
         airedEpisodeId: Long,
@@ -303,7 +303,7 @@ internal class ContinueTrackingTest : BaseDatabaseTest() {
         )
     }
 
-    private fun seedShow() {
+    private fun addShow() {
         database.tvShowQueries.upsert(
             tmdb_id = Id(SHOW_ID),
             name = "Severance",

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepositoryNotificationTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepositoryNotificationTest.kt
@@ -47,7 +47,7 @@ internal class DefaultEpisodeRepositoryNotificationTest : BaseDatabaseTest() {
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        seedShow()
+        addShow()
     }
 
     @AfterTest
@@ -134,7 +134,7 @@ internal class DefaultEpisodeRepositoryNotificationTest : BaseDatabaseTest() {
         message = "message",
     )
 
-    private fun seedShow() {
+    private fun addShow() {
         database.tvShowQueries.upsert(
             tmdb_id = Id(SHOW_ID),
             name = "Test Show",

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepositorySyncErrorTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepositorySyncErrorTest.kt
@@ -47,7 +47,7 @@ internal class DefaultEpisodeRepositorySyncErrorTest : BaseDatabaseTest() {
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        seedShow()
+        addShow()
     }
 
     @AfterTest
@@ -148,7 +148,7 @@ internal class DefaultEpisodeRepositorySyncErrorTest : BaseDatabaseTest() {
         )
     }
 
-    private fun seedShow() {
+    private fun addShow() {
         database.tvShowQueries.upsert(
             tmdb_id = Id(SHOW_ID),
             name = "Test Show",

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultNextEpisodeDaoTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultNextEpisodeDaoTest.kt
@@ -634,7 +634,7 @@ internal class DefaultNextEpisodeDaoTest : BaseDatabaseTest() {
         insertShowWithTenAiredEpisodes()
         followShow(showId = 12L, followedAt = watchDate)
         (1L..8L).forEach { episodeNumber ->
-            seedTraktSyncedWatch(
+            addTraktSyncedWatch(
                 showId = 12L,
                 seasonNumber = 1L,
                 episodeNumber = episodeNumber,
@@ -954,7 +954,7 @@ internal class DefaultNextEpisodeDaoTest : BaseDatabaseTest() {
         }
     }
 
-    private fun seedTraktSyncedWatch(
+    private fun addTraktSyncedWatch(
         showId: Long,
         seasonNumber: Long,
         episodeNumber: Long,

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepositoryTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepositoryTest.kt
@@ -9,9 +9,9 @@ import com.thomaskioko.tvmaniac.datastore.testing.FakeDatastoreRepository
 import com.thomaskioko.tvmaniac.db.Id
 import com.thomaskioko.tvmaniac.db.ShowId
 import com.thomaskioko.tvmaniac.episodes.api.EpisodeWatchesDataSource
-import com.thomaskioko.tvmaniac.episodes.api.ShowRuntime
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeEntry
 import com.thomaskioko.tvmaniac.episodes.api.WatchedShowBatch
+import com.thomaskioko.tvmaniac.episodes.api.WatchedShowMetadata
 import com.thomaskioko.tvmaniac.episodes.implementation.dao.DefaultEpisodesDao
 import com.thomaskioko.tvmaniac.episodes.implementation.dao.DefaultWatchedEpisodeDao
 import com.thomaskioko.tvmaniac.followedshows.api.PendingAction
@@ -473,6 +473,25 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
         showId = showIdForTraktId(traktId = SHOW_TRAKT_ID, tmdbId = SHOW_ID)
     }
 
+    private fun seedShowWithoutMetadata() {
+        database.tvShowQueries.upsert(
+            tmdb_id = Id(SHOW_ID),
+            name = "Test Show",
+            overview = "",
+            language = "en",
+            year = null,
+            ratings = 8.0,
+            vote_count = 100,
+            genres = null,
+            status = "Returning Series",
+            episode_numbers = null,
+            season_numbers = null,
+            poster_path = null,
+            backdrop_path = null,
+        )
+        showId = showIdForTraktId(traktId = SHOW_TRAKT_ID, tmdbId = SHOW_ID)
+    }
+
     private fun seedAdditionalShow(tmdbId: Long, traktId: Long): Id<ShowId> {
         database.tvShowQueries.upsert(
             tmdb_id = Id(tmdbId),
@@ -558,19 +577,19 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
     fun `should store runtime for watched shows missing it given bulk sync runs`() = runTest(testDispatcher) {
         seedShow()
         recordingDataSource.batchesToReturn = listOf(watchedBatch(tmdbId = SHOW_ID))
-        recordingDataSource.runtimesToReturn = listOf(
-            ShowRuntime(tmdbId = SHOW_ID, runtimeMinutes = 47),
+        recordingDataSource.metadataToReturn = listOf(
+            WatchedShowMetadata(tmdbId = SHOW_ID, runtimeMinutes = 47),
         )
 
         defaultWatchedEpisodeSyncRepository.syncAllWatchedEpisodes(forceRefresh = true)
         advanceUntilIdle()
 
         database.tvShowQueries.tvshowByTmdbId(Id(SHOW_ID)).executeAsOne().runtime shouldBe 47L
-        recordingDataSource.runtimeRequestPages shouldContainExactly listOf(1)
+        recordingDataSource.metadataRequestPages shouldContainExactly listOf(1)
     }
 
     @Test
-    fun `should skip the runtime request given every watched show already has one`() = runTest(testDispatcher) {
+    fun `should skip the metadata request given every watched show already has it`() = runTest(testDispatcher) {
         seedShow()
         database.tvShowQueries.updateRuntime(runtime = 47, tmdbId = Id(SHOW_ID))
         recordingDataSource.batchesToReturn = listOf(watchedBatch(tmdbId = SHOW_ID))
@@ -578,7 +597,55 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
         defaultWatchedEpisodeSyncRepository.syncAllWatchedEpisodes(forceRefresh = true)
         advanceUntilIdle()
 
-        recordingDataSource.runtimeRequestPages.shouldBeEmpty()
+        recordingDataSource.metadataRequestPages.shouldBeEmpty()
+    }
+
+    @Test
+    fun `should store the release year and genres given a watched show is missing them`() = runTest(testDispatcher) {
+        seedShowWithoutMetadata()
+        recordingDataSource.batchesToReturn = listOf(watchedBatch(tmdbId = SHOW_ID))
+        recordingDataSource.metadataToReturn = listOf(
+            WatchedShowMetadata(
+                tmdbId = SHOW_ID,
+                runtimeMinutes = 47,
+                year = "2019",
+                genres = listOf("Drama", "Science-fiction"),
+            ),
+        )
+
+        defaultWatchedEpisodeSyncRepository.syncAllWatchedEpisodes(forceRefresh = true)
+        advanceUntilIdle()
+
+        val show = database.tvShowQueries.tvshowByTmdbId(Id(SHOW_ID)).executeAsOne()
+        show.year shouldBe "2019"
+        show.genres shouldContainExactly listOf("Drama", "Science-fiction")
+    }
+
+    @Test
+    fun `should keep the stored genres given the provider returns none`() = runTest(testDispatcher) {
+        seedShow()
+        recordingDataSource.batchesToReturn = listOf(watchedBatch(tmdbId = SHOW_ID))
+        recordingDataSource.metadataToReturn = listOf(
+            WatchedShowMetadata(tmdbId = SHOW_ID, runtimeMinutes = 47, year = null, genres = null),
+        )
+
+        defaultWatchedEpisodeSyncRepository.syncAllWatchedEpisodes(forceRefresh = true)
+        advanceUntilIdle()
+
+        val show = database.tvShowQueries.tvshowByTmdbId(Id(SHOW_ID)).executeAsOne()
+        show.year shouldBe "2024"
+        show.genres shouldContainExactly listOf("Drama")
+    }
+
+    @Test
+    fun `should store the release year given a batch carries one`() = runTest(testDispatcher) {
+        seedShowWithoutMetadata()
+        recordingDataSource.batchesToReturn = listOf(watchedBatch(tmdbId = SHOW_ID).copy(year = "2016"))
+
+        defaultWatchedEpisodeSyncRepository.syncAllWatchedEpisodes(forceRefresh = true)
+        advanceUntilIdle()
+
+        database.tvShowQueries.tvshowByTmdbId(Id(SHOW_ID)).executeAsOne().year shouldBe "2016"
     }
 }
 
@@ -594,15 +661,15 @@ private class RecordingEpisodeWatchesDataSource : EpisodeWatchesDataSource {
     val getShowEpisodeWatchesCalls: List<Long> get() = _getShowEpisodeWatchesCalls.toList()
     var showWatchesToReturn: List<WatchedEpisodeEntry> = emptyList()
     var batchesToReturn: List<WatchedShowBatch> = emptyList()
-    var runtimesToReturn: List<ShowRuntime> = emptyList()
+    var metadataToReturn: List<WatchedShowMetadata> = emptyList()
 
-    private val _runtimeRequestPages = mutableListOf<Int>()
-    val runtimeRequestPages: List<Int> get() = _runtimeRequestPages.toList()
+    private val _metadataRequestPages = mutableListOf<Int>()
+    val metadataRequestPages: List<Int> get() = _metadataRequestPages.toList()
 
-    override suspend fun getWatchedShowRuntimes(page: Int, limit: Int): List<ShowRuntime> {
-        _runtimeRequestPages += page
+    override suspend fun getWatchedShowMetadata(page: Int, limit: Int): List<WatchedShowMetadata> {
+        _metadataRequestPages += page
         val offset = (page - 1) * limit
-        return runtimesToReturn.drop(offset).take(limit)
+        return metadataToReturn.drop(offset).take(limit)
     }
 
     override suspend fun getShowEpisodeWatches(showId: Long): List<WatchedEpisodeEntry> {

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepositoryTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepositoryTest.kt
@@ -72,7 +72,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        seedShow()
+        addShow()
         dao = DefaultWatchedEpisodeDao(database, showIdResolver, dispatchers, fakeDateTimeProvider)
         defaultWatchedEpisodeSyncRepository = DefaultWatchedEpisodeSyncRepository(
             dao = dao,
@@ -96,7 +96,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should hard-delete pending DELETE row after pushing to Trakt`() = runTest {
-        seedDeletePending(seasonNumber = 1L, episodeNumber = 1L, traktId = 999L)
+        addPendingDelete(seasonNumber = 1L, episodeNumber = 1L, traktId = 999L)
 
         defaultWatchedEpisodeSyncRepository.syncPendingEpisodes()
 
@@ -106,8 +106,8 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should hard-delete both synced and unsynced rows after pushing deletes`() = runTest {
-        seedDeletePending(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L)
-        seedDeletePending(seasonNumber = 1L, episodeNumber = 2L, traktId = null)
+        addPendingDelete(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L)
+        addPendingDelete(seasonNumber = 1L, episodeNumber = 2L, traktId = null)
 
         defaultWatchedEpisodeSyncRepository.syncPendingEpisodes()
 
@@ -118,7 +118,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should upload pending entries exactly once given concurrent pending pushes`() = runTest {
-        seedUploadPending(seasonNumber = 1L, episodeNumber = 1L)
+        addPendingUpload(seasonNumber = 1L, episodeNumber = 1L)
 
         launch { defaultWatchedEpisodeSyncRepository.syncPendingEpisodes() }
         launch { defaultWatchedEpisodeSyncRepository.syncPendingEpisodes() }
@@ -271,7 +271,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should keep syncing remaining shows and hold checkpoint given one show fails during bulk sync`() = runTest {
-        val thirdShowId = seedAdditionalShow(tmdbId = THIRD_SHOW_ID, traktId = THIRD_SHOW_TRAKT_ID)
+        val thirdShowId = addAnotherShow(tmdbId = THIRD_SHOW_ID, traktId = THIRD_SHOW_TRAKT_ID)
         val throwingRepository = DefaultWatchedEpisodeSyncRepository(
             dao = dao,
             episodesDao = DefaultEpisodesDao(database, showIdResolver, dispatchers, fakeDateTimeProvider),
@@ -327,10 +327,10 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should remove a locally-watched episode the provider no longer reports on per-show sync`() = runTest {
-        seedEpisode(seasonId = 100L, seasonNumber = 1L, episodeNumber = 1L, episodeTraktId = 555L)
-        seedEpisode(seasonId = 100L, seasonNumber = 1L, episodeNumber = 2L, episodeTraktId = 556L)
-        seedSynced(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L)
-        seedSynced(seasonNumber = 1L, episodeNumber = 2L, traktId = 556L)
+        addEpisode(seasonId = 100L, seasonNumber = 1L, episodeNumber = 1L, episodeTraktId = 555L)
+        addEpisode(seasonId = 100L, seasonNumber = 1L, episodeNumber = 2L, episodeTraktId = 556L)
+        addSyncedWatch(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L)
+        addSyncedWatch(seasonNumber = 1L, episodeNumber = 2L, traktId = 556L)
         recordingDataSource.showWatchesToReturn = listOf(
             WatchedEpisodeEntry(
                 showId = SHOW_ID,
@@ -381,7 +381,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
         lastUpdatedAt = lastUpdatedAt,
     )
 
-    private fun seedUploadPending(seasonNumber: Long, episodeNumber: Long) {
+    private fun addPendingUpload(seasonNumber: Long, episodeNumber: Long) {
         database.watchedEpisodesQueries.upsertFromTrakt(
             show_id = showId,
             episode_id = null,
@@ -394,7 +394,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
         )
     }
 
-    private fun seedDeletePending(
+    private fun addPendingDelete(
         seasonNumber: Long,
         episodeNumber: Long,
         traktId: Long?,
@@ -411,7 +411,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
         )
     }
 
-    private fun seedSynced(seasonNumber: Long, episodeNumber: Long, traktId: Long) {
+    private fun addSyncedWatch(seasonNumber: Long, episodeNumber: Long, traktId: Long) {
         database.watchedEpisodesQueries.upsertFromTrakt(
             show_id = showId,
             episode_id = null,
@@ -424,7 +424,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
         )
     }
 
-    private fun seedEpisode(
+    private fun addEpisode(
         seasonId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
@@ -454,7 +454,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
         )
     }
 
-    private fun seedShow() {
+    private fun addShow() {
         database.tvShowQueries.upsert(
             tmdb_id = Id(SHOW_ID),
             name = "Test Show",
@@ -473,7 +473,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
         showId = showIdForTraktId(traktId = SHOW_TRAKT_ID, tmdbId = SHOW_ID)
     }
 
-    private fun seedShowWithoutMetadata() {
+    private fun addShowWithoutMetadata() {
         database.tvShowQueries.upsert(
             tmdb_id = Id(SHOW_ID),
             name = "Test Show",
@@ -492,7 +492,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
         showId = showIdForTraktId(traktId = SHOW_TRAKT_ID, tmdbId = SHOW_ID)
     }
 
-    private fun seedAdditionalShow(tmdbId: Long, traktId: Long): Id<ShowId> {
+    private fun addAnotherShow(tmdbId: Long, traktId: Long): Id<ShowId> {
         database.tvShowQueries.upsert(
             tmdb_id = Id(tmdbId),
             name = "Test Show $tmdbId",
@@ -575,7 +575,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should store runtime for watched shows missing it given bulk sync runs`() = runTest(testDispatcher) {
-        seedShow()
+        addShow()
         recordingDataSource.batchesToReturn = listOf(watchedBatch(tmdbId = SHOW_ID))
         recordingDataSource.metadataToReturn = listOf(
             WatchedShowMetadata(tmdbId = SHOW_ID, runtimeMinutes = 47),
@@ -590,7 +590,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should skip the metadata request given every watched show already has it`() = runTest(testDispatcher) {
-        seedShow()
+        addShow()
         database.tvShowQueries.updateRuntime(runtime = 47, tmdbId = Id(SHOW_ID))
         recordingDataSource.batchesToReturn = listOf(watchedBatch(tmdbId = SHOW_ID))
 
@@ -602,7 +602,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should store the release year and genres given a watched show is missing them`() = runTest(testDispatcher) {
-        seedShowWithoutMetadata()
+        addShowWithoutMetadata()
         recordingDataSource.batchesToReturn = listOf(watchedBatch(tmdbId = SHOW_ID))
         recordingDataSource.metadataToReturn = listOf(
             WatchedShowMetadata(
@@ -623,7 +623,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should keep the stored genres given the provider returns none`() = runTest(testDispatcher) {
-        seedShow()
+        addShow()
         recordingDataSource.batchesToReturn = listOf(watchedBatch(tmdbId = SHOW_ID))
         recordingDataSource.metadataToReturn = listOf(
             WatchedShowMetadata(tmdbId = SHOW_ID, runtimeMinutes = 47, year = null, genres = null),
@@ -639,7 +639,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should store the release year given a batch carries one`() = runTest(testDispatcher) {
-        seedShowWithoutMetadata()
+        addShowWithoutMetadata()
         recordingDataSource.batchesToReturn = listOf(watchedBatch(tmdbId = SHOW_ID).copy(year = "2016"))
 
         defaultWatchedEpisodeSyncRepository.syncAllWatchedEpisodes(forceRefresh = true)

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/MarkWatchedFromDiscoverUpNextRefreshTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/MarkWatchedFromDiscoverUpNextRefreshTest.kt
@@ -47,7 +47,7 @@ internal class MarkWatchedFromDiscoverUpNextRefreshTest : BaseDatabaseTest() {
         fakeDateTimeProvider.setCurrentTimeMillis(now)
         watchedEpisodeDao = DefaultWatchedEpisodeDao(database, showIdResolver, dispatchers, fakeDateTimeProvider)
         nextEpisodeDao = DefaultNextEpisodeDao(database, dispatchers, fakeDateTimeProvider)
-        seedShowWithThreeAiredEpisodes()
+        addShowWithThreeAiredEpisodes()
     }
 
     @AfterTest
@@ -187,7 +187,7 @@ internal class MarkWatchedFromDiscoverUpNextRefreshTest : BaseDatabaseTest() {
         afterUnmark shouldBe now + 1_000L
     }
 
-    private fun seedShowWithThreeAiredEpisodes() {
+    private fun addShowWithThreeAiredEpisodes() {
         database.tvShowQueries.upsert(
             tmdb_id = Id(SHOW_ID),
             name = "Severance",

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/WatchedEpisodeTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/WatchedEpisodeTest.kt
@@ -57,7 +57,7 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
             dispatchers = dispatchers,
             dateTimeProvider = fakeDateTimeProvider,
         )
-        seedShow()
+        addShow()
     }
 
     @AfterTest
@@ -90,8 +90,8 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
 
     @Test
     fun `should remove a synced row absent from a fresh pull`() = runTest {
-        seedSyncedRow(seasonNumber = 1L, episodeNumber = 1L, traktId = 901L)
-        seedSyncedRow(seasonNumber = 1L, episodeNumber = 2L, traktId = 902L)
+        addSyncedRow(seasonNumber = 1L, episodeNumber = 1L, traktId = 901L)
+        addSyncedRow(seasonNumber = 1L, episodeNumber = 2L, traktId = 902L)
 
         dao.upsertBatchFromTrakt(
             showId = SHOW_ID,
@@ -126,7 +126,7 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
 
     @Test
     fun `should keep the later watched_at given a stale pull`() = runTest {
-        seedSyncedRow(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L, watchedAt = now)
+        addSyncedRow(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L, watchedAt = now)
 
         dao.upsertBatchFromTrakt(
             showId = SHOW_ID,
@@ -139,7 +139,7 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
 
     @Test
     fun `should adopt a newer watched_at given a re-watch pull`() = runTest {
-        seedSyncedRow(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L, watchedAt = now - 50_000L)
+        addSyncedRow(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L, watchedAt = now - 50_000L)
 
         dao.upsertBatchFromTrakt(
             showId = SHOW_ID,
@@ -172,7 +172,7 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
 
     @Test
     fun `should flip DELETE to UPLOAD when re-marked watched`() = runTest {
-        seedSyncedRow(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L)
+        addSyncedRow(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L)
         dao.markAsUnwatched(
             showId = SHOW_ID,
             episodeId = EPISODE_1_ID,
@@ -195,7 +195,7 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
 
     @Test
     fun `should preserve trakt_id when synced row is re-marked watched`() = runTest {
-        seedSyncedRow(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L, watchedAt = now - 100_000L)
+        addSyncedRow(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L, watchedAt = now - 100_000L)
         readRow(seasonNumber = 1L, episodeNumber = 1L)!!.trakt_id shouldBe 555L
 
         dao.markAsWatched(
@@ -215,7 +215,7 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
 
     @Test
     fun `markSeasonAsUnwatched should flip synced rows to DELETE and hard-delete unsynced rows`() = runTest {
-        seedSyncedRow(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L)
+        addSyncedRow(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L)
         dao.markAsWatched(
             showId = SHOW_ID,
             episodeId = EPISODE_2_ID,
@@ -260,7 +260,7 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
                 )
             }
 
-    private fun seedSyncedRow(
+    private fun addSyncedRow(
         seasonNumber: Long,
         episodeNumber: Long,
         traktId: Long,
@@ -295,7 +295,7 @@ internal class WatchedEpisodeTest : BaseDatabaseTest() {
         pendingAction = PendingAction.NOTHING,
     )
 
-    private fun seedShow() {
+    private fun addShow() {
         database.tvShowQueries.upsert(
             tmdb_id = Id(SHOW_ID),
             name = "Synced Delete Test",

--- a/data/episode/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/testing/FakeEpisodeRepository.kt
+++ b/data/episode/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/testing/FakeEpisodeRepository.kt
@@ -9,6 +9,7 @@ import com.thomaskioko.tvmaniac.episodes.api.model.ShowMetadataSyncInfo
 import com.thomaskioko.tvmaniac.episodes.api.model.ShowWatchProgress
 import com.thomaskioko.tvmaniac.episodes.api.model.UpcomingEpisode
 import com.thomaskioko.tvmaniac.episodes.api.model.WatchedEpisodeRuntime
+import com.thomaskioko.tvmaniac.episodes.api.model.WatchedShowComposition
 import com.thomaskioko.tvmaniac.upnext.api.model.NextEpisodeWithShow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -44,9 +45,14 @@ public class FakeEpisodeRepository : EpisodeRepository {
 
     private val watchedEpisodeRuntimesFlow = MutableStateFlow<List<WatchedEpisodeRuntime>>(emptyList())
     private val mostWatchedShowsFlow = MutableStateFlow<List<MostWatchedShow>>(emptyList())
+    private val watchedShowCompositionFlow = MutableStateFlow<List<WatchedShowComposition>>(emptyList())
 
     public fun setWatchedEpisodeRuntimes(runtimes: List<WatchedEpisodeRuntime>) {
         watchedEpisodeRuntimesFlow.value = runtimes
+    }
+
+    public fun setWatchedShowComposition(composition: List<WatchedShowComposition>) {
+        watchedShowCompositionFlow.value = composition
     }
 
     public fun setMostWatchedShows(shows: List<MostWatchedShow>) {
@@ -120,6 +126,9 @@ public class FakeEpisodeRepository : EpisodeRepository {
 
     override fun observeWatchedEpisodeRuntimes(): Flow<List<WatchedEpisodeRuntime>> =
         watchedEpisodeRuntimesFlow.asStateFlow()
+
+    override fun observeWatchedShowComposition(): Flow<List<WatchedShowComposition>> =
+        watchedShowCompositionFlow.asStateFlow()
 
     override fun observeMostWatchedShows(limit: Long): Flow<List<MostWatchedShow>> =
         mostWatchedShowsFlow.asStateFlow()

--- a/data/episode/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/testing/FakeEpisodeWatchesDataSource.kt
+++ b/data/episode/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/testing/FakeEpisodeWatchesDataSource.kt
@@ -2,9 +2,9 @@ package com.thomaskioko.tvmaniac.episodes.testing
 
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.episodes.api.EpisodeWatchesDataSource
-import com.thomaskioko.tvmaniac.episodes.api.ShowRuntime
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeEntry
 import com.thomaskioko.tvmaniac.episodes.api.WatchedShowBatch
+import com.thomaskioko.tvmaniac.episodes.api.WatchedShowMetadata
 
 public class FakeEpisodeWatchesDataSource : EpisodeWatchesDataSource {
     override var provider: SyncProviderSource = SyncProviderSource.TRAKT
@@ -13,18 +13,18 @@ public class FakeEpisodeWatchesDataSource : EpisodeWatchesDataSource {
     private val addEpisodeWatchesInvocations = mutableListOf<List<WatchedEpisodeEntry>>()
     private val removeEpisodeWatchesInvocations = mutableListOf<List<WatchedEpisodeEntry>>()
     private var allWatchedShowsError: Throwable? = null
-    private val showRuntimePages = mutableMapOf<Int, List<ShowRuntime>>()
-    private val runtimeRequestPages = mutableListOf<Int>()
+    private val showMetadataPages = mutableMapOf<Int, List<WatchedShowMetadata>>()
+    private val metadataRequestPages = mutableListOf<Int>()
 
-    public fun setShowRuntimePage(page: Int, runtimes: List<ShowRuntime>) {
-        showRuntimePages[page] = runtimes
+    public fun setShowMetadataPage(page: Int, metadata: List<WatchedShowMetadata>) {
+        showMetadataPages[page] = metadata
     }
 
-    public fun runtimeRequestPages(): List<Int> = runtimeRequestPages.toList()
+    public fun metadataRequestPages(): List<Int> = metadataRequestPages.toList()
 
-    override suspend fun getWatchedShowRuntimes(page: Int, limit: Int): List<ShowRuntime> {
-        runtimeRequestPages.add(page)
-        return showRuntimePages[page].orEmpty()
+    override suspend fun getWatchedShowMetadata(page: Int, limit: Int): List<WatchedShowMetadata> {
+        metadataRequestPages.add(page)
+        return showMetadataPages[page].orEmpty()
     }
 
     public fun setShowEpisodeWatches(showId: Long, watches: List<WatchedEpisodeEntry>) {

--- a/data/featuredshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/featuredshows/implementation/DefaultFeaturedShowsDaoTest.kt
+++ b/data/featuredshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/featuredshows/implementation/DefaultFeaturedShowsDaoTest.kt
@@ -54,7 +54,7 @@ internal class DefaultFeaturedShowsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `should insert featured shows`() = runTest {
-        val showId = seedShow(showId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
+        val showId = addShow(showId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
 
         val featuredShow = Featured_shows(
             show_id = showId,
@@ -99,7 +99,7 @@ internal class DefaultFeaturedShowsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `should not return shows with null names`() = runTest {
-        val showId = seedShow(showId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
+        val showId = addShow(showId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
         featuredShowsQueries.insert(
             showId = showId,
             tmdbId = Id<TmdbId>(999),
@@ -134,7 +134,7 @@ internal class DefaultFeaturedShowsDaoTest : BaseDatabaseTest() {
             val initialShows = awaitItem()
             initialShows.size shouldBe 2
 
-            val showId = seedShow(showId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
+            val showId = addShow(showId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
             val newShow = Featured_shows(
                 show_id = showId,
                 tmdb_id = Id<TmdbId>(999),
@@ -184,7 +184,7 @@ internal class DefaultFeaturedShowsDaoTest : BaseDatabaseTest() {
         }
     }
 
-    private fun seedShow(showId: Long, name: String, posterPath: String): Id<ShowId> {
+    private fun addShow(showId: Long, name: String, posterPath: String): Id<ShowId> {
         database.tvShowQueries.upsert(
             tmdb_id = Id<TmdbId>(showId),
             name = name,

--- a/data/logout/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/logout/implementation/DefaultLogoutHandlerTest.kt
+++ b/data/logout/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/logout/implementation/DefaultLogoutHandlerTest.kt
@@ -71,7 +71,7 @@ internal class DefaultLogoutHandlerTest : BaseDatabaseTest() {
 
         showIdForBreakingBad = insertTvShow(traktId = BREAKING_BAD_TRAKT_ID, tmdbId = BREAKING_BAD_TMDB_ID)
         showIdForTheWire = insertTvShow(traktId = THE_WIRE_TRAKT_ID, tmdbId = THE_WIRE_TMDB_ID)
-        seedUserState()
+        addUserState()
     }
 
     @AfterTest
@@ -207,7 +207,7 @@ internal class DefaultLogoutHandlerTest : BaseDatabaseTest() {
         fakeActivitySyncRepository.clearAllCallCount() shouldBe 1
     }
 
-    private fun seedUserState() {
+    private fun addUserState() {
         val now = Clock.System.now().toEpochMilliseconds()
 
         database.watchedEpisodesQueries.upsert(

--- a/data/popularshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/popularshows/implementation/DefaultPopularShowsDaoTest.kt
+++ b/data/popularshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/popularshows/implementation/DefaultPopularShowsDaoTest.kt
@@ -56,7 +56,7 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `should insert popular shows`() = runTest {
         // Given - first insert a show into tvshow table
-        val showId = seedShow(showId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
+        val showId = addShow(showId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
 
         val popularShow = Popular_shows(
             show_id = showId,
@@ -224,7 +224,7 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `stable query should not return shows with null names`() = runTest {
         // Given - insert a show without name (simulating pre-migration data)
-        val showId = seedShow(showId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
+        val showId = addShow(showId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
         popularShowsQueries.insert(
             showId = showId,
             tmdbId = Id<TmdbId>(999),
@@ -248,7 +248,7 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `stable query should filter by page correctly`() = runTest {
         // Given - add shows to different pages
-        val showId = seedShow(showId = 999, name = "Page 2 Show", posterPath = "/page2.jpg")
+        val showId = addShow(showId = 999, name = "Page 2 Show", posterPath = "/page2.jpg")
         popularShowsQueries.insert(
             showId = showId,
             tmdbId = Id<TmdbId>(999),
@@ -298,7 +298,7 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
             initialShows.size shouldBe 2
 
             // When - add a new show
-            val showId = seedShow(showId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
+            val showId = addShow(showId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
             val newShow = Popular_shows(
                 show_id = showId,
                 tmdb_id = Id<TmdbId>(999),
@@ -321,7 +321,7 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `should handle COALESCE for empty names correctly`() = runTest {
-        val showId = seedShow(showId = 888, name = "Empty Name Show", posterPath = "/empty.jpg")
+        val showId = addShow(showId = 888, name = "Empty Name Show", posterPath = "/empty.jpg")
         database.popularShowsQueries.transaction {
             database.popularShowsQueries.insert(
                 showId = showId,
@@ -342,7 +342,7 @@ internal class DefaultPopularShowsDaoTest : BaseDatabaseTest() {
         }
     }
 
-    private fun seedShow(showId: Long, name: String, posterPath: String): Id<ShowId> {
+    private fun addShow(showId: Long, name: String, posterPath: String): Id<ShowId> {
         database.tvShowQueries.upsert(
             tmdb_id = Id<TmdbId>(showId),
             name = name,

--- a/data/ratings/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/ratings/implementation/DefaultRatingsDaoTest.kt
+++ b/data/ratings/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/ratings/implementation/DefaultRatingsDaoTest.kt
@@ -34,7 +34,7 @@ internal class DefaultRatingsDaoTest : BaseDatabaseTest() {
     @BeforeTest
     fun setup() {
         dao = DefaultRatingsDao(database, coroutineDispatcher)
-        seedShow(showId = 1L)
+        addShow(showId = 1L)
     }
 
     @AfterTest
@@ -100,7 +100,7 @@ internal class DefaultRatingsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `should return only entries with upload pending action given mixed pending actions`() = runTest {
-        seedShow(showId = 2L)
+        addShow(showId = 2L)
         dao.upsertShowUserRating(showId = 1L, userRating = 8L, ratedAt = 1_700_000_000L, pendingAction = PendingAction.UPLOAD)
         dao.upsertShowUserRating(showId = 2L, userRating = 5L, ratedAt = 1_700_000_000L, pendingAction = PendingAction.NOTHING)
 
@@ -112,7 +112,7 @@ internal class DefaultRatingsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `should return season rating given user rating is upserted`() = runTest {
-        seedSeason(seasonId = 100L, showId = 1L)
+        addSeason(seasonId = 100L, showId = 1L)
 
         dao.upsertSeasonUserRating(seasonId = 100L, userRating = 7L, ratedAt = 1_700_000_000L, pendingAction = PendingAction.UPLOAD)
 
@@ -127,8 +127,8 @@ internal class DefaultRatingsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `should return only season entries with delete pending action given mixed pending actions`() = runTest {
-        seedSeason(seasonId = 100L, showId = 1L)
-        seedSeason(seasonId = 101L, showId = 1L)
+        addSeason(seasonId = 100L, showId = 1L)
+        addSeason(seasonId = 101L, showId = 1L)
         dao.upsertSeasonUserRating(seasonId = 100L, userRating = 7L, ratedAt = 1_700_000_000L, pendingAction = PendingAction.NOTHING)
         dao.upsertSeasonUserRating(seasonId = 101L, userRating = 4L, ratedAt = 1_700_000_000L, pendingAction = PendingAction.NOTHING)
 
@@ -141,8 +141,8 @@ internal class DefaultRatingsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `should return episode rating given user rating is upserted`() = runTest {
-        seedSeason(seasonId = 100L, showId = 1L)
-        seedEpisode(episodeId = 200L, seasonId = 100L, showId = 1L)
+        addSeason(seasonId = 100L, showId = 1L)
+        addEpisode(episodeId = 200L, seasonId = 100L, showId = 1L)
 
         dao.upsertEpisodeUserRating(episodeId = 200L, userRating = 9L, ratedAt = 1_700_000_000L, pendingAction = PendingAction.UPLOAD)
 
@@ -157,9 +157,9 @@ internal class DefaultRatingsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `should return only episode entries with delete pending action given mixed pending actions`() = runTest {
-        seedSeason(seasonId = 100L, showId = 1L)
-        seedEpisode(episodeId = 200L, seasonId = 100L, showId = 1L)
-        seedEpisode(episodeId = 201L, seasonId = 100L, showId = 1L)
+        addSeason(seasonId = 100L, showId = 1L)
+        addEpisode(episodeId = 200L, seasonId = 100L, showId = 1L)
+        addEpisode(episodeId = 201L, seasonId = 100L, showId = 1L)
         dao.upsertEpisodeUserRating(episodeId = 200L, userRating = 9L, ratedAt = 1_700_000_000L, pendingAction = PendingAction.NOTHING)
         dao.upsertEpisodeUserRating(episodeId = 201L, userRating = 3L, ratedAt = 1_700_000_000L, pendingAction = PendingAction.NOTHING)
 
@@ -170,7 +170,7 @@ internal class DefaultRatingsDaoTest : BaseDatabaseTest() {
         entries.first().episodeId shouldBe 200L
     }
 
-    private fun seedSeason(seasonId: Long, showId: Long) {
+    private fun addSeason(seasonId: Long, showId: Long) {
         database.seasonsQueries.upsert(
             id = Id(seasonId),
             show_id = Id(showId),
@@ -182,7 +182,7 @@ internal class DefaultRatingsDaoTest : BaseDatabaseTest() {
         )
     }
 
-    private fun seedEpisode(episodeId: Long, seasonId: Long, showId: Long) {
+    private fun addEpisode(episodeId: Long, seasonId: Long, showId: Long) {
         database.episodesQueries.upsert(
             id = Id(episodeId),
             season_id = Id(seasonId),
@@ -198,7 +198,7 @@ internal class DefaultRatingsDaoTest : BaseDatabaseTest() {
         )
     }
 
-    private fun seedShow(showId: Long) {
+    private fun addShow(showId: Long) {
         database.tvShowQueries.upsert(
             tmdb_id = Id<TmdbId>(showId),
             name = "Test Show $showId",

--- a/data/ratings/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/ratings/implementation/DefaultRatingsRepositoryTest.kt
+++ b/data/ratings/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/ratings/implementation/DefaultRatingsRepositoryTest.kt
@@ -68,7 +68,7 @@ internal class DefaultRatingsRepositoryTest : BaseDatabaseTest() {
             dateTimeProvider = dateTimeProvider,
             dispatchers = dispatchers,
         )
-        seedShow(showId = SHOW_ID)
+        addShow(showId = SHOW_ID)
         tvShowsDao.upsert(
             ShowToPersist(
                 showId = Id(SHOW_ID),
@@ -197,7 +197,7 @@ internal class DefaultRatingsRepositoryTest : BaseDatabaseTest() {
     @Test
     fun `should push the tmdb id resolved from the local show id given syncPendingRatings succeeds`() = runTest {
         val repository = buildRepository(FakeSyncObserver())
-        val secondShowId = seedShow(showId = SECOND_TMDB_ID)
+        val secondShowId = addShow(showId = SECOND_TMDB_ID)
         tvShowsDao.setTmdbIdForLocalShowId(showId = secondShowId, tmdbId = DISTINCT_TMDB_ID)
         tvShowsDao.setLocalShowIdForTmdbId(tmdbId = DISTINCT_TMDB_ID, showId = secondShowId)
         remoteDataSource.setAddShowRatingResponse(ApiResponse.Success(Unit))
@@ -299,7 +299,7 @@ internal class DefaultRatingsRepositoryTest : BaseDatabaseTest() {
     fun `should save the provider user rating given refreshCommunityRating fetches it`() = runTest {
         val repository = buildRepository(FakeSyncObserver())
         remoteDataSource.provider = SyncProviderSource.TRAKT
-        seedProviderShowId(SHOW_ID, SyncProviderSource.TRAKT, externalId = 555L)
+        addProviderShowId(SHOW_ID, SyncProviderSource.TRAKT, externalId = 555L)
         remoteDataSource.setUserRatingResponse(ApiResponse.Success(7))
 
         repository.refreshCommunityRating(TMDB_ID, forceRefresh = true)
@@ -316,7 +316,7 @@ internal class DefaultRatingsRepositoryTest : BaseDatabaseTest() {
     fun `should keep the pending local rating given a provider user rating is fetched`() = runTest {
         val repository = buildRepository(FakeSyncObserver())
         remoteDataSource.provider = SyncProviderSource.TRAKT
-        seedProviderShowId(SHOW_ID, SyncProviderSource.TRAKT, externalId = 555L)
+        addProviderShowId(SHOW_ID, SyncProviderSource.TRAKT, externalId = 555L)
         ratingsDao.upsertShowUserRating(
             showId = SHOW_ID,
             userRating = 5L,
@@ -337,7 +337,7 @@ internal class DefaultRatingsRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should persist show rating keyed by the local show id given rateShow receives the tmdb id`() = runTest {
-        val localShowId = seedShow(showId = THIRD_TMDB_ID)
+        val localShowId = addShow(showId = THIRD_TMDB_ID)
         tvShowsDao.setLocalShowIdForTmdbId(tmdbId = THIRD_TMDB_ID, showId = localShowId)
         val repository = buildRepository(FakeSyncObserver())
 
@@ -358,7 +358,7 @@ internal class DefaultRatingsRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should persist pending action as upload immediately after rating a season`() = runTest {
-        seedSeason(seasonId = SEASON_ID)
+        addSeason(seasonId = SEASON_ID)
         val repository = buildRepository(FakeSyncObserver())
 
         repository.rateSeason(seasonId = SEASON_ID, rating = 7)
@@ -371,7 +371,7 @@ internal class DefaultRatingsRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should flip season pending action to nothing given syncPendingRatings succeeds`() = runTest {
-        seedSeason(seasonId = SEASON_ID)
+        addSeason(seasonId = SEASON_ID)
         val repository = buildRepository(FakeSyncObserver())
         ratingsDao.upsertSeasonUserRating(
             seasonId = SEASON_ID,
@@ -392,7 +392,7 @@ internal class DefaultRatingsRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should leave season pending action as upload and log background sync failure given syncPendingRatings fails`() = runTest {
-        seedSeason(seasonId = SEASON_ID)
+        addSeason(seasonId = SEASON_ID)
         val syncObserver = FakeSyncObserver()
         val repository = buildRepository(syncObserver)
         ratingsDao.upsertSeasonUserRating(
@@ -419,7 +419,7 @@ internal class DefaultRatingsRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should emit season user rating given observeSeasonRating is collected`() = runTest {
-        seedSeason(seasonId = SEASON_ID)
+        addSeason(seasonId = SEASON_ID)
         val repository = buildRepository(FakeSyncObserver())
         ratingsDao.upsertSeasonUserRating(
             seasonId = SEASON_ID,
@@ -438,7 +438,7 @@ internal class DefaultRatingsRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should persist locally and sync as no-op given active provider has no season rating api`() = runTest {
-        seedSeason(seasonId = SEASON_ID)
+        addSeason(seasonId = SEASON_ID)
         val repository = buildRepository(FakeSyncObserver())
         remoteDataSource.setAddSeasonRatingResponse(ApiResponse.Success(Unit))
 
@@ -455,8 +455,8 @@ internal class DefaultRatingsRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should persist pending action as upload immediately after rating an episode`() = runTest {
-        seedSeason(seasonId = SEASON_ID)
-        seedEpisode(episodeId = EPISODE_ID, seasonId = SEASON_ID)
+        addSeason(seasonId = SEASON_ID)
+        addEpisode(episodeId = EPISODE_ID, seasonId = SEASON_ID)
         val repository = buildRepository(FakeSyncObserver())
 
         repository.rateEpisode(episodeId = EPISODE_ID, rating = 6)
@@ -469,8 +469,8 @@ internal class DefaultRatingsRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should flip episode pending action to nothing given syncPendingRatings succeeds`() = runTest {
-        seedSeason(seasonId = SEASON_ID)
-        seedEpisode(episodeId = EPISODE_ID, seasonId = SEASON_ID)
+        addSeason(seasonId = SEASON_ID)
+        addEpisode(episodeId = EPISODE_ID, seasonId = SEASON_ID)
         val repository = buildRepository(FakeSyncObserver())
         ratingsDao.upsertEpisodeUserRating(
             episodeId = EPISODE_ID,
@@ -491,8 +491,8 @@ internal class DefaultRatingsRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should leave episode pending action as upload and log background sync failure given syncPendingRatings fails`() = runTest {
-        seedSeason(seasonId = SEASON_ID)
-        seedEpisode(episodeId = EPISODE_ID, seasonId = SEASON_ID)
+        addSeason(seasonId = SEASON_ID)
+        addEpisode(episodeId = EPISODE_ID, seasonId = SEASON_ID)
         val syncObserver = FakeSyncObserver()
         val repository = buildRepository(syncObserver)
         ratingsDao.upsertEpisodeUserRating(
@@ -519,8 +519,8 @@ internal class DefaultRatingsRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should emit episode user rating given observeEpisodeRating is collected`() = runTest {
-        seedSeason(seasonId = SEASON_ID)
-        seedEpisode(episodeId = EPISODE_ID, seasonId = SEASON_ID)
+        addSeason(seasonId = SEASON_ID)
+        addEpisode(episodeId = EPISODE_ID, seasonId = SEASON_ID)
         val repository = buildRepository(FakeSyncObserver())
         ratingsDao.upsertEpisodeUserRating(
             episodeId = EPISODE_ID,
@@ -549,7 +549,7 @@ internal class DefaultRatingsRepositoryTest : BaseDatabaseTest() {
             logger = FakeLogger(),
         )
 
-    private fun seedProviderShowId(showId: Long, provider: SyncProviderSource, externalId: Long) {
+    private fun addProviderShowId(showId: Long, provider: SyncProviderSource, externalId: Long) {
         database.tvshowExternalIdQueries.insert(
             showId = Id(showId),
             provider = provider.toDbProvider(),
@@ -557,7 +557,7 @@ internal class DefaultRatingsRepositoryTest : BaseDatabaseTest() {
         )
     }
 
-    private fun seedShow(showId: Long): Long {
+    private fun addShow(showId: Long): Long {
         database.tvShowQueries.upsert(
             tmdb_id = Id<TmdbId>(showId),
             name = "Test Show",
@@ -576,7 +576,7 @@ internal class DefaultRatingsRepositoryTest : BaseDatabaseTest() {
         return database.tvShowQueries.getShowIdByTmdbId(Id(showId)).executeAsOne().id
     }
 
-    private fun seedSeason(seasonId: Long) {
+    private fun addSeason(seasonId: Long) {
         database.seasonsQueries.upsert(
             id = Id(seasonId),
             show_id = Id(SHOW_ID),
@@ -588,7 +588,7 @@ internal class DefaultRatingsRepositoryTest : BaseDatabaseTest() {
         )
     }
 
-    private fun seedEpisode(episodeId: Long, seasonId: Long) {
+    private fun addEpisode(episodeId: Long, seasonId: Long) {
         database.episodesQueries.upsert(
             id = Id(episodeId),
             season_id = Id(seasonId),

--- a/data/ratings/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/ratings/implementation/RatingsStoreTest.kt
+++ b/data/ratings/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/ratings/implementation/RatingsStoreTest.kt
@@ -74,7 +74,7 @@ internal class RatingsStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should persist community rating given trakt fetch succeeds`() = runTest(testDispatcher) {
-        val showId = seedShow(tmdbId = TMDB_ID)
+        val showId = addShow(tmdbId = TMDB_ID)
         database.tvshowExternalIdQueries.insert(showId = showId, provider = Provider.TRAKT, externalId = TRAKT_ID.toString())
         remoteDataSource.provider = SyncProviderSource.TRAKT
         remoteDataSource.setCommunityRatingResponse(ApiResponse.Success(CommunityRating(rating = 8.5, votes = 100)))
@@ -94,7 +94,7 @@ internal class RatingsStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should persist community rating given simkl fetch succeeds`() = runTest(testDispatcher) {
-        val showId = seedShow(tmdbId = TMDB_ID)
+        val showId = addShow(tmdbId = TMDB_ID)
         database.tvshowExternalIdQueries.insert(showId = showId, provider = Provider.SIMKL, externalId = SIMKL_ID)
         remoteDataSource.provider = SyncProviderSource.SIMKL
         remoteDataSource.setCommunityRatingResponse(ApiResponse.Success(CommunityRating(rating = 7.2, votes = 42)))
@@ -114,7 +114,7 @@ internal class RatingsStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should throw given show has no provider id for the active provider`() = runTest(testDispatcher) {
-        val showId = seedShow(tmdbId = TMDB_ID)
+        val showId = addShow(tmdbId = TMDB_ID)
         remoteDataSource.provider = SyncProviderSource.SIMKL
         val store = buildStore()
 
@@ -125,7 +125,7 @@ internal class RatingsStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should throw given no active sync provider`() = runTest(testDispatcher) {
-        val showId = seedShow(tmdbId = TMDB_ID)
+        val showId = addShow(tmdbId = TMDB_ID)
         activeRemoteSource = null
         val store = buildStore()
 
@@ -134,7 +134,7 @@ internal class RatingsStoreTest : BaseDatabaseTest() {
         }
     }
 
-    private fun seedShow(tmdbId: Long): Id<ShowId> {
+    private fun addShow(tmdbId: Long): Id<ShowId> {
         database.tvShowQueries.upsert(
             tmdb_id = Id<TmdbId>(tmdbId),
             name = "Test Show",

--- a/data/recommendedshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/recommendedshows/implementation/RecommendedShowsStoreTest.kt
+++ b/data/recommendedshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/recommendedshows/implementation/RecommendedShowsStoreTest.kt
@@ -86,7 +86,7 @@ internal class RecommendedShowsStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should fetch and persist recommended shows given trakt id is present`() = runTest(testDispatcher) {
-        seedParentShow(tmdbId = PARENT_TMDB_ID)
+        addParentShow(tmdbId = PARENT_TMDB_ID)
         showIdForTraktId(traktId = PARENT_TRAKT_ID, tmdbId = PARENT_TMDB_ID)
 
         traktSource.setRelatedShows(
@@ -118,7 +118,7 @@ internal class RecommendedShowsStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should fetch and persist recommended shows given no trakt id`() = runTest(testDispatcher) {
-        seedParentShow(tmdbId = PARENT_TMDB_ID)
+        addParentShow(tmdbId = PARENT_TMDB_ID)
 
         tmdbSource.setRecommendedShows(
             ApiResponse.Success(
@@ -160,7 +160,7 @@ internal class RecommendedShowsStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should return empty list given no trakt id and tmdb returns empty results`() = runTest(testDispatcher) {
-        seedParentShow(tmdbId = PARENT_TMDB_ID)
+        addParentShow(tmdbId = PARENT_TMDB_ID)
 
         tmdbSource.setRecommendedShows(
             ApiResponse.Success(
@@ -185,7 +185,7 @@ internal class RecommendedShowsStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should return empty list given no trakt id and tmdb returns error`() = runTest(testDispatcher) {
-        seedParentShow(tmdbId = PARENT_TMDB_ID)
+        addParentShow(tmdbId = PARENT_TMDB_ID)
 
         tmdbSource.setRecommendedShows(
             ApiResponse.Error.HttpError(code = 500, errorBody = null, errorMessage = "Internal error"),
@@ -201,7 +201,7 @@ internal class RecommendedShowsStoreTest : BaseDatabaseTest() {
         rows shouldHaveSize 0
     }
 
-    private fun seedParentShow(tmdbId: Long) {
+    private fun addParentShow(tmdbId: Long) {
         database.tvShowQueries.upsert(
             tmdb_id = Id(tmdbId),
             name = "Parent Show",

--- a/data/topratedshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/toprated/data/implementation/DefaultTopRatedShowsDaoTest.kt
+++ b/data/topratedshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/toprated/data/implementation/DefaultTopRatedShowsDaoTest.kt
@@ -55,7 +55,7 @@ internal class DefaultTopRatedShowsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `should insert top rated shows`() = runTest {
-        val showId = seedShow(showId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
+        val showId = addShow(showId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
 
         val topRatedShow = Toprated_shows(
             show_id = showId,
@@ -107,7 +107,7 @@ internal class DefaultTopRatedShowsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `stable query should not return shows with null names`() = runTest {
-        val showId = seedShow(showId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
+        val showId = addShow(showId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
         topRatedShowsQueries.insert(
             showId = showId,
             tmdbId = Id<TmdbId>(999),
@@ -128,7 +128,7 @@ internal class DefaultTopRatedShowsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `stable query should filter by page correctly`() = runTest {
-        val showId = seedShow(showId = 999, name = "Page 2 Show", posterPath = "/page2.jpg")
+        val showId = addShow(showId = 999, name = "Page 2 Show", posterPath = "/page2.jpg")
         topRatedShowsQueries.insert(
             showId = showId,
             tmdbId = Id<TmdbId>(999),
@@ -185,7 +185,7 @@ internal class DefaultTopRatedShowsDaoTest : BaseDatabaseTest() {
             initialShows.size shouldBe 2
 
             // When - add a new show
-            val showId = seedShow(showId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
+            val showId = addShow(showId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
             val newShow = Toprated_shows(
                 show_id = showId,
                 tmdb_id = Id<TmdbId>(999),
@@ -206,7 +206,7 @@ internal class DefaultTopRatedShowsDaoTest : BaseDatabaseTest() {
         }
     }
 
-    private fun seedShow(showId: Long, name: String, posterPath: String): Id<ShowId> {
+    private fun addShow(showId: Long, name: String, posterPath: String): Id<ShowId> {
         database.tvShowQueries.upsert(
             tmdb_id = Id<TmdbId>(showId),
             name = name,

--- a/data/trailers/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/trailers/implementation/TrailerStoreTest.kt
+++ b/data/trailers/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/trailers/implementation/TrailerStoreTest.kt
@@ -82,7 +82,7 @@ internal class TrailerStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should persist trailers from trakt given trakt id is present`() = runTest(testDispatcher) {
-        seedShow(tmdbId = SHOW_TMDB_ID)
+        addShow(tmdbId = SHOW_TMDB_ID)
         showIdForTraktId(traktId = SHOW_TRAKT_ID, tmdbId = SHOW_TMDB_ID)
 
         traktSource.setVideos(
@@ -114,7 +114,7 @@ internal class TrailerStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should persist trailers from tmdb given no trakt id`() = runTest(testDispatcher) {
-        seedShow(tmdbId = SHOW_TMDB_ID)
+        addShow(tmdbId = SHOW_TMDB_ID)
 
         tmdbSource.setShowDetails(
             ApiResponse.Success(
@@ -153,7 +153,7 @@ internal class TrailerStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should skip non-youtube videos given no trakt id`() = runTest(testDispatcher) {
-        seedShow(tmdbId = SHOW_TMDB_ID)
+        addShow(tmdbId = SHOW_TMDB_ID)
 
         tmdbSource.setShowDetails(
             ApiResponse.Success(
@@ -200,7 +200,7 @@ internal class TrailerStoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should return empty list given no trakt id and tmdb returns error`() = runTest(testDispatcher) {
-        seedShow(tmdbId = SHOW_TMDB_ID)
+        addShow(tmdbId = SHOW_TMDB_ID)
 
         tmdbSource.setShowDetails(
             ApiResponse.Error.HttpError(code = 500, errorBody = null, errorMessage = "Internal error"),
@@ -216,7 +216,7 @@ internal class TrailerStoreTest : BaseDatabaseTest() {
         trailers shouldHaveSize 0
     }
 
-    private fun seedShow(tmdbId: Long) {
+    private fun addShow(tmdbId: Long) {
         database.tvShowQueries.upsert(
             tmdb_id = Id<TmdbId>(tmdbId),
             name = "Test Show",

--- a/data/traktlists/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/DefaultTraktListRepositoryTest.kt
+++ b/data/traktlists/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/DefaultTraktListRepositoryTest.kt
@@ -147,7 +147,7 @@ internal class DefaultTraktListRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should preserve pending UPLOAD rows given items sync replaces synced rows`() = runTest {
-        seedShow(tmdbId = 990L, traktId = 99L)
+        addShow(tmdbId = 990L, traktId = 99L)
         remoteDataSource.lists = listOf(traktListResponse(id = 1L, slug = "watchlist", itemCount = 1))
         remoteDataSource.itemsByListId = mapOf(
             1L to listOf(traktListItemResponse(traktId = 10L, tmdbId = 100L)),
@@ -170,7 +170,7 @@ internal class DefaultTraktListRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should preserve pending DELETE rows given items sync replaces synced rows`() = runTest {
-        seedShow(tmdbId = 200L, traktId = 20L)
+        addShow(tmdbId = 200L, traktId = 20L)
         remoteDataSource.lists = listOf(traktListResponse(id = 1L, slug = "watchlist", itemCount = 2))
         remoteDataSource.itemsByListId = mapOf(
             1L to listOf(
@@ -196,7 +196,7 @@ internal class DefaultTraktListRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should reflect synced shows in observeListsForShow given user has multiple lists`() = runTest {
-        seedShow(tmdbId = 100L, traktId = 10L)
+        addShow(tmdbId = 100L, traktId = 10L)
         remoteDataSource.lists = listOf(
             traktListResponse(id = 1L, slug = "watchlist", itemCount = 3),
             traktListResponse(id = 2L, slug = "favorites", itemCount = 1),
@@ -256,8 +256,8 @@ internal class DefaultTraktListRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should store trakt id and call remote with trakt id given show is added to list`() = runTest {
-        seedShow(tmdbId = 100L, traktId = 10L)
-        seedList(listId = 1L)
+        addShow(tmdbId = 100L, traktId = 10L)
+        addList(listId = 1L)
 
         repository.toggleShowInList(slug = "sean", listId = 1L, showId = 100L, isCurrentlyInList = false)
 
@@ -269,8 +269,8 @@ internal class DefaultTraktListRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should keep added show given items sync runs after upload`() = runTest {
-        seedShow(tmdbId = 100L, traktId = 10L)
-        seedList(listId = 1L)
+        addShow(tmdbId = 100L, traktId = 10L)
+        addList(listId = 1L)
 
         repository.toggleShowInList(slug = "sean", listId = 1L, showId = 100L, isCurrentlyInList = false)
 
@@ -285,8 +285,8 @@ internal class DefaultTraktListRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should revert junction entry given remote add fails`() = runTest {
-        seedShow(tmdbId = 100L, traktId = 10L)
-        seedList(listId = 1L)
+        addShow(tmdbId = 100L, traktId = 10L)
+        addList(listId = 1L)
         remoteDataSource.addToListResponse = ApiResponse.Error.HttpError(
             code = 500,
             errorBody = null,
@@ -302,8 +302,8 @@ internal class DefaultTraktListRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should delete junction entry and call remote with trakt id given show is removed from list`() = runTest {
-        seedShow(tmdbId = 100L, traktId = 10L)
-        seedList(listId = 1L)
+        addShow(tmdbId = 100L, traktId = 10L)
+        addList(listId = 1L)
         showDao.upsertSynced(listId = 1L, traktId = 10L, listedAt = "")
 
         repository.toggleShowInList(slug = "sean", listId = 1L, showId = 100L, isCurrentlyInList = true)
@@ -315,8 +315,8 @@ internal class DefaultTraktListRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should restore junction entry given remote remove fails`() = runTest {
-        seedShow(tmdbId = 100L, traktId = 10L)
-        seedList(listId = 1L)
+        addShow(tmdbId = 100L, traktId = 10L)
+        addList(listId = 1L)
         showDao.upsertSynced(listId = 1L, traktId = 10L, listedAt = "")
         remoteDataSource.removeFromListResponse = ApiResponse.Error.HttpError(
             code = 500,
@@ -333,14 +333,14 @@ internal class DefaultTraktListRepositoryTest : BaseDatabaseTest() {
 
     @Test
     fun `should fail given show has no trakt id mapping`() = runTest {
-        seedList(listId = 1L)
+        addList(listId = 1L)
 
         shouldThrow<IllegalArgumentException> {
             repository.toggleShowInList(slug = "sean", listId = 1L, showId = 100L, isCurrentlyInList = false)
         }
     }
 
-    private fun seedShow(tmdbId: Long, traktId: Long) {
+    private fun addShow(tmdbId: Long, traktId: Long) {
         database.tvShowQueries.upsert(
             tmdb_id = Id<TmdbId>(tmdbId),
             name = "Show $tmdbId",
@@ -360,7 +360,7 @@ internal class DefaultTraktListRepositoryTest : BaseDatabaseTest() {
         tvShowsDao.setTraktIdForTmdbId(tmdbId = tmdbId, traktId = traktId)
     }
 
-    private suspend fun seedList(listId: Long) {
+    private suspend fun addList(listId: Long) {
         remoteDataSource.lists = listOf(traktListResponse(id = listId, slug = "watchlist", itemCount = 0))
         remoteDataSource.itemsByListId = mapOf(listId to emptyList())
         repository.fetchUserLists(slug = "sean", forceRefresh = true)

--- a/data/trendingshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/discover/implementation/DefaultTrendingShowsDaoTest.kt
+++ b/data/trendingshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/discover/implementation/DefaultTrendingShowsDaoTest.kt
@@ -55,7 +55,7 @@ internal class DefaultTrendingShowsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `should insert trending shows`() = runTest {
-        val showId = seedShow(showId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
+        val showId = addShow(showId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
 
         val trendingShow = Trending_shows(
             show_id = showId,
@@ -102,7 +102,7 @@ internal class DefaultTrendingShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `stable query should not return shows with null names`() = runTest {
         // Given - insert a show without name (simulating pre-migration data)
-        val showId = seedShow(showId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
+        val showId = addShow(showId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
         trendingShowsQueries.insert(
             showId = showId,
             tmdbId = Id<TmdbId>(999),
@@ -125,7 +125,7 @@ internal class DefaultTrendingShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `stable query should filter by page correctly`() = runTest {
         // Given - add shows to different pages
-        val showId = seedShow(showId = 999, name = "Page 2 Show", posterPath = "/page2.jpg")
+        val showId = addShow(showId = 999, name = "Page 2 Show", posterPath = "/page2.jpg")
         trendingShowsQueries.insert(
             showId = showId,
             tmdbId = Id<TmdbId>(999),
@@ -184,7 +184,7 @@ internal class DefaultTrendingShowsDaoTest : BaseDatabaseTest() {
             initialShows.size shouldBe 2
 
             // When - add a new show
-            val showId = seedShow(showId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
+            val showId = addShow(showId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
             val newShow = Trending_shows(
                 show_id = showId,
                 tmdb_id = Id<TmdbId>(999),
@@ -245,7 +245,7 @@ internal class DefaultTrendingShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `stable query should handle COALESCE for empty names correctly`() = runTest {
         // Given - manually insert entry with empty string name to test COALESCE
-        val showId = seedShow(showId = 888, name = "Empty Name Show", posterPath = "/empty.jpg")
+        val showId = addShow(showId = 888, name = "Empty Name Show", posterPath = "/empty.jpg")
         database.trendingShowsQueries.transaction {
             // Insert with empty name directly
             database.trendingShowsQueries.insert(
@@ -269,7 +269,7 @@ internal class DefaultTrendingShowsDaoTest : BaseDatabaseTest() {
         }
     }
 
-    private fun seedShow(showId: Long, name: String, posterPath: String): Id<ShowId> {
+    private fun addShow(showId: Long, name: String, posterPath: String): Id<ShowId> {
         database.tvShowQueries.upsert(
             tmdb_id = Id<TmdbId>(showId),
             name = name,

--- a/data/upcomingshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/upcomingshows/implementation/DefaultUpcomingShowsDaoTest.kt
+++ b/data/upcomingshows/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/upcomingshows/implementation/DefaultUpcomingShowsDaoTest.kt
@@ -56,7 +56,7 @@ internal class DefaultUpcomingShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `should insert upcoming shows`() = runTest {
         // Given - first insert a show into tvshow table
-        val showId = seedShow(showId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
+        val showId = addShow(showId = 999, name = "New Test Show", posterPath = "/new_test.jpg")
 
         val upcomingShow = Upcoming_shows(
             show_id = showId,
@@ -109,7 +109,7 @@ internal class DefaultUpcomingShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `stable query should not return shows with null names`() = runTest {
         // Given - insert a show without name (simulating pre-migration data)
-        val showId = seedShow(showId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
+        val showId = addShow(showId = 999, name = "Null Name Show", posterPath = "/test999.jpg")
         upcomingShowsQueries.insert(
             showId = showId,
             tmdbId = Id<TmdbId>(999),
@@ -133,7 +133,7 @@ internal class DefaultUpcomingShowsDaoTest : BaseDatabaseTest() {
     @Test
     fun `stable query should filter by page correctly`() = runTest {
         // Given - add shows to different pages
-        val showId = seedShow(showId = 999, name = "Page 2 Show", posterPath = "/page2.jpg")
+        val showId = addShow(showId = 999, name = "Page 2 Show", posterPath = "/page2.jpg")
         upcomingShowsQueries.insert(
             showId = showId,
             tmdbId = Id<TmdbId>(999),
@@ -192,7 +192,7 @@ internal class DefaultUpcomingShowsDaoTest : BaseDatabaseTest() {
             initialShows.size shouldBe 2
 
             // When - add a new show
-            val showId = seedShow(showId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
+            val showId = addShow(showId = 999, name = "New Reactive Show", posterPath = "/reactive.jpg")
             val newShow = Upcoming_shows(
                 show_id = showId,
                 tmdb_id = Id<TmdbId>(999),
@@ -251,7 +251,7 @@ internal class DefaultUpcomingShowsDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `stable query should handle COALESCE for empty names correctly`() = runTest {
-        val showId = seedShow(showId = 888, name = "Empty Name Show", posterPath = "/empty.jpg")
+        val showId = addShow(showId = 888, name = "Empty Name Show", posterPath = "/empty.jpg")
         database.upcomingShowsQueries.transaction {
             database.upcomingShowsQueries.insert(
                 showId = showId,
@@ -274,7 +274,7 @@ internal class DefaultUpcomingShowsDaoTest : BaseDatabaseTest() {
         }
     }
 
-    private fun seedShow(showId: Long, name: String, posterPath: String): Id<ShowId> {
+    private fun addShow(showId: Long, name: String, posterPath: String): Id<ShowId> {
         database.tvShowQueries.upsert(
             tmdb_id = Id<TmdbId>(showId),
             name = name,

--- a/data/watch-status/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/watchstatus/implementation/DefaultShowWatchStatusDaoTest.kt
+++ b/data/watch-status/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/watchstatus/implementation/DefaultShowWatchStatusDaoTest.kt
@@ -40,7 +40,7 @@ internal class DefaultShowWatchStatusDaoTest : BaseDatabaseTest() {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         dao = DefaultShowWatchStatusDao(database, dispatchers)
-        showId = seedShow(SHOW_TRAKT_ID)
+        showId = addShow(SHOW_TRAKT_ID)
     }
 
     @AfterTest
@@ -95,7 +95,7 @@ internal class DefaultShowWatchStatusDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `should delete all statuses`() {
-        val otherShowId = seedShow(OTHER_TRAKT_ID)
+        val otherShowId = addShow(OTHER_TRAKT_ID)
         dao.upsert(showId, WatchStatus.WATCHING, null, null)
         dao.upsert(otherShowId, WatchStatus.COMPLETED, null, null)
 
@@ -187,7 +187,7 @@ internal class DefaultShowWatchStatusDaoTest : BaseDatabaseTest() {
         )
     }
 
-    private fun seedShow(traktId: Long): Id<ShowId> {
+    private fun addShow(traktId: Long): Id<ShowId> {
         database.tvShowQueries.upsert(
             tmdb_id = Id<TmdbId>(traktId),
             name = "show-$traktId",

--- a/domain/notifications/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/notifications/interactor/SyncCalendarInteractorTest.kt
+++ b/domain/notifications/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/notifications/interactor/SyncCalendarInteractorTest.kt
@@ -12,6 +12,7 @@ import com.thomaskioko.tvmaniac.episodes.api.model.ShowMetadataSyncInfo
 import com.thomaskioko.tvmaniac.episodes.api.model.ShowWatchProgress
 import com.thomaskioko.tvmaniac.episodes.api.model.UpcomingEpisode
 import com.thomaskioko.tvmaniac.episodes.api.model.WatchedEpisodeRuntime
+import com.thomaskioko.tvmaniac.episodes.api.model.WatchedShowComposition
 import com.thomaskioko.tvmaniac.util.testing.FakeDateTimeProvider
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.flow.Flow
@@ -85,6 +86,7 @@ private class CountingCalendarEpisodeRepository : EpisodeRepository {
     override fun observeEpisodeById(episodeId: Long): Flow<EpisodeById?> = flowOf(null)
     override fun observeRecentlyWatched(limit: Long): Flow<List<RecentlyWatchedEpisode>> = flowOf(emptyList())
     override fun observeWatchedEpisodeRuntimes(): Flow<List<WatchedEpisodeRuntime>> = flowOf(emptyList())
+    override fun observeWatchedShowComposition(): Flow<List<WatchedShowComposition>> = flowOf(emptyList())
     override fun observeMostWatchedShows(limit: Long): Flow<List<MostWatchedShow>> = flowOf(emptyList())
     override suspend fun markEpisodeAsWatched(showId: Long, episodeId: Long, seasonNumber: Long, episodeNumber: Long) {}
     override suspend fun markEpisodeAndPreviousEpisodesWatched(showId: Long, episodeId: Long, seasonNumber: Long, episodeNumber: Long) {}

--- a/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/ObserveWatchStatisticsInteractor.kt
+++ b/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/ObserveWatchStatisticsInteractor.kt
@@ -22,12 +22,14 @@ public class ObserveWatchStatisticsInteractor(
         episodeRepository.observeMostWatchedShows(MOST_WATCHED_LIMIT),
         showWatchStatusRepository.observeShowCountsByStatus(),
         ratingsRepository.observeUserRatingDistribution(),
-    ) { watches, mostWatchedShows, showCountsByStatus, ratingCounts ->
+        episodeRepository.observeWatchedShowComposition(),
+    ) { watches, mostWatchedShows, showCountsByStatus, ratingCounts, showComposition ->
         calculator.calculate(
             watches = watches,
             mostWatchedShows = mostWatchedShows,
             showCountsByStatus = showCountsByStatus,
             ratingCounts = ratingCounts,
+            showComposition = showComposition,
         )
     }
 

--- a/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/WatchStatisticsCalculator.kt
+++ b/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/WatchStatisticsCalculator.kt
@@ -3,10 +3,12 @@ package com.thomaskioko.tvmaniac.domain.statistics
 import com.thomaskioko.tvmaniac.db.WatchStatus
 import com.thomaskioko.tvmaniac.domain.statistics.model.AverageRating
 import com.thomaskioko.tvmaniac.domain.statistics.model.DailyWatchCount
+import com.thomaskioko.tvmaniac.domain.statistics.model.GenreCount
 import com.thomaskioko.tvmaniac.domain.statistics.model.MonthlyWatchCount
 import com.thomaskioko.tvmaniac.domain.statistics.model.PeakYear
 import com.thomaskioko.tvmaniac.domain.statistics.model.PeriodSummary
 import com.thomaskioko.tvmaniac.domain.statistics.model.RatingCount
+import com.thomaskioko.tvmaniac.domain.statistics.model.ReleaseYearCount
 import com.thomaskioko.tvmaniac.domain.statistics.model.ShowsTracked
 import com.thomaskioko.tvmaniac.domain.statistics.model.TopWeekday
 import com.thomaskioko.tvmaniac.domain.statistics.model.WatchDaysThisMonth
@@ -19,6 +21,7 @@ import com.thomaskioko.tvmaniac.domain.statistics.model.WeekdayWatchCount
 import com.thomaskioko.tvmaniac.domain.statistics.model.YearlyWatchCount
 import com.thomaskioko.tvmaniac.episodes.api.model.MostWatchedShow
 import com.thomaskioko.tvmaniac.episodes.api.model.WatchedEpisodeRuntime
+import com.thomaskioko.tvmaniac.episodes.api.model.WatchedShowComposition
 import com.thomaskioko.tvmaniac.util.api.DateTimeProvider
 import dev.zacsweers.metro.Inject
 import kotlinx.datetime.DateTimeUnit
@@ -39,6 +42,7 @@ public class WatchStatisticsCalculator(
         mostWatchedShows: List<MostWatchedShow>,
         showCountsByStatus: Map<WatchStatus, Long>,
         ratingCounts: Map<Int, Long>,
+        showComposition: List<WatchedShowComposition>,
     ): WatchStatistics {
         val timeZone = dateTimeProvider.getTimeZone()
         val today = dateTimeProvider.now().toLocalDateTime(timeZone).date
@@ -70,8 +74,27 @@ public class WatchStatisticsCalculator(
             mostWatchedShows = mostWatchedShows,
             showsByWatchStatus = getShowsByWatchStatus(showCountsByStatus),
             ratingDistribution = getRatingDistribution(ratingCounts),
+            genreBreakdown = calculateGenreBreakdown(showComposition),
+            releaseYears = calculateReleaseYears(showComposition),
         )
     }
+
+    private fun calculateGenreBreakdown(showComposition: List<WatchedShowComposition>): List<GenreCount> =
+        showComposition
+            .flatMap { show -> show.genres.orEmpty() }
+            .filter { genre -> genre.isNotBlank() }
+            .groupingBy { genre -> genre }
+            .eachCount()
+            .map { (genre, count) -> GenreCount(name = genre, showCount = count.toLong()) }
+            .sortedWith(compareByDescending<GenreCount> { it.showCount }.thenBy { it.name })
+
+    private fun calculateReleaseYears(showComposition: List<WatchedShowComposition>): List<ReleaseYearCount> =
+        showComposition
+            .mapNotNull { show -> show.year?.toIntOrNull() }
+            .groupingBy { year -> year }
+            .eachCount()
+            .map { (year, count) -> ReleaseYearCount(year = year, showCount = count.toLong()) }
+            .sortedBy { it.year }
 
     private fun calculateShowsTracked(showCountsByStatus: Map<WatchStatus, Long>): ShowsTracked =
         ShowsTracked(

--- a/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/model/GenreCount.kt
+++ b/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/model/GenreCount.kt
@@ -1,0 +1,6 @@
+package com.thomaskioko.tvmaniac.domain.statistics.model
+
+public data class GenreCount(
+    val name: String,
+    val showCount: Long,
+)

--- a/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/model/ReleaseYearCount.kt
+++ b/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/model/ReleaseYearCount.kt
@@ -1,0 +1,6 @@
+package com.thomaskioko.tvmaniac.domain.statistics.model
+
+public data class ReleaseYearCount(
+    val year: Int,
+    val showCount: Long,
+)

--- a/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/model/WatchStatistics.kt
+++ b/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/model/WatchStatistics.kt
@@ -20,6 +20,8 @@ public data class WatchStatistics(
     val mostWatchedShows: List<MostWatchedShow>,
     val showsByWatchStatus: List<WatchStatusCount>,
     val ratingDistribution: List<RatingCount>,
+    val genreBreakdown: List<GenreCount>,
+    val releaseYears: List<ReleaseYearCount>,
 ) {
     val hasWatchHistory: Boolean
         get() = episodesWatched > 0
@@ -46,6 +48,8 @@ public data class WatchStatistics(
             mostWatchedShows = emptyList(),
             showsByWatchStatus = emptyList(),
             ratingDistribution = emptyList(),
+            genreBreakdown = emptyList(),
+            releaseYears = emptyList(),
         )
     }
 }

--- a/domain/statistics/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/statistics/WatchStatisticsCalculatorTest.kt
+++ b/domain/statistics/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/statistics/WatchStatisticsCalculatorTest.kt
@@ -9,6 +9,8 @@ import com.thomaskioko.tvmaniac.db.SeasonId
 import com.thomaskioko.tvmaniac.db.ShowId
 import com.thomaskioko.tvmaniac.db.TmdbId
 import com.thomaskioko.tvmaniac.db.WatchStatus
+import com.thomaskioko.tvmaniac.domain.statistics.model.GenreCount
+import com.thomaskioko.tvmaniac.domain.statistics.model.ReleaseYearCount
 import com.thomaskioko.tvmaniac.domain.statistics.model.WatchStatistics
 import com.thomaskioko.tvmaniac.domain.statistics.model.WatchStreak
 import com.thomaskioko.tvmaniac.episodes.implementation.dao.DefaultWatchedEpisodeDao
@@ -55,6 +57,7 @@ internal class WatchStatisticsCalculatorTest : BaseDatabaseTest() {
         mostWatchedShows = watchedEpisodeDao.observeMostWatchedShows(10).first(),
         showCountsByStatus = showWatchStatusDao.observeStatusCounts().first(),
         ratingCounts = ratingsDao.observeUserRatingDistribution().first(),
+        showComposition = watchedEpisodeDao.observeWatchedShowComposition().first(),
     )
 
     @AfterTest
@@ -451,6 +454,87 @@ internal class WatchStatisticsCalculatorTest : BaseDatabaseTest() {
         )
 
         calculate().ratingDistribution.shouldBeEmptyList()
+    }
+
+    @Test
+    fun `should count a genre once for every watched show carrying it`() = runTest(testDispatcher) {
+        insertShow(tmdbId = BREAKING_BAD)
+        insertShow(tmdbId = THE_WIRE)
+        setShowComposition(BREAKING_BAD, year = "2008", genres = listOf("Drama", "Crime"))
+        setShowComposition(THE_WIRE, year = "2002", genres = listOf("Drama"))
+        markWatched(tmdbId = BREAKING_BAD, episodeNumber = 1, watchedAt = epochMillis(2026, 8, 3))
+        markWatched(tmdbId = THE_WIRE, episodeNumber = 1, watchedAt = epochMillis(2026, 8, 3))
+
+        calculate().genreBreakdown shouldBe listOf(
+            GenreCount(name = "Drama", showCount = 2),
+            GenreCount(name = "Crime", showCount = 1),
+        )
+    }
+
+    @Test
+    fun `should leave out a show with no genres from the breakdown`() = runTest(testDispatcher) {
+        insertShow(tmdbId = BREAKING_BAD)
+        insertShow(tmdbId = THE_WIRE)
+        setShowComposition(BREAKING_BAD, year = "2008", genres = listOf("Drama"))
+        setShowComposition(THE_WIRE, year = "2002", genres = null)
+        markWatched(tmdbId = BREAKING_BAD, episodeNumber = 1, watchedAt = epochMillis(2026, 8, 3))
+        markWatched(tmdbId = THE_WIRE, episodeNumber = 1, watchedAt = epochMillis(2026, 8, 3))
+
+        calculate().genreBreakdown shouldBe listOf(GenreCount(name = "Drama", showCount = 1))
+    }
+
+    @Test
+    fun `should count the release years oldest first`() = runTest(testDispatcher) {
+        insertShow(tmdbId = BREAKING_BAD)
+        insertShow(tmdbId = THE_WIRE)
+        setShowComposition(BREAKING_BAD, year = "2008", genres = listOf("Drama"))
+        setShowComposition(THE_WIRE, year = "2002", genres = listOf("Drama"))
+        markWatched(tmdbId = BREAKING_BAD, episodeNumber = 1, watchedAt = epochMillis(2026, 8, 3))
+        markWatched(tmdbId = THE_WIRE, episodeNumber = 1, watchedAt = epochMillis(2026, 8, 3))
+
+        calculate().releaseYears shouldBe listOf(
+            ReleaseYearCount(year = 2002, showCount = 1),
+            ReleaseYearCount(year = 2008, showCount = 1),
+        )
+    }
+
+    @Test
+    fun `should leave out a show with no release year`() = runTest(testDispatcher) {
+        insertShow(tmdbId = BREAKING_BAD)
+        setShowComposition(BREAKING_BAD, year = null, genres = listOf("Drama"))
+        markWatched(tmdbId = BREAKING_BAD, episodeNumber = 1, watchedAt = epochMillis(2026, 8, 3))
+
+        calculate().releaseYears.shouldBeEmptyList()
+    }
+
+    @Test
+    fun `should leave out a show that is not watched`() = runTest(testDispatcher) {
+        insertShow(tmdbId = BREAKING_BAD)
+        insertShow(tmdbId = THE_WIRE)
+        setShowComposition(BREAKING_BAD, year = "2008", genres = listOf("Drama"))
+        setShowComposition(THE_WIRE, year = "2002", genres = listOf("Crime"))
+        markWatched(tmdbId = BREAKING_BAD, episodeNumber = 1, watchedAt = epochMillis(2026, 8, 3))
+
+        calculate().genreBreakdown shouldBe listOf(GenreCount(name = "Drama", showCount = 1))
+        calculate().releaseYears shouldBe listOf(ReleaseYearCount(year = 2008, showCount = 1))
+    }
+
+    private fun setShowComposition(tmdbId: Long, year: String?, genres: List<String>?) {
+        database.tvShowQueries.upsert(
+            tmdb_id = Id<TmdbId>(tmdbId),
+            name = "show-$tmdbId",
+            overview = "overview",
+            language = "en",
+            year = year,
+            ratings = 8.0,
+            vote_count = 100,
+            genres = genres,
+            status = "Ended",
+            episode_numbers = null,
+            season_numbers = null,
+            poster_path = null,
+            backdrop_path = null,
+        )
     }
 
     private fun internalId(tmdbId: Long): Id<ShowId> =

--- a/features/statistics/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/statistics/presenter/StatisticsPresenterTest.kt
+++ b/features/statistics/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/statistics/presenter/StatisticsPresenterTest.kt
@@ -103,7 +103,7 @@ internal class StatisticsPresenterTest {
 
     @Test
     fun `should show content given watch history`() = runTest(testDispatcher) {
-        seedWatches()
+        addWatches()
         val presenter = buildPresenter()
 
         presenter.state.test {
@@ -121,7 +121,7 @@ internal class StatisticsPresenterTest {
 
     @Test
     fun `should report the total watch time given episodes carry a runtime`() = runTest(testDispatcher) {
-        seedWatches(runtimeMinutes = 45)
+        addWatches(runtimeMinutes = 45)
         val presenter = buildPresenter()
 
         presenter.state.test {
@@ -136,7 +136,7 @@ internal class StatisticsPresenterTest {
 
     @Test
     fun `should omit the total watch time given no episode carries a runtime`() = runTest(testDispatcher) {
-        seedWatches(runtimeMinutes = null)
+        addWatches(runtimeMinutes = null)
         val presenter = buildPresenter()
 
         presenter.state.test {
@@ -147,7 +147,7 @@ internal class StatisticsPresenterTest {
 
     @Test
     fun `should omit the rating tile given nothing is rated`() = runTest(testDispatcher) {
-        seedWatches()
+        addWatches()
         val presenter = buildPresenter()
 
         presenter.state.test {
@@ -161,7 +161,7 @@ internal class StatisticsPresenterTest {
 
     @Test
     fun `should add the rating tile given ratings exist`() = runTest(testDispatcher) {
-        seedWatches()
+        addWatches()
         ratingsRepository.setUserRatingDistribution(mapOf(8 to 1L, 10 to 1L))
         val presenter = buildPresenter()
 
@@ -175,7 +175,7 @@ internal class StatisticsPresenterTest {
 
     @Test
     fun `should order the tiles from the widest time span down`() = runTest(testDispatcher) {
-        seedWatches()
+        addWatches()
         ratingsRepository.setUserRatingDistribution(mapOf(9 to 1L))
         val presenter = buildPresenter()
 
@@ -200,7 +200,7 @@ internal class StatisticsPresenterTest {
     @Test
     fun `should lock the screen given the subscription does not cover statistics`() = runTest(testDispatcher) {
         subscriptionManager.setAccess(SubscriptionFeature.Statistics, false)
-        seedWatches()
+        addWatches()
         val presenter = buildPresenter()
 
         presenter.state.test {
@@ -216,7 +216,7 @@ internal class StatisticsPresenterTest {
     @Test
     fun `should note marked watched times given a Simkl account`() = runTest(testDispatcher) {
         accountManager.setActiveProvider(SyncProviderSource.SIMKL)
-        seedWatches()
+        addWatches()
         val presenter = buildPresenter()
 
         presenter.state.test {
@@ -227,7 +227,7 @@ internal class StatisticsPresenterTest {
 
     @Test
     fun `should not note marked watched times given a Trakt account`() = runTest(testDispatcher) {
-        seedWatches()
+        addWatches()
         val presenter = buildPresenter()
 
         presenter.state.test {
@@ -238,7 +238,7 @@ internal class StatisticsPresenterTest {
 
     @Test
     fun `should count only the watch statuses shows sit in`() = runTest(testDispatcher) {
-        seedWatches()
+        addWatches()
         showWatchStatusRepository.setShowCountsByStatus(
             mapOf(WatchStatus.COMPLETED to 3L, WatchStatus.WATCHING to 1L),
         )
@@ -256,7 +256,7 @@ internal class StatisticsPresenterTest {
 
     @Test
     fun `should open the show given a show is clicked`() = runTest(testDispatcher) {
-        seedWatches()
+        addWatches()
         val presenter = buildPresenter()
 
         presenter.state.test {
@@ -273,7 +273,7 @@ internal class StatisticsPresenterTest {
     @Test
     fun `should ignore a show click given the screen is locked`() = runTest(testDispatcher) {
         subscriptionManager.setAccess(SubscriptionFeature.Statistics, false)
-        seedWatches()
+        addWatches()
         val presenter = buildPresenter()
 
         presenter.state.test {
@@ -286,7 +286,7 @@ internal class StatisticsPresenterTest {
         }
     }
 
-    private fun seedWatches(runtimeMinutes: Long? = 45) {
+    private fun addWatches(runtimeMinutes: Long? = 45) {
         episodeRepository.setWatchedEpisodeRuntimes(
             listOf(
                 WatchedEpisodeRuntime(watchedAt = epochMillis(2026, 8, 2), runtimeMinutes = runtimeMinutes),
@@ -308,7 +308,7 @@ internal class StatisticsPresenterTest {
 
     @Test
     fun `should read the watches and the ratings again given a refresh is asked for`() = runTest(testDispatcher) {
-        seedWatches()
+        addWatches()
         val presenter = buildPresenter()
 
         presenter.state.test {
@@ -326,7 +326,7 @@ internal class StatisticsPresenterTest {
 
     @Test
     fun `should wait for the sync to finish given refresh is awaited`() = runTest(testDispatcher) {
-        seedWatches()
+        addWatches()
         val presenter = buildPresenter()
 
         presenter.state.test {
@@ -344,7 +344,7 @@ internal class StatisticsPresenterTest {
     @Test
     fun `should return right away given refresh is awaited on a locked screen`() = runTest(testDispatcher) {
         subscriptionManager.setAccess(SubscriptionFeature.Statistics, false)
-        seedWatches()
+        addWatches()
         val presenter = buildPresenter()
 
         presenter.state.test {
@@ -361,7 +361,7 @@ internal class StatisticsPresenterTest {
     @Test
     fun `should not refresh given the screen is locked`() = runTest(testDispatcher) {
         subscriptionManager.setAccess(SubscriptionFeature.Statistics, false)
-        seedWatches()
+        addWatches()
         val presenter = buildPresenter()
 
         presenter.state.test {


### PR DESCRIPTION
## Description
This PR stores the release year and genres for shows that arrived through history sync, and counts them for the statistics screen. Neither panel is drawn yet, so there is nothing new to see until the show composition sections land.

## Changes
- Store the release year and genres for watched shows during the watched-shows sync.
- Count a show as missing metadata when its runtime, release year, or genres are absent, so one pass fills all three.
- Store the release year for Simkl accounts, which return it alongside the watch history.
- Keep a stored value when a provider returns nothing for that field.
- Add the query and the models that the genre breakdown and the release year chart read.
- Rename the `seed` test helpers to say what they add.
