### PR TITLE
fix: Standardize genre name

### DIFF
--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktEpisodeWatchesDataSource.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktEpisodeWatchesDataSource.kt
@@ -80,9 +80,7 @@ public class TraktEpisodeWatchesDataSource(
                     tmdbId = tmdbId,
                     runtimeMinutes = entry.show.runtime,
                     year = entry.show.year?.toString(),
-                    genres = entry.show.genres
-                        ?.takeIf { it.isNotEmpty() }
-                        ?.map { genre -> genre.replaceFirstChar { char -> char.uppercase() } },
+                    genres = entry.show.genres?.takeIf { it.isNotEmpty() },
                 )
             }
             is ApiResponse.Unauthenticated -> emptyList()

--- a/core/test-tags/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testtags/statistics/StatisticsTestTags.kt
+++ b/core/test-tags/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testtags/statistics/StatisticsTestTags.kt
@@ -19,7 +19,7 @@ public object StatisticsTestTags {
     public const val WEEKDAY_ACTIVITY_TEST_TAG: String = "statistics_weekday_activity"
     public const val ACTIVITY_TOOLTIP_TEST_TAG: String = "statistics_activity_tooltip"
     public const val GENRES_SECTION_TEST_TAG: String = "statistics_genres_section"
-    public const val GENRES_UNAVAILABLE_NOTE_TEST_TAG: String = "statistics_genres_unavailable_note"
+    public const val GENRES_EMPTY_MESSAGE_TEST_TAG: String = "statistics_genres_empty_message"
     public const val RELEASE_YEARS_TEST_TAG: String = "statistics_release_years"
     public fun tile(id: String): String = "statistics_tile_$id"
     public fun mostWatchedShowCard(showId: Long): String = "statistics_most_watched_show_$showId"

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepository.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepository.kt
@@ -12,6 +12,7 @@ import com.thomaskioko.tvmaniac.episodes.api.WatchedShowBatch
 import com.thomaskioko.tvmaniac.followedshows.api.PendingAction
 import com.thomaskioko.tvmaniac.shows.api.ShowReconciler
 import com.thomaskioko.tvmaniac.shows.api.ShowResolveOutcome
+import com.thomaskioko.tvmaniac.shows.api.traktGenreName
 import com.thomaskioko.tvmaniac.syncactivity.api.ActivitySyncRepository
 import com.thomaskioko.tvmaniac.syncactivity.api.ActivitySyncTypes
 import com.thomaskioko.tvmaniac.syncactivity.api.model.ActivityType
@@ -229,7 +230,7 @@ public class DefaultWatchedEpisodeSyncRepository(
                     tmdbId = show.tmdbId,
                     runtime = show.runtimeMinutes,
                     year = show.year,
-                    genres = show.genres,
+                    genres = show.genres?.map(::traktGenreName),
                 )
             }
             updated += metadata.size

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepositoryTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepositoryTest.kt
@@ -609,7 +609,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
                 tmdbId = SHOW_ID,
                 runtimeMinutes = 47,
                 year = "2019",
-                genres = listOf("Drama", "Science-fiction"),
+                genres = listOf("drama", "science-fiction"),
             ),
         )
 
@@ -618,7 +618,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
 
         val show = database.tvShowQueries.tvshowByTmdbId(Id(SHOW_ID)).executeAsOne()
         show.year shouldBe "2019"
-        show.genres shouldContainExactly listOf("Drama", "Science-fiction")
+        show.genres shouldContainExactly listOf("Drama", "Science Fiction")
     }
 
     @Test

--- a/data/featuredshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/featuredshows/implementation/FeaturedShowsStore.kt
+++ b/data/featuredshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/featuredshows/implementation/FeaturedShowsStore.kt
@@ -15,6 +15,7 @@ import com.thomaskioko.tvmaniac.resourcemanager.api.RequestTypeConfig.FEATURED_S
 import com.thomaskioko.tvmaniac.shows.api.ShowToPersist
 import com.thomaskioko.tvmaniac.shows.api.TvShowsDao
 import com.thomaskioko.tvmaniac.shows.api.model.ShowEntity
