### PR TITLE
feat: Finish a rewatch session and store the ones Simkl reports

### DIFF
--- a/api/simkl/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/api/SimklRewatchRemoteDataSource.kt
+++ b/api/simkl/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/api/SimklRewatchRemoteDataSource.kt
@@ -1,6 +1,7 @@
 package com.thomaskioko.tvmaniac.simkl.api
 
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchCloseRequest
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchHistoryRequest
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchHistoryResponse
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchItemsResponse
@@ -9,4 +10,6 @@ public interface SimklRewatchRemoteDataSource {
     public suspend fun getRewatchSessions(dateFrom: String? = null): ApiResponse<SimklRewatchItemsResponse>
 
     public suspend fun addRewatchHistory(request: SimklRewatchHistoryRequest): ApiResponse<SimklRewatchHistoryResponse>
+
+    public suspend fun closeRewatchSession(request: SimklRewatchCloseRequest): ApiResponse<SimklRewatchHistoryResponse>
 }

--- a/api/simkl/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/api/model/SimklRewatchModels.kt
+++ b/api/simkl/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/api/model/SimklRewatchModels.kt
@@ -15,7 +15,20 @@ public data class SimklRewatchShow(
     @SerialName("rewatch_status") val rewatchStatus: String? = null,
     @SerialName("last_watched_at") val lastWatchedAt: String? = null,
     @SerialName("watched_episodes_count") val watchedEpisodesCount: Int? = null,
+    @SerialName("seasons") val seasons: List<SimklRewatchSeason> = emptyList(),
     @SerialName("show") val show: SimklShowEntry,
+)
+
+@Serializable
+public data class SimklRewatchSeason(
+    @SerialName("number") val number: Int? = null,
+    @SerialName("episodes") val episodes: List<SimklRewatchEpisode> = emptyList(),
+)
+
+@Serializable
+public data class SimklRewatchEpisode(
+    @SerialName("number") val number: Int? = null,
+    @SerialName("watched_at") val watchedAt: String? = null,
 )
 
 @Serializable
@@ -30,6 +43,19 @@ public data class SimklRewatchHistoryShow(
     @SerialName("rewatch_id") val rewatchId: Long? = null,
     @SerialName("rewatch_status") val rewatchStatus: String = "active",
     @SerialName("seasons") val seasons: List<SimklRewatchHistorySeason>,
+)
+
+@Serializable
+public data class SimklRewatchCloseRequest(
+    @SerialName("shows") val shows: List<SimklRewatchCloseShow>,
+)
+
+@Serializable
+public data class SimklRewatchCloseShow(
+    @SerialName("ids") val ids: SimklShowIds,
+    @SerialName("is_rewatch") val isRewatch: Boolean = true,
+    @SerialName("rewatch_id") val rewatchId: Long,
+    @SerialName("rewatch_status") val rewatchStatus: String = "closed",
 )
 
 @Serializable

--- a/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/DefaultSimklRewatchRemoteDataSource.kt
+++ b/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/DefaultSimklRewatchRemoteDataSource.kt
@@ -4,6 +4,7 @@ import com.thomaskioko.tvmaniac.core.base.SimklApi
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.authSafeRequest
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.simkl.api.SimklRewatchRemoteDataSource
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchCloseRequest
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchHistoryRequest
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchHistoryResponse
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchItemsResponse
@@ -36,6 +37,17 @@ public class DefaultSimklRewatchRemoteDataSource(
         }
 
     override suspend fun addRewatchHistory(request: SimklRewatchHistoryRequest): ApiResponse<SimklRewatchHistoryResponse> =
