### PR TITLE
fix: Flaky Test

### DIFF
--- a/core/integration/ui/src/androidMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/ui/BaseRobot.kt
+++ b/core/integration/ui/src/androidMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/ui/BaseRobot.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.test.hasContentDescription as composeHasContentDescri
 
 public const val TIMEOUT_MILLIS: Long = 10_000
 
+private const val CLOCK_CATCH_UP_MILLIS: Long = 200
+
 /**
  * Base robot for integration tests.
  *
@@ -71,7 +73,7 @@ public abstract class BaseRobot<T : BaseRobot<T>>(protected val composeUi: Compo
         useUnmergedTree: Boolean = false,
         timeoutMillis: Long = TIMEOUT_MILLIS,
     ): T = self().apply {
-        composeUi.waitUntil(timeoutMillis = timeoutMillis) {
+        awaitCondition(timeoutMillis) {
             val nodes = fetchNodesSafely(matcher = hasTestTag(tag), useUnmergedTree = useUnmergedTree)
             nodes != null && nodes.size == 1
         }
@@ -82,9 +84,21 @@ public abstract class BaseRobot<T : BaseRobot<T>>(protected val composeUi: Compo
         useUnmergedTree: Boolean = false,
         timeoutMillis: Long = TIMEOUT_MILLIS,
     ): T = self().apply {
-        composeUi.waitUntil(timeoutMillis = timeoutMillis) {
+        awaitCondition(timeoutMillis) {
             val nodes = fetchNodesSafely(matcher = matcher, useUnmergedTree = useUnmergedTree)
             !nodes.isNullOrEmpty()
+        }
+    }
+
+    // App coroutines run on the Compose test scheduler, so work behind a `delay` resumes only as
+    // virtual time advances. waitUntil advances one frame per poll while counting its timeout in
+    // real milliseconds, so on a loaded machine a pending delay outlives the timeout.
+    private fun awaitCondition(timeoutMillis: Long, condition: () -> Boolean) {
+        composeUi.waitUntil(timeoutMillis = timeoutMillis) {
+            condition() || run {
+                composeUi.mainClock.advanceTimeBy(CLOCK_CATCH_UP_MILLIS)
+                condition()
+            }
         }
     }
 
@@ -280,7 +294,7 @@ public abstract class BaseRobot<T : BaseRobot<T>>(protected val composeUi: Compo
         useUnmergedTree: Boolean = false,
         timeoutMillis: Long = TIMEOUT_MILLIS,
     ): T = self().apply {
-        composeUi.waitUntil(timeoutMillis = timeoutMillis) {
+        awaitCondition(timeoutMillis) {
             val nodes = fetchNodesSafely(matcher = hasTestTag(tag), useUnmergedTree = useUnmergedTree)
             nodes != null && nodes.isEmpty()
         }
@@ -387,7 +401,7 @@ public abstract class BaseRobot<T : BaseRobot<T>>(protected val composeUi: Compo
 
     /** Asserts node with [tag] has exact text matching [text]. */
     public fun assertTextEquals(tag: String, text: String, useUnmergedTree: Boolean = false): T = self().apply {
-        composeUi.waitUntil(timeoutMillis = TIMEOUT_MILLIS) {
+        awaitCondition(TIMEOUT_MILLIS) {
             val nodes = fetchNodesSafely(
                 matcher = hasTestTag(tag) and hasText(text, substring = false, ignoreCase = true),
                 useUnmergedTree = useUnmergedTree,

--- a/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingState.kt
+++ b/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingState.kt
@@ -29,7 +29,7 @@ public data class ContinueWatchingState(
             watchNextEpisodes.isEmpty() && staleEpisodes.isEmpty()
 
     val showLoading: Boolean
-        get() = (isLoading || isSyncing) && isEmpty
+        get() = (isLoading || isSyncing) && isEmpty && query.isBlank()
 
     val showRefreshIndicator: Boolean
         get() = (isLoading || isSyncing || isRefreshing) && !isEmpty

--- a/features/continue-watching/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingPresenterTest.kt
+++ b/features/continue-watching/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingPresenterTest.kt
@@ -108,6 +108,20 @@ class ContinueWatchingPresenterTest {
     }
 
     @Test
+    fun `should show empty state instead of loading given a search query is active`() = runTest {
+        presenter.state.test {
+            awaitItem().showLoading shouldBe true
+
+            presenter.onQueryChanged("Zzzzz")
+
+            val searching = awaitItem()
+            searching.query shouldBe "Zzzzz"
+            searching.isEmpty shouldBe true
+            searching.showLoading shouldBe false
+        }
+    }
+
+    @Test
     fun `should show refresh indicator given syncing but content already present`() = runTest {
         presenter.state.test {
             awaitItem() shouldBe ContinueWatchingState()


### PR DESCRIPTION
## Description
This PR advances the Compose test clock while an integration test waits for a condition, so work behind a coroutine delay resumes at a rate that does not depend on how loaded the machine is.

## Bug Fixes
- Show the Continue Watching empty state when a search returns no matches, instead of a loading indicator, while a sync is running.