+import com.thomaskioko.tvmaniac.shows.api.traktGenreName
 import com.thomaskioko.tvmaniac.tmdb.api.TmdbShowDetailsNetworkDataSource
 import com.thomaskioko.tvmaniac.trakt.api.TraktShowsRemoteDataSource
 import com.thomaskioko.tvmaniac.trakt.api.model.TraktShowResponse
@@ -157,7 +158,7 @@ private fun TraktShowResponse.toTvshow(
     posterPath = posterPath,
     backdropPath = backdropPath,
     status = status,
-    genres = genres?.map { it.replaceFirstChar { char -> char.uppercase() } },
+    genres = genres?.map(::traktGenreName),
     episodeNumbers = airedEpisodes?.toString(),
     seasonNumbers = null,
 )

--- a/data/genre/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/genre/GenreShowsStore.kt
+++ b/data/genre/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/genre/GenreShowsStore.kt
@@ -14,6 +14,7 @@ import com.thomaskioko.tvmaniac.resourcemanager.api.RequestTypeConfig.GENRE_SHOW
 import com.thomaskioko.tvmaniac.shows.api.ShowToPersist
 import com.thomaskioko.tvmaniac.shows.api.TvShowsDao
 import com.thomaskioko.tvmaniac.shows.api.model.ShowEntity
+import com.thomaskioko.tvmaniac.shows.api.traktGenreName
 import com.thomaskioko.tvmaniac.tmdb.api.TmdbShowDetailsNetworkDataSource
 import com.thomaskioko.tvmaniac.trakt.api.TraktShowsRemoteDataSource
 import com.thomaskioko.tvmaniac.trakt.api.model.TraktShowResponse
@@ -159,7 +160,7 @@ private fun TraktShowResponse.toTvshow(
     posterPath = posterPath,
     backdropPath = backdropPath,
     status = status,
-    genres = genres?.map { it.replaceFirstChar { char -> char.uppercase() } },
+    genres = genres?.map(::traktGenreName),
     episodeNumbers = airedEpisodes?.toString(),
     seasonNumbers = null,
 )

--- a/data/popularshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/popularshows/implementation/PopularShowsStore.kt
+++ b/data/popularshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/popularshows/implementation/PopularShowsStore.kt
@@ -15,6 +15,7 @@ import com.thomaskioko.tvmaniac.resourcemanager.api.RequestTypeConfig.POPULAR_SH
 import com.thomaskioko.tvmaniac.shows.api.ShowToPersist
 import com.thomaskioko.tvmaniac.shows.api.TvShowsDao
 import com.thomaskioko.tvmaniac.shows.api.model.ShowEntity
+import com.thomaskioko.tvmaniac.shows.api.traktGenreName
 import com.thomaskioko.tvmaniac.tmdb.api.TmdbShowDetailsNetworkDataSource
 import com.thomaskioko.tvmaniac.trakt.api.TraktShowsRemoteDataSource
 import com.thomaskioko.tvmaniac.trakt.api.model.TraktShowResponse
@@ -160,7 +161,7 @@ private fun TraktShowResponse.toTvshow(
     posterPath = posterPath,
     backdropPath = backdropPath,
     status = status,
-    genres = genres?.map { it.replaceFirstChar { char -> char.uppercase() } },
+    genres = genres?.map(::traktGenreName),
     episodeNumbers = airedEpisodes?.toString(),
     seasonNumbers = null,
 )

--- a/data/recommendedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/recommendedshows/implementation/RecommendedShowsStore.kt
+++ b/data/recommendedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/recommendedshows/implementation/RecommendedShowsStore.kt
@@ -14,6 +14,7 @@ import com.thomaskioko.tvmaniac.resourcemanager.api.RequestManagerRepository
 import com.thomaskioko.tvmaniac.resourcemanager.api.RequestTypeConfig.RECOMMENDED_SHOWS
 import com.thomaskioko.tvmaniac.shows.api.ShowToPersist
 import com.thomaskioko.tvmaniac.shows.api.TvShowsDao