+        httpClient.authSafeRequest {
+            url {
+                method = HttpMethod.Post
+                path("sync/history")
+                parameter("allow_rewatch", "yes")
+            }
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }
+
+    override suspend fun closeRewatchSession(request: SimklRewatchCloseRequest): ApiResponse<SimklRewatchHistoryResponse> =
         httpClient.authSafeRequest {
             url {
                 method = HttpMethod.Post

--- a/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklRewatchSyncProviderDataSource.kt
+++ b/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklRewatchSyncProviderDataSource.kt
@@ -3,13 +3,17 @@ package com.thomaskioko.tvmaniac.simkl.implementation
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.map
+import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchClose
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchSession
+import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchSessionStatus
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchWrite
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchWriteResult
 import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchSyncProviderDataSource
 import com.thomaskioko.tvmaniac.simkl.api.SimklRewatchRemoteDataSource
 import com.thomaskioko.tvmaniac.simkl.api.SimklUserRemoteDataSource
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklAccountTier
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchCloseRequest
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchCloseShow
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchHistoryEpisode
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchHistoryRequest
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchHistorySeason
@@ -74,6 +78,23 @@ public class SimklRewatchSyncProviderDataSource(
         }
     }
 
+    override suspend fun closeRewatch(close: RemoteRewatchClose): ApiResponse<Unit> {
+        val tierResponse = currentTier()
+        if (tierResponse !is ApiResponse.Success) return tierResponse.map { }
+        if (tierResponse.body != SimklAccountTier.PREMIUM) return ApiResponse.Success(Unit)
+
+        return rewatchRemoteDataSource.closeRewatchSession(
+            SimklRewatchCloseRequest(
+                shows = listOf(
+                    SimklRewatchCloseShow(
+                        ids = SimklShowIds(tmdb = close.providerShowId.toString()),
+                        rewatchId = close.providerSessionId,
+                    ),
+                ),
+            ),
+        ).map { }
+    }
+
     private suspend fun currentTier(): ApiResponse<SimklAccountTier> {
         cachedTier?.let { return ApiResponse.Success(it) }
         return userRemoteDataSource.getUserSettings()
@@ -87,5 +108,12 @@ private fun SimklRewatchShow.toRemoteRewatchSession(): RemoteRewatchSession = Re
     seasonNumber = null,
     episodeNumber = null,
     episodeCount = watchedEpisodesCount?.toLong()?.takeIf { it > 0 },
-    lastWatchedAt = lastWatchedAt?.let { runCatching { Instant.parse(it).toEpochMilliseconds() }.getOrNull() },
+    lastWatchedAt = lastWatchedAt?.toEpochMillis(),
+    status = RemoteRewatchSessionStatus.fromRaw(rewatchStatus),
+    startedAt = seasons
+        .flatMap { season -> season.episodes }
+        .mapNotNull { episode -> episode.watchedAt?.toEpochMillis() }
+        .minOrNull(),
 )
+
+private fun String.toEpochMillis(): Long? = runCatching { Instant.parse(this).toEpochMilliseconds() }.getOrNull()

--- a/api/simkl/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklRewatchSyncProviderDataSourceTest.kt
+++ b/api/simkl/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklRewatchSyncProviderDataSourceTest.kt
@@ -3,14 +3,18 @@ package com.thomaskioko.tvmaniac.simkl.implementation
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.getOrThrow
+import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchClose
+import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchSessionStatus
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchWrite
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchWriteResult
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklAccount
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchEpisode
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchHistoryAdded
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchHistoryResponse
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchHistoryStatus
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchHistoryStatusResponse
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchItemsResponse
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchSeason
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchShow
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklShowEntry
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklShowIds
@@ -24,6 +28,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.time.Instant
 
 internal class SimklRewatchSyncProviderDataSourceTest {
 
@@ -226,6 +231,93 @@ internal class SimklRewatchSyncProviderDataSourceTest {
         sessions shouldBe emptyList()
     }
 
+    @Test
+    fun `should send a close carrying the session id and the closed status given the account tier is vip`() = runTest {
+        userRemoteDataSource.setUserSettings(ApiResponse.Success(userSettings(type = "vip")))
+
+        source.closeRewatch(RemoteRewatchClose(providerShowId = 1396L, providerSessionId = 7482L))
+
+        val request = checkNotNull(rewatchRemoteDataSource.lastCloseRewatchSessionRequest)
+        request.shows.first().rewatchId shouldBe 7482L
+        request.shows.first().rewatchStatus shouldBe "closed"
+        request.shows.first().isRewatch shouldBe true
+        request.shows.first().ids.tmdb shouldBe "1396"
+    }
+
+    @Test
+    fun `should not send a close given the account tier is free`() = runTest {
+        userRemoteDataSource.setUserSettings(ApiResponse.Success(userSettings(type = "free")))
+
+        source.closeRewatch(RemoteRewatchClose(providerShowId = 1396L, providerSessionId = 7482L))
+
+        rewatchRemoteDataSource.lastCloseRewatchSessionRequest.shouldBeNull()
+    }
+
+    @Test
+    fun `should not send a close given the tier lookup fails`() = runTest {
+        userRemoteDataSource.setUserSettings(ApiResponse.Error.HttpError(code = 500, errorBody = null, errorMessage = "boom"))
+
+        val result = source.closeRewatch(RemoteRewatchClose(providerShowId = 1396L, providerSessionId = 7482L))
+
+        rewatchRemoteDataSource.lastCloseRewatchSessionRequest.shouldBeNull()
+        result.shouldBeInstanceOf<ApiResponse.Error.HttpError<Unit>>()
+    }
+
+    @Test
+    fun `should read the session status given sessions are read`() = runTest {
+        rewatchRemoteDataSource.setRewatchSessionsResponse(
+            ApiResponse.Success(
+                SimklRewatchItemsResponse(
+                    shows = listOf(rewatchShow(tmdbId = "1396", watchedEpisodesCount = 5, rewatchStatus = "completed")),
+                ),
+            ),
+        )
+
+        val sessions = source.readRewatchSessions(providerShowId = 1396L).getOrThrow()
+
+        sessions.first().status shouldBe RemoteRewatchSessionStatus.COMPLETED
+    }
+
+    @Test
+    fun `should take the earliest episode date as the start given the extended payload carries episodes`() = runTest {
+        rewatchRemoteDataSource.setRewatchSessionsResponse(
+            ApiResponse.Success(
+                SimklRewatchItemsResponse(
+                    shows = listOf(
+                        rewatchShow(
+                            tmdbId = "1396",
+                            watchedEpisodesCount = 2,
+                            seasons = listOf(
+                                SimklRewatchSeason(
+                                    number = 1,
+                                    episodes = listOf(
+                                        SimklRewatchEpisode(number = 2, watchedAt = "2026-02-01T00:00:00Z"),
+                                        SimklRewatchEpisode(number = 1, watchedAt = "2026-01-15T00:00:00Z"),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val sessions = source.readRewatchSessions(providerShowId = 1396L).getOrThrow()
+
+        sessions.first().startedAt shouldBe Instant.parse("2026-01-15T00:00:00Z").toEpochMilliseconds()
+    }
+
+    @Test
+    fun `should report no start given the payload carries no episode dates`() = runTest {
+        rewatchRemoteDataSource.setRewatchSessionsResponse(
+            ApiResponse.Success(SimklRewatchItemsResponse(shows = listOf(rewatchShow(tmdbId = "1396", watchedEpisodesCount = 5)))),
+        )
+
+        val sessions = source.readRewatchSessions(providerShowId = 1396L).getOrThrow()
+
+        sessions.first().startedAt.shouldBeNull()
+    }
+
     private fun write(providerSessionId: Long?, episodeNumber: Long = 1L): RemoteRewatchWrite = RemoteRewatchWrite(
         localSessionId = 7L,
         providerShowId = 1396L,
@@ -256,12 +348,15 @@ internal class SimklRewatchSyncProviderDataSourceTest {
         watchedEpisodesCount: Int?,
         isRewatch: Boolean = true,
         rewatchId: Long? = 1001L,
+        rewatchStatus: String = "active",
+        seasons: List<SimklRewatchSeason> = emptyList(),
     ): SimklRewatchShow = SimklRewatchShow(
         isRewatch = isRewatch,
         rewatchId = rewatchId,
-        rewatchStatus = "active",
+        rewatchStatus = rewatchStatus,
         lastWatchedAt = "2026-01-01T00:00:00Z",
         watchedEpisodesCount = watchedEpisodesCount,
+        seasons = seasons,
         show = SimklShowEntry(ids = SimklShowIds(simkl = 39687L, tmdb = tmdbId)),
     )
 }

--- a/api/simkl/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/testing/FakeSimklRewatchRemoteDataSource.kt
+++ b/api/simkl/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/testing/FakeSimklRewatchRemoteDataSource.kt
@@ -2,6 +2,7 @@ package com.thomaskioko.tvmaniac.simkl.testing
 
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.simkl.api.SimklRewatchRemoteDataSource
+import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchCloseRequest
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchHistoryRequest
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchHistoryResponse
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklRewatchItemsResponse
@@ -13,7 +14,13 @@ public class FakeSimklRewatchRemoteDataSource : SimklRewatchRemoteDataSource {
     private var addRewatchHistoryResponse: ApiResponse<SimklRewatchHistoryResponse> =
         ApiResponse.Success(SimklRewatchHistoryResponse())
 
+    private var closeRewatchSessionResponse: ApiResponse<SimklRewatchHistoryResponse> =
+        ApiResponse.Success(SimklRewatchHistoryResponse())
+
     public var lastAddRewatchHistoryRequest: SimklRewatchHistoryRequest? = null
+        private set
+
+    public var lastCloseRewatchSessionRequest: SimklRewatchCloseRequest? = null
         private set
 
     public fun setRewatchSessionsResponse(response: ApiResponse<SimklRewatchItemsResponse>) {
@@ -24,11 +31,20 @@ public class FakeSimklRewatchRemoteDataSource : SimklRewatchRemoteDataSource {
         addRewatchHistoryResponse = response
     }
 
+    public fun setCloseRewatchSessionResponse(response: ApiResponse<SimklRewatchHistoryResponse>) {
+        closeRewatchSessionResponse = response
+    }
+
     override suspend fun getRewatchSessions(dateFrom: String?): ApiResponse<SimklRewatchItemsResponse> =
         rewatchSessionsResponse
 
     override suspend fun addRewatchHistory(request: SimklRewatchHistoryRequest): ApiResponse<SimklRewatchHistoryResponse> {
         lastAddRewatchHistoryRequest = request
         return addRewatchHistoryResponse
+    }
+
+    override suspend fun closeRewatchSession(request: SimklRewatchCloseRequest): ApiResponse<SimklRewatchHistoryResponse> {
+        lastCloseRewatchSessionRequest = request
+        return closeRewatchSessionResponse
     }
 }

--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktRewatchSyncProviderDataSource.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktRewatchSyncProviderDataSource.kt
@@ -3,6 +3,7 @@ package com.thomaskioko.trakt.service.implementation.sync
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.map
+import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchClose
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchSession
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchWrite
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchWriteResult
@@ -57,6 +58,8 @@ public class TraktRewatchSyncProviderDataSource(
                 ),
             ),
         ).map { RemoteRewatchWriteResult() }
+
+    override suspend fun closeRewatch(close: RemoteRewatchClose): ApiResponse<Unit> = ApiResponse.Success(Unit)
 }
 
 private fun TraktWatchedShowResponse.toRemoteRewatchSessions(): List<RemoteRewatchSession> =

--- a/api/trakt/implementation/src/commonTest/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktRewatchSyncProviderDataSourceTest.kt
+++ b/api/trakt/implementation/src/commonTest/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktRewatchSyncProviderDataSourceTest.kt
@@ -3,6 +3,7 @@ package com.thomaskioko.trakt.service.implementation.sync
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.getOrThrow
+import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchClose
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchWrite
 import com.thomaskioko.tvmaniac.trakt.api.model.ShowIds
 import com.thomaskioko.tvmaniac.trakt.api.model.TraktShowResponse
@@ -13,6 +14,7 @@ import com.thomaskioko.tvmaniac.trakt.testing.FakeTraktEpisodeHistoryRemoteDataS
 import com.thomaskioko.tvmaniac.trakt.testing.FakeTraktSyncRemoteDataSource
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
@@ -36,6 +38,15 @@ internal class TraktRewatchSyncProviderDataSourceTest {
     @Test
     fun `should always support rewatch`() = runTest {
         source.supportsRewatch() shouldBe true
+    }
+
+    @Test
+    fun `should send nothing given a rewatch session is closed`() = runTest {
+        val result = source.closeRewatch(RemoteRewatchClose(providerShowId = 1396L, providerSessionId = 7482L))
+
+        result.shouldBeInstanceOf<ApiResponse.Success<Unit>>()
+        episodeHistoryRemoteDataSource.lastAddedItems.shouldBeNull()
+        episodeHistoryRemoteDataSource.lastRemovedItems.shouldBeNull()
     }
 
     @Test

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Rewatch.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Rewatch.sq
@@ -65,6 +65,39 @@ UPDATE rewatch_session
 SET provider_session_id = :providerSessionId
 WHERE id = :sessionId;
 
+sessionByProviderSessionId:
+SELECT *
+FROM rewatch_session
+WHERE show_id = :showId AND provider_session_id = :providerSessionId;
+
+insertProviderSession:
+INSERT INTO rewatch_session(show_id, started_at, closed_at, provider_session_id)
+VALUES (:showId, :startedAt, :closedAt, :providerSessionId);
+
+mergeProviderSession:
+UPDATE rewatch_session
+SET started_at = MIN(started_at, :startedAt),
+    closed_at = COALESCE(:closedAt, closed_at)
+WHERE id = :sessionId;
+
+sessionCoverage:
+SELECT
+    (SELECT COUNT(DISTINCT rse.episode_id)
+     FROM rewatch_session_episode rse
+     INNER JOIN episode e ON rse.episode_id = e.id
+     INNER JOIN season s ON e.season_id = s.id
+     WHERE rse.session_id = rs.id
+       AND (s.season_number > 0 OR s.title != 'Specials')
+       AND (e.first_aired IS NULL OR e.first_aired <= strftime('%s', 'now') * 1000)) AS watched_in_session,
+    (SELECT COUNT(*)
+     FROM episode e
+     INNER JOIN season s ON e.season_id = s.id
+     WHERE e.show_id = rs.show_id
+       AND (s.season_number > 0 OR s.title != 'Specials')
+       AND (e.first_aired IS NULL OR e.first_aired <= strftime('%s', 'now') * 1000)) AS aired_total
+FROM rewatch_session rs
+WHERE rs.id = :sessionId;
+
 playCountForEpisode:
 SELECT COUNT(*) + 1 AS play_count
 FROM rewatch_session_episode

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RemoteRewatchClose.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RemoteRewatchClose.kt
@@ -1,0 +1,6 @@
+package com.thomaskioko.tvmaniac.data.rewatch.api
+
+public data class RemoteRewatchClose(
+    val providerShowId: Long,
+    val providerSessionId: Long,
+)

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RemoteRewatchSession.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RemoteRewatchSession.kt
@@ -4,10 +4,13 @@ package com.thomaskioko.tvmaniac.data.rewatch.api
  * A single rewatch session as reported by the active provider.
  *
  * The two providers fill this differently. Simkl returns one row per show: a session-level
- * aggregate with [providerSessionId] and [episodeCount] set, and [seasonNumber] and [episodeNumber]
- * null, since Simkl does not say which episodes made up the count. Trakt returns one row per
- * rewatched episode: [seasonNumber] and [episodeNumber] set, and [providerSessionId] null, since
- * Trakt has no session concept.
+ * aggregate with [providerSessionId], [episodeCount], [status] and [startedAt] set, and
+ * [seasonNumber] and [episodeNumber] null, since Simkl does not say which episodes made up the
+ * count. Trakt returns one row per rewatched episode: [seasonNumber] and [episodeNumber] set, and
+ * [providerSessionId] and [startedAt] null, since Trakt has no session concept.
+ *
+ * Only a session carrying a [providerSessionId] can be written to the local table, since that id is
+ * what makes a repeated sync land on the row it wrote last time.
  */
 public data class RemoteRewatchSession(
     val providerSessionId: Long?,
@@ -15,4 +18,6 @@ public data class RemoteRewatchSession(
     val episodeNumber: Long?,
     val episodeCount: Long?,
     val lastWatchedAt: Long?,
+    val status: RemoteRewatchSessionStatus = RemoteRewatchSessionStatus.ACTIVE,
+    val startedAt: Long? = null,
 )

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RemoteRewatchSessionStatus.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RemoteRewatchSessionStatus.kt
@@ -1,0 +1,22 @@
+package com.thomaskioko.tvmaniac.data.rewatch.api
+
+/**
+ * The state a provider reports for a rewatch session.
+ *
+ * An unrecognised value maps to [ACTIVE], since treating an unknown state as finished would close
+ * a session the user is still working through.
+ */
+public enum class RemoteRewatchSessionStatus {
+    ACTIVE,
+    CLOSED,
+    COMPLETED,
+    ;
+
+    public companion object {
+        public fun fromRaw(raw: String?): RemoteRewatchSessionStatus = when (raw) {
+            "closed" -> CLOSED
+            "completed" -> COMPLETED
+            else -> ACTIVE
+        }
+    }
+}

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchCoverage.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchCoverage.kt
@@ -1,0 +1,16 @@
+package com.thomaskioko.tvmaniac.data.rewatch.api
+
+/**
+ * How far a session has got through the show it belongs to, counting aired regular episodes only.
+ *
+ * [coversShow] follows Simkl's own rule for promoting a session to completed, so the local state
+ * and the provider's agree instead of drifting apart. A show with nothing aired covers nothing,
+ * which keeps a session on an unaired show from closing the moment it opens.
+ */
+public data class RewatchCoverage(
+    val watchedInSession: Long,
+    val airedTotal: Long,
+) {
+    public val coversShow: Boolean
+        get() = airedTotal > 0 && watchedInSession >= airedTotal
+}

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchRepository.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchRepository.kt
@@ -16,6 +16,8 @@ public interface RewatchRepository {
 
     public suspend fun closeSession(sessionId: Long, closedAt: Long)
 
+    public suspend fun finishSession(sessionId: Long, closedAt: Long)
+
     public fun observeSessionsForShow(showId: Long): Flow<List<RewatchSession>>
 
     public suspend fun openSessionForShow(showId: Long): RewatchSession?

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchSessionDao.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchSessionDao.kt
@@ -23,5 +23,14 @@ public interface RewatchSessionDao {
 
     public fun markEpisodeSynced(rowId: Long, syncedAt: Long)
 
+    public fun sessionCoverage(sessionId: Long): RewatchCoverage?
+
+    public fun upsertProviderSession(
+        showId: Long,
+        providerSessionId: Long,
+        startedAt: Long,
+        closedAt: Long?,
+    )
+
     public fun clearAll()
 }

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchSyncProviderDataSource.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchSyncProviderDataSource.kt
@@ -9,4 +9,6 @@ public interface RewatchSyncProviderDataSource : SyncProvider {
     public suspend fun readRewatchSessions(providerShowId: Long): ApiResponse<List<RemoteRewatchSession>>
 
     public suspend fun writeRewatch(write: RemoteRewatchWrite): ApiResponse<RemoteRewatchWriteResult>
+
+    public suspend fun closeRewatch(close: RemoteRewatchClose): ApiResponse<Unit>
 }

--- a/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchRepository.kt
+++ b/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchRepository.kt
@@ -1,7 +1,9 @@
 package com.thomaskioko.tvmaniac.data.rewatch.implementation
 
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchClose
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchSession
+import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchSessionStatus
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchWrite
 import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchRepository
 import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchSession
@@ -55,11 +57,36 @@ public class DefaultRewatchRepository(
                 episodeNumber = episodeNumber,
                 watchedAt = watchedAt,
             )
+            closeIfShowCovered(sessionId = sessionId, closedAt = watchedAt)
         }
     }
 
     override suspend fun closeSession(sessionId: Long, closedAt: Long) {
         rewatchSessionDao.closeSession(sessionId = sessionId, closedAt = closedAt)
+    }
+
+    override suspend fun finishSession(sessionId: Long, closedAt: Long) {
+        val session = rewatchSessionDao.sessionById(sessionId)
+        rewatchSessionDao.closeSession(sessionId = sessionId, closedAt = closedAt)
+
+        val providerSessionId = session?.providerSessionId ?: return
+        val providerShowId = tvShowsDao.getTmdbIdForLocalShowId(session.showId) ?: return
+
+        syncMutex.withLock {
+            val source = activeSource() ?: return@withLock
+            try {
+                val response = source.closeRewatch(
+                    RemoteRewatchClose(providerShowId = providerShowId, providerSessionId = providerSessionId),
+                )
+                if (response is ApiResponse.Error) {
+                    syncObserver.log(SyncError.BackgroundSyncFailed(operationId = TAG, cause = response.toThrowable()))
+                }
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (throwable: Throwable) {
+                syncObserver.log(SyncError.BackgroundSyncFailed(operationId = TAG, cause = throwable))
+            }
+        }
     }
 
     override fun observeSessionsForShow(showId: Long): Flow<List<RewatchSession>> {
@@ -84,7 +111,7 @@ public class DefaultRewatchRepository(
         val source = activeSource() ?: return@withLock emptyList()
         try {
             when (val response = source.readRewatchSessions(showId)) {
-                is ApiResponse.Success -> response.body
+                is ApiResponse.Success -> response.body.also { backfillSessions(showId = showId, sessions = it) }
                 is ApiResponse.Unauthenticated -> emptyList()
                 is ApiResponse.Error -> {
                     syncObserver.log(SyncError.BackgroundSyncFailed(operationId = TAG, cause = response.toThrowable()))
@@ -96,6 +123,33 @@ public class DefaultRewatchRepository(
         } catch (throwable: Throwable) {
             syncObserver.log(SyncError.BackgroundSyncFailed(operationId = TAG, cause = throwable))
             emptyList()
+        }
+    }
+
+    private fun closeIfShowCovered(sessionId: Long, closedAt: Long) {
+        val coverage = rewatchSessionDao.sessionCoverage(sessionId) ?: return
+        if (coverage.coversShow) {
+            rewatchSessionDao.closeSession(sessionId = sessionId, closedAt = closedAt)
+        }
+    }
+
+    private fun backfillSessions(showId: Long, sessions: List<RemoteRewatchSession>) {
+        val localShowId = tvShowsDao.getLocalShowIdByTmdbId(showId) ?: return
+
+        for (session in sessions) {
+            val providerSessionId = session.providerSessionId ?: continue
+            val startedAt = session.startedAt ?: session.lastWatchedAt ?: continue
+            rewatchSessionDao.upsertProviderSession(
+                showId = localShowId,
+                providerSessionId = providerSessionId,
+                startedAt = startedAt,
+                closedAt = when (session.status) {
+                    RemoteRewatchSessionStatus.ACTIVE -> null
+                    RemoteRewatchSessionStatus.CLOSED,
+                    RemoteRewatchSessionStatus.COMPLETED,
+                    -> session.lastWatchedAt ?: startedAt
+                },
+            )
         }
     }
 

--- a/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchSessionDao.kt
+++ b/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchSessionDao.kt
@@ -3,6 +3,7 @@ package com.thomaskioko.tvmaniac.data.rewatch.implementation
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
+import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchCoverage
 import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchSession
 import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchSessionDao
 import com.thomaskioko.tvmaniac.data.rewatch.api.UnsentRewatchEpisode
@@ -66,6 +67,40 @@ public class DefaultRewatchSessionDao(
 
     override fun markEpisodeSynced(rowId: Long, syncedAt: Long) {
         queries.markEpisodeSynced(rowId = rowId, syncedAt = syncedAt)
+    }
+
+    override fun sessionCoverage(sessionId: Long): RewatchCoverage? =
+        queries.sessionCoverage(sessionId).executeAsOneOrNull()?.let { row ->
+            RewatchCoverage(watchedInSession = row.watched_in_session, airedTotal = row.aired_total)
+        }
+
+    override fun upsertProviderSession(
+        showId: Long,
+        providerSessionId: Long,
+        startedAt: Long,
+        closedAt: Long?,
+    ) {
+        queries.transaction {
+            val existing = queries.sessionByProviderSessionId(
+                showId = Id(showId),
+                providerSessionId = providerSessionId,
+            ).executeAsOneOrNull()
+
+            if (existing == null) {
+                queries.insertProviderSession(
+                    showId = Id(showId),
+                    startedAt = startedAt,
+                    closedAt = closedAt,
+                    providerSessionId = providerSessionId,
+                )
+            } else {
+                queries.mergeProviderSession(
+                    startedAt = startedAt,
+                    closedAt = closedAt,
+                    sessionId = existing.id,
+                )
+            }
+        }
     }
 
     override fun clearAll() {

--- a/data/rewatch/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchRepositoryTest.kt
+++ b/data/rewatch/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchRepositoryTest.kt
@@ -5,6 +5,7 @@ import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchSession
+import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchSessionStatus
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchWriteResult
 import com.thomaskioko.tvmaniac.data.rewatch.testing.FakeRewatchSyncProviderDataSource
 import com.thomaskioko.tvmaniac.database.test.BaseDatabaseTest
@@ -21,6 +22,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -540,6 +542,179 @@ internal class DefaultRewatchRepositoryTest : BaseDatabaseTest() {
             repository.syncRewatchSessions(TMDB_ID)
         }
     }
+
+    @Test
+    fun `should close the session given the rewatch covers every aired episode`() = runTest {
+        val repository = buildRepository()
+        val sessionId = repository.startSession(showId = TMDB_ID, startedAt = STARTED_AT)!!
+
+        repository.addEpisodeToSession(
+            sessionId = sessionId,
+            showId = TMDB_ID,
+            episodeId = EPISODE_ID,
+            seasonNumber = 1L,
+            episodeNumber = 1L,
+            watchedAt = REWATCHED_AT,
+        )
+        repository.addEpisodeToSession(
+            sessionId = sessionId,
+            showId = TMDB_ID,
+            episodeId = SECOND_EPISODE_ID,
+            seasonNumber = 1L,
+            episodeNumber = 2L,
+            watchedAt = SECOND_REWATCHED_AT,
+        )
+
+        rewatchSessionDao.sessionById(sessionId)?.closedAt shouldBe SECOND_REWATCHED_AT
+    }
+
+    @Test
+    fun `should leave the session open given the rewatch covers only some aired episodes`() = runTest {
+        val repository = buildRepository()
+        val sessionId = repository.startSession(showId = TMDB_ID, startedAt = STARTED_AT)!!
+
+        repository.addEpisodeToSession(
+            sessionId = sessionId,
+            showId = TMDB_ID,
+            episodeId = EPISODE_ID,
+            seasonNumber = 1L,
+            episodeNumber = 1L,
+            watchedAt = REWATCHED_AT,
+        )
+
+        rewatchSessionDao.sessionById(sessionId)?.closedAt.shouldBeNull()
+    }
+
+    @Test
+    fun `should send a close to the active source given a session with a provider id is finished`() = runTest {
+        val repository = buildRepository()
+        val sessionId = repository.startSession(showId = TMDB_ID, startedAt = STARTED_AT)!!
+        rewatchSessionDao.setProviderSessionId(sessionId = sessionId, providerSessionId = PROVIDER_SESSION_ID)
+
+        repository.finishSession(sessionId = sessionId, closedAt = CLOSED_AT)
+
+        rewatchSyncProviderDataSource.lastClose.shouldNotBeNull().providerSessionId shouldBe PROVIDER_SESSION_ID
+        rewatchSessionDao.sessionById(sessionId)?.closedAt shouldBe CLOSED_AT
+    }
+
+    @Test
+    fun `should not send a close given the finished session has no provider id`() = runTest {
+        val repository = buildRepository()
+        val sessionId = repository.startSession(showId = TMDB_ID, startedAt = STARTED_AT)!!
+
+        repository.finishSession(sessionId = sessionId, closedAt = CLOSED_AT)
+
+        rewatchSyncProviderDataSource.lastClose.shouldBeNull()
+        rewatchSessionDao.sessionById(sessionId)?.closedAt shouldBe CLOSED_AT
+    }
+
+    @Test
+    fun `should not send a close given the session was closed by covering the show`() = runTest {
+        val repository = buildRepository()
+        val sessionId = repository.startSession(showId = TMDB_ID, startedAt = STARTED_AT)!!
+        rewatchSessionDao.setProviderSessionId(sessionId = sessionId, providerSessionId = PROVIDER_SESSION_ID)
+
+        repository.addEpisodeToSession(
+            sessionId = sessionId,
+            showId = TMDB_ID,
+            episodeId = EPISODE_ID,
+            seasonNumber = 1L,
+            episodeNumber = 1L,
+            watchedAt = REWATCHED_AT,
+        )
+        repository.addEpisodeToSession(
+            sessionId = sessionId,
+            showId = TMDB_ID,
+            episodeId = SECOND_EPISODE_ID,
+            seasonNumber = 1L,
+            episodeNumber = 2L,
+            watchedAt = SECOND_REWATCHED_AT,
+        )
+
+        rewatchSyncProviderDataSource.lastClose.shouldBeNull()
+    }
+
+    @Test
+    fun `should log a sync error given the close to the active source fails`() = runTest {
+        val repository = buildRepository()
+        val sessionId = repository.startSession(showId = TMDB_ID, startedAt = STARTED_AT)!!
+        rewatchSessionDao.setProviderSessionId(sessionId = sessionId, providerSessionId = PROVIDER_SESSION_ID)
+        rewatchSyncProviderDataSource.setCloseRewatchResponse(
+            ApiResponse.Error.HttpError(code = 500, errorBody = null, errorMessage = "boom"),
+        )
+
+        syncObserver.errors.test {
+            repository.finishSession(sessionId = sessionId, closedAt = CLOSED_AT)
+
+            awaitItem()
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `should write a local session given the provider reports one carrying a session id`() = runTest {
+        val repository = buildRepository()
+        rewatchSyncProviderDataSource.setReadRewatchSessionsResponse(
+            ApiResponse.Success(listOf(remoteSession(status = RemoteRewatchSessionStatus.CLOSED))),
+        )
+
+        repository.syncRewatchSessions(TMDB_ID)
+
+        val stored = rewatchSessionDao.observeSessionsForShow(localShowId).first()
+        stored.single().providerSessionId shouldBe PROVIDER_SESSION_ID
+        stored.single().startedAt shouldBe STARTED_AT
+        stored.single().closedAt shouldBe REWATCHED_AT
+    }
+
+    @Test
+    fun `should keep one local session given the same provider session syncs twice`() = runTest {
+        val repository = buildRepository()
+        rewatchSyncProviderDataSource.setReadRewatchSessionsResponse(
+            ApiResponse.Success(listOf(remoteSession(status = RemoteRewatchSessionStatus.CLOSED))),
+        )
+
+        repository.syncRewatchSessions(TMDB_ID)
+        repository.syncRewatchSessions(TMDB_ID)
+
+        rewatchSessionDao.observeSessionsForShow(localShowId).first().size shouldBe 1
+    }
+
+    @Test
+    fun `should leave a backfilled session open given the provider reports it active`() = runTest {
+        val repository = buildRepository()
+        rewatchSyncProviderDataSource.setReadRewatchSessionsResponse(
+            ApiResponse.Success(listOf(remoteSession(status = RemoteRewatchSessionStatus.ACTIVE))),
+        )
+
+        repository.syncRewatchSessions(TMDB_ID)
+
+        rewatchSessionDao.observeSessionsForShow(localShowId).first().single().closedAt.shouldBeNull()
+    }
+
+    @Test
+    fun `should write no local session given the provider reports one without a session id`() = runTest {
+        val repository = buildRepository()
+        rewatchSyncProviderDataSource.setReadRewatchSessionsResponse(
+            ApiResponse.Success(listOf(remoteSession(providerSessionId = null))),
+        )
+
+        repository.syncRewatchSessions(TMDB_ID)
+
+        rewatchSessionDao.observeSessionsForShow(localShowId).first().shouldBeEmpty()
+    }
+
+    private fun remoteSession(
+        providerSessionId: Long? = PROVIDER_SESSION_ID,
+        status: RemoteRewatchSessionStatus = RemoteRewatchSessionStatus.CLOSED,
+    ): RemoteRewatchSession = RemoteRewatchSession(
+        providerSessionId = providerSessionId,
+        seasonNumber = null,
+        episodeNumber = null,
+        episodeCount = 2L,
+        lastWatchedAt = REWATCHED_AT,
+        status = status,
+        startedAt = STARTED_AT,
+    )
 
     private fun buildRepository(
         activeSource: () -> FakeRewatchSyncProviderDataSource? = { rewatchSyncProviderDataSource },

--- a/data/rewatch/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/testing/FakeRewatchRepository.kt
+++ b/data/rewatch/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/testing/FakeRewatchRepository.kt
@@ -20,6 +20,9 @@ public class FakeRewatchRepository : RewatchRepository {
     public var lastAddEpisodeSessionId: Long? = null
         private set
 
+    public var finishedSessionId: Long? = null
+        private set
+
     public fun setSessionsForShow(showId: Long, sessions: List<RewatchSession>) {
         sessionsByShow.value += (showId to sessions)
     }
@@ -64,6 +67,11 @@ public class FakeRewatchRepository : RewatchRepository {
             if (session.id == sessionId) session.copy(closedAt = closedAt) else session
         }
         setSessionsForShow(showId, updated)
+    }
+
+    override suspend fun finishSession(sessionId: Long, closedAt: Long) {
+        finishedSessionId = sessionId
+        closeSession(sessionId = sessionId, closedAt = closedAt)
     }
 
     override fun observeSessionsForShow(showId: Long): Flow<List<RewatchSession>> =

--- a/data/rewatch/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/testing/FakeRewatchSyncProviderDataSource.kt
+++ b/data/rewatch/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/testing/FakeRewatchSyncProviderDataSource.kt
@@ -2,6 +2,7 @@ package com.thomaskioko.tvmaniac.data.rewatch.testing
 
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchClose
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchSession
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchWrite
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchWriteResult
@@ -17,8 +18,13 @@ public class FakeRewatchSyncProviderDataSource(
     private var writeHandler: ((RemoteRewatchWrite) -> ApiResponse<RemoteRewatchWriteResult>)? = null
     private var readException: Throwable? = null
     private var writeException: Throwable? = null
+    private var closeResponse: ApiResponse<Unit> = ApiResponse.Success(Unit)
+    private var closeException: Throwable? = null
 
     public var lastWrite: RemoteRewatchWrite? = null
+        private set
+
+    public var lastClose: RemoteRewatchClose? = null
         private set
 
     public fun setSupportsRewatch(value: Boolean) {
@@ -45,6 +51,14 @@ public class FakeRewatchSyncProviderDataSource(
         writeException = exception
     }
 
+    public fun setCloseRewatchResponse(response: ApiResponse<Unit>) {
+        closeResponse = response
+    }
+
+    public fun setCloseRewatchException(exception: Throwable) {
+        closeException = exception
+    }
+
     override suspend fun supportsRewatch(): Boolean = supportsRewatchValue
 
     override suspend fun readRewatchSessions(providerShowId: Long): ApiResponse<List<RemoteRewatchSession>> {
@@ -56,5 +70,11 @@ public class FakeRewatchSyncProviderDataSource(
         lastWrite = write
         writeException?.let { throw it }
         return writeHandler?.invoke(write) ?: writeResponse
+    }
+
+    override suspend fun closeRewatch(close: RemoteRewatchClose): ApiResponse<Unit> {
+        lastClose = close
+        closeException?.let { throw it }
+        return closeResponse
     }
 }

--- a/domain/rewatch/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/rewatch/FinishRewatchSessionInteractor.kt
+++ b/domain/rewatch/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/rewatch/FinishRewatchSessionInteractor.kt
@@ -10,7 +10,7 @@ public class FinishRewatchSessionInteractor(
 ) : Interactor<FinishRewatchSessionInteractor.Param>() {
 
     override suspend fun doWork(params: Param) {
-        rewatchRepository.closeSession(sessionId = params.sessionId, closedAt = params.closedAt)
+        rewatchRepository.finishSession(sessionId = params.sessionId, closedAt = params.closedAt)
     }
 
     public data class Param(


### PR DESCRIPTION
## Description
This PR finishes a rewatch session once it has covered every aired episode of a show, or when the viewer stops it early, and stores the rewatch sessions Simkl already knows about. Nothing is visible in the app yet; the show detail screen that starts and finishes a rewatch comes in the slice that follows.

## Changes
- Finish a session once the rewatch covers every aired regular episode, matching the rule Simkl uses so the local state and the provider agree.
- Tell Simkl when a viewer stops a rewatch early, since that is the only change Simkl cannot work out on its own.
- Send nothing to Trakt, which has no rewatch session of its own.
- Skip the write for a Simkl account on a tier that cannot accept it.
- Store the rewatch sessions Simkl reports, keyed on the session id it assigns, so a repeated sync lands on the row it wrote last time instead of adding another.
- Read the dates of the episodes in a Simkl session, so a stored session starts on the day the rewatch began rather than the day it was last watched.
