### PR TITLE
fix: Enable automatic retry for flakey tests

### DIFF
--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/sheet/EpisodeSheetFlowTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/sheet/EpisodeSheetFlowTest.kt
@@ -5,6 +5,7 @@ import com.thomaskioko.tvmaniac.app.test.AppFlowScope
 import com.thomaskioko.tvmaniac.app.test.BaseAppFlowTest
 import com.thomaskioko.tvmaniac.presentation.episodedetail.EpisodeSheetActionItem
 import com.thomaskioko.tvmaniac.testtags.home.HomeTestTags
+import com.thomaskioko.tvmaniac.util.testing.FlakyTests
 import org.junit.Test
 
 internal class EpisodeSheetFlowTest : BaseAppFlowTest() {
@@ -51,6 +52,7 @@ internal class EpisodeSheetFlowTest : BaseAppFlowTest() {
     }
 
     @Test
+    @FlakyTests(count = 2)
     fun givenEpisodeSheet_whenOpenSeasonClicked_thenNavigatesToSeasonDetails() = runAppFlowTest {
         scenarios.stubAuthenticatedSync()
 
@@ -83,6 +85,7 @@ internal class EpisodeSheetFlowTest : BaseAppFlowTest() {
     }
 
     @Test
+    @FlakyTests(count = 2)
     fun givenEpisodeSheet_whenEpisodeRated_thenRatingPersistsAndCanBeCleared() = runAppFlowTest {
         scenarios.stubTmdb()
         scenarios.stubActiveProvider(SyncProviderSource.TRAKT)

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/showdetails/ShowDetailsFeaturesFlowTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/showdetails/ShowDetailsFeaturesFlowTest.kt
@@ -3,6 +3,7 @@ package com.thomaskioko.tvmaniac.app.test.compose.flows.showdetails
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.app.test.BaseAppFlowTest
 import com.thomaskioko.tvmaniac.testtags.home.HomeTestTags
+import com.thomaskioko.tvmaniac.util.testing.FlakyTests
 import org.junit.Test
 
 internal class ShowDetailsFeaturesFlowTest : BaseAppFlowTest() {
@@ -92,6 +93,7 @@ internal class ShowDetailsFeaturesFlowTest : BaseAppFlowTest() {
     }
 
     @Test
+    @FlakyTests(count = 2)
     fun givenSimklSession_whenShowDetailsOpened_thenAddToListButtonIsDisabled() = runAppFlowTest {
         scenarios.flags.enableSimklLogin()
         scenarios.discover.stubBrowseGraph()


### PR DESCRIPTION
## Description
This PR enables automatic retry for three flow tests that intermittently time out on the nightly emulator run. These tests already share the retry mechanism used by other flow tests in the suite.