+import com.thomaskioko.tvmaniac.shows.api.traktGenreName
 import com.thomaskioko.tvmaniac.tmdb.api.TmdbShowDetailsNetworkDataSource
 import com.thomaskioko.tvmaniac.trakt.api.TraktShowsRemoteDataSource
 import com.thomaskioko.tvmaniac.util.api.DateTimeProvider
@@ -149,7 +150,7 @@ private fun RecommendedShowResult.toShowToPersist(
         posterPath = (tmdbDetails?.posterPath ?: tmdbShow?.posterPath)?.let { formatterUtil.formatTmdbPosterPath(it) },
         backdropPath = (tmdbDetails?.backdropPath ?: tmdbShow?.backdropPath)?.let { formatterUtil.formatTmdbPosterPath(it) },
         status = tmdbDetails?.status ?: trakt?.status,
-        genres = trakt?.genres?.map { it.replaceFirstChar { char -> char.uppercase() } },
+        genres = trakt?.genres?.map(::traktGenreName),
         episodeNumbers = trakt?.airedEpisodes?.toString(),
         seasonNumbers = null,
     )

--- a/data/search/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/search/implementation/SearchShowStore.kt
+++ b/data/search/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/search/implementation/SearchShowStore.kt
@@ -9,6 +9,7 @@ import com.thomaskioko.tvmaniac.db.Id
 import com.thomaskioko.tvmaniac.shows.api.ShowToPersist
 import com.thomaskioko.tvmaniac.shows.api.TvShowsDao
 import com.thomaskioko.tvmaniac.shows.api.model.ShowEntity
+import com.thomaskioko.tvmaniac.shows.api.traktGenreName
 import com.thomaskioko.tvmaniac.tmdb.api.TmdbShowDetailsNetworkDataSource
 import com.thomaskioko.tvmaniac.trakt.api.TraktShowsRemoteDataSource
 import com.thomaskioko.tvmaniac.util.api.DateTimeProvider
@@ -83,7 +84,7 @@ private fun SearchShowResult.toTvshow(formatterUtil: FormatterUtil, dateTimeProv
         voteCount = traktShow.votes ?: 0L,
         posterPath = tmdb?.posterPath?.let { formatterUtil.formatTmdbPosterPath(it) },
         backdropPath = tmdb?.backdropPath?.let { formatterUtil.formatTmdbPosterPath(it) },
-        genres = traktShow.genres?.map { it.replaceFirstChar { char -> char.uppercase() } },
+        genres = traktShow.genres?.map(::traktGenreName),
         seasonNumbers = null,
     )
 }

--- a/data/showdetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/showdetails/implementation/ShowDetailsStore.kt
+++ b/data/showdetails/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/showdetails/implementation/ShowDetailsStore.kt
@@ -15,6 +15,8 @@ import com.thomaskioko.tvmaniac.resourcemanager.api.RequestTypeConfig.SHOW_DETAI
 import com.thomaskioko.tvmaniac.seasons.api.SeasonsDao
 import com.thomaskioko.tvmaniac.shows.api.ShowToPersist
 import com.thomaskioko.tvmaniac.shows.api.TvShowsDao
+import com.thomaskioko.tvmaniac.shows.api.traktGenreName
+import com.thomaskioko.tvmaniac.shows.api.traktGenreNames
 import com.thomaskioko.tvmaniac.tmdb.api.TmdbShowDetailsNetworkDataSource
 import com.thomaskioko.tvmaniac.trakt.api.TraktShowsRemoteDataSource
 import com.thomaskioko.tvmaniac.util.api.DateTimeProvider
