### PR TITLE
fix: Hide watch again while a rewatch is in progress

### DIFF
--- a/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/header/ShowDetailsHeaderPresenter.kt
+++ b/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/header/ShowDetailsHeaderPresenter.kt
@@ -127,7 +127,7 @@ public class ShowDetailsHeaderPresenter internal constructor(
                 if (isInList) StringResourceKey.BtnInList else StringResourceKey.BtnAddToList,
             ),
             rewatchCount = rewatchStatus.finishedCount,
-            canWatchAgain = multiplePlaysEnabled && details.isInLibrary,
+            canWatchAgain = multiplePlaysEnabled && details.isInLibrary && rewatchStatus.openSession == null,
             showMoreSheet = current.showMoreSheet,
             showWatchAgainConfirmation = current.showWatchAgainConfirmation,
         )

--- a/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/header/ShowDetailsHeaderPresenterTest.kt
+++ b/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/header/ShowDetailsHeaderPresenterTest.kt
@@ -16,6 +16,7 @@ import com.thomaskioko.tvmaniac.data.library.testing.FakeLibraryRepository
 import com.thomaskioko.tvmaniac.data.ratings.api.RatingEntityType
 import com.thomaskioko.tvmaniac.data.ratings.api.ShowRating
 import com.thomaskioko.tvmaniac.data.ratings.testing.FakeRatingsRepository
+import com.thomaskioko.tvmaniac.data.rewatch.api.OpenRewatchSession
 import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchStatus
 import com.thomaskioko.tvmaniac.data.rewatch.testing.FakeRewatchRepository
 import com.thomaskioko.tvmaniac.data.showdetails.testing.FakeShowDetailsRepository
@@ -296,6 +297,26 @@ internal class ShowDetailsHeaderPresenterTest {
         datastoreRepository.saveMultiplePlaysEnabled(false)
 
         showDetailsRepository.setShowDetailsResult(tvShowDetails.copy(in_library = 1))
+
+        val presenter = buildPresenter()
+
+        presenter.state.test {
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            expectMostRecentItem().canWatchAgain shouldBe false
+        }
+    }
+
+    @Test
+    fun `should hide watch again given a rewatch is already under way`() = runTest {
+        showDetailsRepository.setShowDetailsResult(tvShowDetails.copy(in_library = 1))
+        rewatchRepository.setRewatchStatusForShow(
+            SHOW_ID,
+            RewatchStatus(
+                finishedCount = 1,
+                openSession = OpenRewatchSession(id = 1, watchedEpisodes = 2, airedEpisodes = 10),
+            ),
+        )
 
         val presenter = buildPresenter()
 


### PR DESCRIPTION
## Description
This PR hides the Watch again action on show details while a rewatch of that show is in progress. Starting a second rewatch has no effect until the first one closes, so the action no longer sits in the menu offering something it cannot do.
