### PR TITLE
feat: Add the genre and release year sections to the statistics screen

### DIFF
--- a/features/statistics/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/statistics/presenter/StatisticsStateMapper.kt
+++ b/features/statistics/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/statistics/presenter/StatisticsStateMapper.kt
@@ -221,12 +221,13 @@ public class StatisticsStateMapper(
         val slices = named.map { genre -> genre.name to genre.showCount } +
             if (tail > 0) listOf(localizer.getString(StringResourceKey.LabelStatisticsGenreOther) to tail) else emptyList()
 
+        val biggest = slices.maxOf { (_, showCount) -> showCount }
         return slices.map { (name, showCount) ->
             GenreSlice(
                 name = name,
                 showCount = showCount.toInt(),
                 caption = localizer.getPlural(PluralsResourceKey.ShowCount, showCount.toInt()),
-                fraction = showCount.toFloat() / total,
+                fraction = showCount.toFloat() / biggest,
             )
         }.toImmutableList()
     }

--- a/features/statistics/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/statistics/presenter/StatisticsStateMapperTest.kt
+++ b/features/statistics/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/statistics/presenter/StatisticsStateMapperTest.kt
@@ -173,7 +173,7 @@ internal class StatisticsStateMapperTest {
     }
 
     @Test
-    fun `should give each genre a share of the whole`() {
+    fun `should scale each genre against the most watched one`() {
         val statistics = WatchStatistics.EMPTY.copy(
             genreBreakdown = listOf(
                 GenreCount(name = "Drama", showCount = 3),
@@ -185,7 +185,7 @@ internal class StatisticsStateMapperTest {
 
         slices.map { it.name } shouldBe listOf("Drama", "Crime")
         slices.map { it.showCount } shouldBe listOf(3, 1)
-        slices.map { it.fraction } shouldBe listOf(0.75f, 0.25f)
+        slices.map { it.fraction } shouldBe listOf(1f, 1f / 3f)
     }
 
     @Test

--- a/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/StatisticsPreviewParameterProvider.kt
+++ b/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/StatisticsPreviewParameterProvider.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.thomaskioko.tvmaniac.statistics.presenter.StatisticsLabels
 import com.thomaskioko.tvmaniac.statistics.presenter.StatisticsState
 import com.thomaskioko.tvmaniac.statistics.presenter.model.ActivityBar
+import com.thomaskioko.tvmaniac.statistics.presenter.model.GenreSlice
 import com.thomaskioko.tvmaniac.statistics.presenter.model.HeatMap
 import com.thomaskioko.tvmaniac.statistics.presenter.model.MostWatchedShowItem
 import com.thomaskioko.tvmaniac.statistics.presenter.model.RatingBar
@@ -31,6 +32,9 @@ internal val previewLabels: StatisticsLabels = StatisticsLabels(
     yearlyActivityTitle = "Episodes by year",
     monthlyActivityTitle = "Episodes by month",
     weekdayActivityTitle = "Episodes by day of the week",
+    genresTitle = "Genres you watch",
+    releaseYearsTitle = "Shows by release year",
+    genresEmptyMessage = "We do not know the genres of the shows you have watched yet.",
     lockedTitle = "Statistics are a Premium feature",
     lockedMessage = "Upgrade to Premium to see how you watch.",
     lockedBadgeText = "Premium",
@@ -200,6 +204,25 @@ internal val emptyState: StatisticsState = StatisticsState(
     labels = previewLabels,
 )
 
+private val previewGenreBreakdown: ImmutableList<GenreSlice> = persistentListOf(
+    GenreSlice(name = "Drama", showCount = 24, caption = "24 shows", fraction = 1f),
+    GenreSlice(name = "Comedy", showCount = 11, caption = "11 shows", fraction = 0.45f),
+    GenreSlice(name = "Crime", showCount = 9, caption = "9 shows", fraction = 0.37f),
+    GenreSlice(name = "Science Fiction", showCount = 7, caption = "7 shows", fraction = 0.29f),
+    GenreSlice(name = "Thriller", showCount = 5, caption = "5 shows", fraction = 0.2f),
+    GenreSlice(name = "Action", showCount = 4, caption = "4 shows", fraction = 0.16f),
+    GenreSlice(name = "Other", showCount = 12, caption = "12 shows", fraction = 0.5f),
+)
+
+private val previewReleaseYears: ImmutableList<ActivityBar> = persistentListOf(
+    ActivityBar(label = "2016", count = 3, caption = "3 shows", fraction = 0.37f),
+    ActivityBar(label = "2017", count = 5, caption = "5 shows", fraction = 0.62f),
+    ActivityBar(label = "2018", count = 2, caption = "2 shows", fraction = 0.25f),
+    ActivityBar(label = "2019", count = 8, caption = "8 shows", fraction = 1f),
+    ActivityBar(label = "2020", count = 4, caption = "4 shows", fraction = 0.5f),
+    ActivityBar(label = "2021", count = 6, caption = "6 shows", fraction = 0.75f),
+)
+
 internal val contentState: StatisticsState = StatisticsState(
     isLoading = false,
     hasWatchHistory = true,
@@ -211,6 +234,8 @@ internal val contentState: StatisticsState = StatisticsState(
     yearlyActivity = previewYearlyActivity,
     monthlyActivity = previewMonthlyActivity,
     weekdayActivity = previewWeekdayActivity,
+    genreBreakdown = previewGenreBreakdown,
+    releaseYears = previewReleaseYears,
     heatMap = previewHeatMap,
     labels = previewLabels,
 )

--- a/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/StatisticsScreen.kt
+++ b/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/StatisticsScreen.kt
@@ -45,6 +45,7 @@ import com.thomaskioko.tvmaniac.statistics.presenter.StatisticsAction
 import com.thomaskioko.tvmaniac.statistics.presenter.StatisticsPresenter
 import com.thomaskioko.tvmaniac.statistics.presenter.StatisticsState
 import com.thomaskioko.tvmaniac.statistics.ui.components.ActivityChartSection
+import com.thomaskioko.tvmaniac.statistics.ui.components.GenreSection
 import com.thomaskioko.tvmaniac.statistics.ui.components.MostWatchedShowsSection
 import com.thomaskioko.tvmaniac.statistics.ui.components.RatingsSection
 import com.thomaskioko.tvmaniac.statistics.ui.components.StatisticTileGrid
@@ -291,6 +292,28 @@ private fun StatisticsContent(
                     title = state.labels.weekdayActivityTitle,
                     sectionTestTag = StatisticsTestTags.WEEKDAY_ACTIVITY_TEST_TAG,
                     sectionName = "weekday",
+                )
+            }
+        }
+
+        if (state.releaseYears.isNotEmpty()) {
+            item(key = "release_years") {
+                ActivityChartSection(
+                    bars = state.releaseYears,
+                    title = state.labels.releaseYearsTitle,
+                    sectionTestTag = StatisticsTestTags.RELEASE_YEARS_TEST_TAG,
+                    sectionName = "release_years",
+                    showAxisLabels = true,
+                )
+            }
+        }
+
+        if (state.hasWatchHistory) {
+            item(key = "genres") {
+                GenreSection(
+                    genres = state.genreBreakdown,
+                    title = state.labels.genresTitle,
+                    emptyMessage = state.labels.genresEmptyMessage,
                 )
             }
         }

--- a/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/components/GenreSection.kt
+++ b/features/statistics/ui/src/main/kotlin/com/thomaskioko/tvmaniac/statistics/ui/components/GenreSection.kt
@@ -1,0 +1,121 @@
+package com.thomaskioko.tvmaniac.statistics.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.PreviewWrapper
+import com.thomaskioko.tvmaniac.compose.components.CollapsibleSection
+import com.thomaskioko.tvmaniac.compose.components.ThemePreviews
+import com.thomaskioko.tvmaniac.compose.components.TvManiacPreviewWrapperProvider
+import com.thomaskioko.tvmaniac.compose.theme.TvManiacSpacing
+import com.thomaskioko.tvmaniac.statistics.presenter.model.GenreSlice
+import com.thomaskioko.tvmaniac.testtags.statistics.StatisticsTestTags
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+@Composable
+internal fun GenreSection(
+    genres: ImmutableList<GenreSlice>,
+    title: String,
+    emptyMessage: String,
+    modifier: Modifier = Modifier,
+) {
+    CollapsibleSection(
+        title = title,
+        modifier = modifier.testTag(StatisticsTestTags.GENRES_SECTION_TEST_TAG),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = TvManiacSpacing.medium),
+            verticalArrangement = Arrangement.spacedBy(TvManiacSpacing.small),
+        ) {
+            if (genres.isEmpty()) {
+                Text(
+                    text = emptyMessage,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.testTag(StatisticsTestTags.GENRES_EMPTY_MESSAGE_TEST_TAG),
+                )
+            } else {
+                genres.forEach { genre ->
+                    GenreRow(
+                        genre = genre,
+                        modifier = Modifier.testTag(StatisticsTestTags.genreRow(genre.name)),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GenreRow(
+    genre: GenreSlice,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = genre.name,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+
+            Text(
+                text = genre.caption,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(TvManiacSpacing.xxxSmall))
+
+        StatisticBar(
+            fraction = genre.fraction,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@ThemePreviews
+@PreviewWrapper(TvManiacPreviewWrapperProvider::class)
+@Composable
+private fun GenreSectionPreview() {
+    GenreSection(
+        genres = persistentListOf(
+            GenreSlice(name = "Drama", showCount = 24, caption = "24 shows", fraction = 1f),
+            GenreSlice(name = "Comedy", showCount = 11, caption = "11 shows", fraction = 0.45f),
+            GenreSlice(name = "Crime", showCount = 9, caption = "9 shows", fraction = 0.37f),
+            GenreSlice(name = "Science Fiction", showCount = 7, caption = "7 shows", fraction = 0.29f),
+            GenreSlice(name = "Thriller", showCount = 5, caption = "5 shows", fraction = 0.2f),
+            GenreSlice(name = "Action", showCount = 4, caption = "4 shows", fraction = 0.16f),
+            GenreSlice(name = "Other", showCount = 12, caption = "12 shows", fraction = 0.5f),
+        ),
+        title = "Genres you watch",
+        emptyMessage = "",
+    )
+}
+
+@ThemePreviews
+@PreviewWrapper(TvManiacPreviewWrapperProvider::class)
+@Composable
+private fun GenreSectionEmptyPreview() {
+    GenreSection(
+        genres = persistentListOf(),
+        title = "Genres you watch",
+        emptyMessage = "We do not know the genres of the shows you have watched yet.",
+    )
+}

--- a/features/statistics/ui/src/test/kotlin/com/thomaskioko/tvmaniac/statistics/ui/GenreSectionTest.kt
+++ b/features/statistics/ui/src/test/kotlin/com/thomaskioko/tvmaniac/statistics/ui/GenreSectionTest.kt
@@ -1,0 +1,84 @@
+package com.thomaskioko.tvmaniac.statistics.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import com.thomaskioko.tvmaniac.compose.components.TvManiacBackground
+import com.thomaskioko.tvmaniac.statistics.presenter.model.GenreSlice
+import com.thomaskioko.tvmaniac.statistics.ui.components.GenreSection
+import com.thomaskioko.tvmaniac.testtags.statistics.StatisticsTestTags
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import org.robolectric.annotation.LooperMode
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@LooperMode(LooperMode.Mode.PAUSED)
+class GenreSectionTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val genres = persistentListOf(
+        GenreSlice(name = "Drama", showCount = 24, caption = "24 shows", fraction = 1f),
+        GenreSlice(name = "Comedy", showCount = 11, caption = "11 shows", fraction = 0.45f),
+        GenreSlice(name = "Other", showCount = 12, caption = "12 shows", fraction = 0.5f),
+    )
+
+    @Test
+    fun `should show a row for every genre`() {
+        showGenres(genres)
+
+        composeTestRule.onNodeWithTag(StatisticsTestTags.genreRow("Drama")).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(StatisticsTestTags.genreRow("Comedy")).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(StatisticsTestTags.genreRow("Other")).assertIsDisplayed()
+    }
+
+    @Test
+    fun `should name each genre and its show count`() {
+        showGenres(genres)
+
+        composeTestRule.onNodeWithText("Drama").assertIsDisplayed()
+        composeTestRule.onNodeWithText("24 shows").assertIsDisplayed()
+    }
+
+    @Test
+    fun `should show the empty message given no genres`() {
+        showGenres(persistentListOf())
+
+        composeTestRule.onNodeWithTag(StatisticsTestTags.GENRES_EMPTY_MESSAGE_TEST_TAG).assertIsDisplayed()
+        composeTestRule.onNodeWithText(EMPTY_MESSAGE).assertIsDisplayed()
+    }
+
+    @Test
+    fun `should leave out the empty message given genres exist`() {
+        showGenres(genres)
+
+        composeTestRule.onNodeWithTag(StatisticsTestTags.GENRES_EMPTY_MESSAGE_TEST_TAG).assertDoesNotExist()
+    }
+
+    private fun showGenres(genres: ImmutableList<GenreSlice>) {
+        composeTestRule.setContent {
+            TvManiacBackground {
+                GenreSection(
+                    genres = genres,
+                    title = "Genres you watch",
+                    emptyMessage = EMPTY_MESSAGE,
+                )
+            }
+        }
+    }
+
+    private companion object {
+        const val EMPTY_MESSAGE = "We do not know the genres of the shows you have watched yet."
+    }
+}


### PR DESCRIPTION
## Description
This PR adds two sections to the Android statistics screen: the genres you watch most, and how many of your shows came out in each year. Both sit alongside the breakdowns already there.

## Changes
- Add a genre section listing each genre with its show count and a bar, keeping the six you watch most and gathering the rest into an Other row.
- Add a release year chart, drawn with the same bars the activity charts already use.
- Say so plainly when there are no genres to show yet, instead of leaving the section blank.
- Scale each genre bar against the genre you watch most, so the smaller ones stay readable.
