### PR TITLE
fix: Rethrow cancellation from the library metadata sync

### DIFF
--- a/domain/library/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/library/SyncLibraryInteractor.kt
+++ b/domain/library/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/library/SyncLibraryInteractor.kt
@@ -97,6 +97,7 @@ public class SyncLibraryInteractor(
                             }
                         }
                         val failure = result.exceptionOrNull() ?: continue
+                        if (failure is CancellationException) throw failure
 
                         logger.warning(TAG, "syncShowMetadata failed for ${show.showId}: ${failure.message}")
                         syncObserver.log(SyncError.BackgroundSyncFailed(TAG, failure))

--- a/domain/library/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/library/SyncLibraryInteractorTest.kt
+++ b/domain/library/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/library/SyncLibraryInteractorTest.kt
@@ -22,9 +22,11 @@ import com.thomaskioko.tvmaniac.syncactivity.testing.FakeActivitySyncRepository
 import com.thomaskioko.tvmaniac.syncactivity.testing.FakeTraktActivityRepository
 import com.thomaskioko.tvmaniac.syncstate.testing.FakeSyncObserver
 import com.thomaskioko.tvmaniac.util.testing.FakeDateTimeProvider
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -189,6 +191,26 @@ class SyncLibraryInteractorTest {
         interactor.executeSync(SyncLibraryInteractor.Param(forceRefresh = true))
 
         showDetailsRepository.fetchInvocations().shouldBeEmpty()
+    }
+
+    @Test
+    fun `should propagate cancellation given the metadata fan-out is cancelled`() = runTest(testDispatcher) {
+        followedShowsRepository.setEntries(listOf(followedShow(showId = 7L)))
+        showDetailsRepository.setFetchError(CancellationException("cancelled"))
+
+        shouldThrow<CancellationException> {
+            interactor.executeSync(SyncLibraryInteractor.Param(forceRefresh = true))
+        }
+    }
+
+    @Test
+    fun `should propagate cancellation given the genre backfill is cancelled`() = runTest(testDispatcher) {
+        watchedEpisodeSyncRepository.setWatchedShowsMissingGenres(listOf(11L))
+        showDetailsRepository.setFetchError(CancellationException("cancelled"))
+
+        shouldThrow<CancellationException> {
+            interactor.executeSync(SyncLibraryInteractor.Param(forceRefresh = true))
+        }
     }
 
     private fun followedShow(showId: Long): FollowedShowEntry = FollowedShowEntry(


### PR DESCRIPTION
## Description
This PR passes cancellation on when a library sync is stopped part way through, so a sync that never finished is no longer recorded as complete.