@@ -59,7 +61,7 @@ public class ShowDetailsStore(
                 seasonNumbers = tmdbDetails.seasons.size.toString(),
                 ratings = traktShow.rating ?: 0.0,
                 voteCount = traktShow.votes ?: 0L,
-                genres = traktShow.genres?.map { it.replaceFirstChar { c -> c.uppercase() } },
+                genres = traktShow.genres?.map(::traktGenreName),
                 posterPath = tmdbDetails.posterPath,
                 backdropPath = tmdbDetails.backdropPath,
                 tmdbSeasons = tmdbDetails.seasons,
@@ -79,7 +81,7 @@ public class ShowDetailsStore(
                 seasonNumbers = tmdbShow.numberOfSeasons.toString(),
                 ratings = tmdbShow.voteAverage,
                 voteCount = tmdbShow.voteCount.toLong(),
-                genres = tmdbShow.genres.map { it.name.replaceFirstChar { c -> c.uppercase() } },
+                genres = tmdbShow.genres.flatMap { traktGenreNames(it.name) }.distinct(),
                 posterPath = tmdbShow.posterPath,
                 backdropPath = tmdbShow.backdropPath,
                 tmdbSeasons = tmdbShow.seasons,

--- a/data/shows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/api/GenreNames.kt
+++ b/data/shows/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/shows/api/GenreNames.kt
@@ -1,0 +1,13 @@
+package com.thomaskioko.tvmaniac.shows.api
+
+public fun traktGenreName(slug: String): String =
+    slug.split("-").joinToString(" ") { part -> part.replaceFirstChar { it.uppercase() } }
+
+public fun traktGenreNames(tmdbGenre: String): List<String> = when (tmdbGenre) {
+    "Action & Adventure" -> listOf("Action", "Adventure")
+    "Sci-Fi & Fantasy" -> listOf("Science Fiction", "Fantasy")
+    "War & Politics" -> listOf("War")
+    "Kids" -> listOf("Children")
+    "Talk" -> listOf("Talk Show")
+    else -> listOf(tmdbGenre)
+}

--- a/data/shows/api/src/commonTest/kotlin/com/thomaskioko/tvmaniac/shows/api/GenreNamesTest.kt
+++ b/data/shows/api/src/commonTest/kotlin/com/thomaskioko/tvmaniac/shows/api/GenreNamesTest.kt
@@ -1,0 +1,45 @@
+package com.thomaskioko.tvmaniac.shows.api
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+internal class GenreNamesTest {
+
+    @Test
+    fun `should title case a single word slug`() {
+        traktGenreName("drama") shouldBe "Drama"
+    }
+
+    @Test
+    fun `should turn a hyphenated slug into separate words`() {
+        traktGenreName("science-fiction") shouldBe "Science Fiction"
+        traktGenreName("talk-show") shouldBe "Talk Show"
+        traktGenreName("home-and-garden") shouldBe "Home And Garden"
+    }
+
+    @Test
+    fun `should keep a TMDB genre that already matches Trakt`() {
+        traktGenreNames("Drama") shouldBe listOf("Drama")
+        traktGenreNames("Western") shouldBe listOf("Western")
+    }
+
+    @Test
+    fun `should split the TMDB genres that cover two Trakt genres`() {
+        traktGenreNames("Action & Adventure") shouldBe listOf("Action", "Adventure")
+        traktGenreNames("Sci-Fi & Fantasy") shouldBe listOf("Science Fiction", "Fantasy")
+    }
+
+    @Test
+    fun `should rename the TMDB genres Trakt calls something else`() {
+        traktGenreNames("War & Politics") shouldBe listOf("War")
+        traktGenreNames("Kids") shouldBe listOf("Children")
+        traktGenreNames("Talk") shouldBe listOf("Talk Show")
+    }
+
+    @Test
+    fun `should give the same name whichever source a genre came from`() {
+        traktGenreNames("Sci-Fi & Fantasy").first() shouldBe traktGenreName("science-fiction")
+        traktGenreNames("Kids").single() shouldBe traktGenreName("children")
+        traktGenreNames("Talk").single() shouldBe traktGenreName("talk-show")
+    }
+}

--- a/data/similar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/implementation/SimilarShowStore.kt
+++ b/data/similar/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/similar/implementation/SimilarShowStore.kt
@@ -12,6 +12,7 @@ import com.thomaskioko.tvmaniac.resourcemanager.api.RequestManagerRepository
 import com.thomaskioko.tvmaniac.resourcemanager.api.RequestTypeConfig.SIMILAR_SHOWS
 import com.thomaskioko.tvmaniac.shows.api.ShowToPersist
 import com.thomaskioko.tvmaniac.shows.api.TvShowsDao
+import com.thomaskioko.tvmaniac.shows.api.traktGenreName
 import com.thomaskioko.tvmaniac.similar.api.SimilarShowsDao
 import com.thomaskioko.tvmaniac.tmdb.api.TmdbShowDetailsNetworkDataSource
 import com.thomaskioko.tvmaniac.trakt.api.TraktShowsRemoteDataSource
@@ -140,7 +141,7 @@ private fun SimilarShowResult.toTvshow(
         posterPath = tmdb?.posterPath?.let { formatterUtil.formatTmdbPosterPath(it) },
         backdropPath = tmdb?.backdropPath?.let { formatterUtil.formatTmdbPosterPath(it) },
         status = tmdb?.status ?: trakt.status,
-        genres = trakt.genres?.map { it.replaceFirstChar { char -> char.uppercase() } },
+        genres = trakt.genres?.map(::traktGenreName),
         episodeNumbers = trakt.airedEpisodes?.toString(),
         seasonNumbers = null,
     )

--- a/data/topratedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/toprated/data/implementation/TopRatedShowsStore.kt
+++ b/data/topratedshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/toprated/data/implementation/TopRatedShowsStore.kt
@@ -14,6 +14,7 @@ import com.thomaskioko.tvmaniac.resourcemanager.api.RequestTypeConfig.TOP_RATED_
 import com.thomaskioko.tvmaniac.shows.api.ShowToPersist
 import com.thomaskioko.tvmaniac.shows.api.TvShowsDao
 import com.thomaskioko.tvmaniac.shows.api.model.ShowEntity
+import com.thomaskioko.tvmaniac.shows.api.traktGenreName
 import com.thomaskioko.tvmaniac.tmdb.api.TmdbShowDetailsNetworkDataSource
 import com.thomaskioko.tvmaniac.topratedshows.data.api.TopRatedShowsDao
 import com.thomaskioko.tvmaniac.trakt.api.TraktShowsRemoteDataSource
@@ -152,7 +153,7 @@ private fun TraktShowResponse.toTvshow(
     posterPath = posterPath,
     backdropPath = backdropPath,
     status = status,
-    genres = genres?.map { it.replaceFirstChar { char -> char.uppercase() } },
+    genres = genres?.map(::traktGenreName),
     episodeNumbers = airedEpisodes?.toString(),
     seasonNumbers = null,
 )

--- a/data/trendingshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/implementation/TrendingShowsStore.kt
+++ b/data/trendingshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/implementation/TrendingShowsStore.kt
@@ -16,6 +16,7 @@ import com.thomaskioko.tvmaniac.resourcemanager.api.RequestTypeConfig.TRENDING_S
 import com.thomaskioko.tvmaniac.shows.api.ShowToPersist
 import com.thomaskioko.tvmaniac.shows.api.TvShowsDao
 import com.thomaskioko.tvmaniac.shows.api.model.ShowEntity
+import com.thomaskioko.tvmaniac.shows.api.traktGenreName
 import com.thomaskioko.tvmaniac.tmdb.api.TmdbShowDetailsNetworkDataSource
 import com.thomaskioko.tvmaniac.trakt.api.TraktShowsRemoteDataSource
 import com.thomaskioko.tvmaniac.trakt.api.model.TraktShowResponse
@@ -153,7 +154,7 @@ private fun TraktShowResponse.toTvShow(
     posterPath = posterPath,
     backdropPath = backdropPath,
     status = status,
-    genres = genres?.map { it.replaceFirstChar { char -> char.uppercase() } },
+    genres = genres?.map(::traktGenreName),
     episodeNumbers = airedEpisodes?.toString(),
     seasonNumbers = null,
 )

--- a/data/upcomingshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/upcomingshows/implementation/UpcomingShowsStore.kt
+++ b/data/upcomingshows/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/upcomingshows/implementation/UpcomingShowsStore.kt
@@ -16,6 +16,7 @@ import com.thomaskioko.tvmaniac.resourcemanager.api.RequestTypeConfig.UPCOMING_S
 import com.thomaskioko.tvmaniac.shows.api.ShowToPersist
 import com.thomaskioko.tvmaniac.shows.api.TvShowsDao
 import com.thomaskioko.tvmaniac.shows.api.model.ShowEntity
+import com.thomaskioko.tvmaniac.shows.api.traktGenreName
 import com.thomaskioko.tvmaniac.tmdb.api.TmdbShowsNetworkDataSource
 import com.thomaskioko.tvmaniac.trakt.api.TraktShowsRemoteDataSource
 import com.thomaskioko.tvmaniac.util.api.DateTimeProvider
@@ -150,7 +151,7 @@ private fun UpcomingShowResult.toTvshow(
         posterPath = tmdb.posterPath?.let { formatterUtil.formatTmdbPosterPath(it) },
         backdropPath = tmdb.backdropPath?.let { formatterUtil.formatTmdbPosterPath(it) },
         status = trakt?.status,
-        genres = trakt?.genres?.map { it.replaceFirstChar { char -> char.uppercase() } },
+        genres = trakt?.genres?.map(::traktGenreName),
         episodeNumbers = trakt?.airedEpisodes?.toString(),
         seasonNumbers = null,
     )

--- a/features/statistics/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/statistics/presenter/StatisticsLabels.kt
+++ b/features/statistics/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/statistics/presenter/StatisticsLabels.kt
@@ -17,7 +17,7 @@ public data class StatisticsLabels(
     val weekdayActivityTitle: String = "",
     val genresTitle: String = "",
     val releaseYearsTitle: String = "",
-    val genresUnavailableNote: String = "",
+    val genresEmptyMessage: String = "",
     val lockedTitle: String = "",
     val lockedMessage: String = "",
     val lockedBadgeText: String = "",

--- a/features/statistics/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/statistics/presenter/StatisticsPresenter.kt
+++ b/features/statistics/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/statistics/presenter/StatisticsPresenter.kt
@@ -80,7 +80,6 @@ public class StatisticsPresenter internal constructor(
             weekdayActivity = stateMapper.toWeekdayActivity(statistics),
             genreBreakdown = stateMapper.toGenreBreakdown(statistics),
             releaseYears = stateMapper.toReleaseYears(statistics),
-            genresUnavailable = activeProvider == SyncProviderSource.SIMKL,
             labels = stateMapper.toLabels(),
             message = message,
         )

--- a/features/statistics/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/statistics/presenter/StatisticsState.kt
+++ b/features/statistics/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/statistics/presenter/StatisticsState.kt
@@ -29,7 +29,6 @@ public data class StatisticsState(
     val weekdayActivity: ImmutableList<ActivityBar> = persistentListOf(),
     val genreBreakdown: ImmutableList<GenreSlice> = persistentListOf(),
     val releaseYears: ImmutableList<ActivityBar> = persistentListOf(),
-    val genresUnavailable: Boolean = false,
     val labels: StatisticsLabels = StatisticsLabels(),
     val message: UiMessage? = null,
 ) {

--- a/features/statistics/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/statistics/presenter/StatisticsStateMapper.kt
+++ b/features/statistics/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/statistics/presenter/StatisticsStateMapper.kt
@@ -248,7 +248,7 @@ public class StatisticsStateMapper(
         weekdayActivityTitle = localizer.getString(StringResourceKey.LabelStatisticsWeekdayActivity),
         genresTitle = localizer.getString(StringResourceKey.LabelStatisticsGenres),
         releaseYearsTitle = localizer.getString(StringResourceKey.LabelStatisticsReleaseYears),
-        genresUnavailableNote = localizer.getString(StringResourceKey.LabelStatisticsGenresUnavailable),
+        genresEmptyMessage = localizer.getString(StringResourceKey.LabelStatisticsGenresEmpty),
         lockedTitle = localizer.getString(StringResourceKey.LabelStatisticsLockedTitle),
         lockedMessage = localizer.getString(StringResourceKey.LabelStatisticsLockedMessage),
         lockedBadgeText = localizer.getString(StringResourceKey.LabelPremiumBadge),

--- a/i18n/generator/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/base/strings.xml
@@ -553,7 +553,7 @@
     <string name="label_statistics_genres">Genres you watch</string>
     <string name="label_statistics_release_years">Shows by release year</string>
     <string name="label_statistics_genre_other">Other</string>
-    <string name="label_statistics_genres_unavailable">Simkl does not provide genres, so this is only available on a Trakt account.</string>
+    <string name="label_statistics_genres_empty">We do not know the genres of the shows you have watched yet.</string>
     <string name="label_statistics_current_streak">Current streak</string>
     <string name="label_statistics_running_now">running now</string>
     <string name="label_statistics_watch_days_month">Watch days this month</string>

--- a/i18n/generator/src/commonMain/moko-resources/de/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/de/strings.xml
@@ -545,7 +545,7 @@
     <string name="label_statistics_genres">Genres, die Sie sehen</string>
     <string name="label_statistics_release_years">Serien nach Erscheinungsjahr</string>
     <string name="label_statistics_genre_other">Andere</string>
-    <string name="label_statistics_genres_unavailable">Simkl liefert keine Genres, daher ist dies nur mit einem Trakt-Konto verfügbar.</string>
+    <string name="label_statistics_genres_empty">Wir kennen die Genres der von Ihnen gesehenen Serien noch nicht.</string>
     <string name="label_statistics_current_streak">Aktuelle Serie</string>
     <string name="label_statistics_running_now">läuft gerade</string>
     <string name="label_statistics_watch_days_month">Sehtage diesen Monat</string>

--- a/i18n/generator/src/commonMain/moko-resources/fr/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/fr/strings.xml
@@ -542,7 +542,7 @@
     <string name="label_statistics_genres">Genres que vous regardez</string>
     <string name="label_statistics_release_years">Séries par année de sortie</string>
     <string name="label_statistics_genre_other">Autres</string>
-    <string name="label_statistics_genres_unavailable">Simkl ne fournit pas de genres, ceci n'est donc disponible qu'avec un compte Trakt.</string>
+    <string name="label_statistics_genres_empty">Nous ne connaissons pas encore les genres des séries que vous avez regardées.</string>
     <string name="label_statistics_current_streak">Série en cours</string>
     <string name="label_statistics_running_now">en cours</string>
     <string name="label_statistics_watch_days_month">Jours de visionnage ce mois-ci</string>


### PR DESCRIPTION
## Description
This PR stores genres under one vocabulary, the names Trakt uses, so the same genre is never counted or shown under two different names. Show details now reads `Science Fiction` where it used to read `Science-fiction`.

## Changes
- Turn a Trakt genre slug into its proper name instead of only capitalising the first letter.
- Translate the five TMDB television genres that Trakt names differently, splitting the two that cover a pair of Trakt genres.
- Apply the same names everywhere a show is saved, so browsing, search, show details and the watched sync all agree.
- Show the genre panel empty message whenever there is nothing to count, rather than telling Simkl users the panel needs a Trakt account.
