### PR TITLE
feat: Record every time an episode is watched

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1303,9 +1303,11 @@ graph TB
   :features:episode-sheet:presenter --> :core:base
   :features:episode-sheet:presenter --> :core:logger:api
   :features:episode-sheet:presenter --> :core:view
+  :features:episode-sheet:presenter --> :data:datastore:api
   :features:episode-sheet:presenter --> :domain:episode
   :features:episode-sheet:presenter --> :domain:followedshows
   :features:episode-sheet:presenter --> :domain:ratings
+  :features:episode-sheet:presenter --> :domain:rewatch
   :features:episode-sheet:presenter --> :features:episode-sheet:nav
   :features:episode-sheet:presenter --> :features:rating-sheet:nav
   :features:episode-sheet:presenter -.-> :features:season-details:nav

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/sheet/EpisodeSheetFlowTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/sheet/EpisodeSheetFlowTest.kt
@@ -32,7 +32,7 @@ internal class EpisodeSheetFlowTest : BaseAppFlowTest() {
         openEpisodeSheetFromUpNextCard()
 
         episodeSheetRobot
-            .assertActionItemDisplayed(EpisodeSheetActionItem.TOGGLE_WATCHED)
+            .assertActionItemDisplayed(EpisodeSheetActionItem.MARK_WATCHED)
             .assertActionItemDisplayed(EpisodeSheetActionItem.OPEN_SHOW)
             .assertActionItemDisplayed(EpisodeSheetActionItem.OPEN_SEASON)
             .assertActionItemDisplayed(EpisodeSheetActionItem.UNFOLLOW)
@@ -68,13 +68,13 @@ internal class EpisodeSheetFlowTest : BaseAppFlowTest() {
     }
 
     @Test
-    fun givenEpisodeSheet_whenToggleWatchedClicked_thenMarksEpisodeWatched() = runAppFlowTest {
+    fun givenEpisodeSheet_whenMarkWatchedClicked_thenMarksEpisodeWatched() = runAppFlowTest {
         scenarios.stubAuthenticatedSync()
 
         openEpisodeSheetFromUpNextCard()
 
         episodeSheetRobot
-            .clickActionItem(EpisodeSheetActionItem.TOGGLE_WATCHED)
+            .clickActionItem(EpisodeSheetActionItem.MARK_WATCHED)
 
         homeRobot.clickMyShowsTab()
         watchlistRobot.clickShowCard(breakingBadTmdbId)

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/robot/EpisodeSheetRobot.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/robot/EpisodeSheetRobot.kt
@@ -14,7 +14,7 @@ internal class EpisodeSheetRobot(composeUi: ComposeUiTest) : BaseRobot<EpisodeSh
         awaitTagOnce(EpisodeSheetTestTags.SHEET_TEST_TAG, timeoutMillis = SHEET_APPEARANCE_TIMEOUT_MILLIS)
         assertDisplayed(EpisodeSheetTestTags.SHEET_TEST_TAG)
         awaitTagOnce(EpisodeSheetTestTags.TITLE_TEST_TAG)
-        awaitMatcherAtLeastOne(matcher = hasTestTag(EpisodeSheetTestTags.actionItem(EpisodeSheetActionItem.TOGGLE_WATCHED.name)))
+        awaitMatcherAtLeastOne(matcher = hasTestTag(EpisodeSheetTestTags.actionItem(EpisodeSheetActionItem.MARK_WATCHED.name)))
         waitForIdle()
     }
 

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Rewatch.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Rewatch.sq
@@ -98,8 +98,8 @@ SELECT
 FROM rewatch_session rs
 WHERE rs.id = :sessionId;
 
-playCountForEpisode:
-SELECT COUNT(*) + 1 AS play_count
+observeEpisodeRewatches:
+SELECT COUNT(*) AS rewatch_count
 FROM rewatch_session_episode
 WHERE episode_id = :episodeId;
 

--- a/data/logout/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/logout/implementation/DefaultLogoutHandlerTest.kt
+++ b/data/logout/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/logout/implementation/DefaultLogoutHandlerTest.kt
@@ -22,6 +22,7 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -173,10 +174,10 @@ internal class DefaultLogoutHandlerTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun `should reset the play count given clear called`() = runTest(testDispatcher) {
+    fun `should reset the rewatch count given clear called`() = runTest(testDispatcher) {
         cleaner.clear()
 
-        rewatchSessionDao.playCountForEpisode(REWATCHED_EPISODE_ID) shouldBe 1L
+        rewatchSessionDao.observeEpisodeRewatches(REWATCHED_EPISODE_ID).first() shouldBe 0L
     }
 
     @Test

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchRepository.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchRepository.kt
@@ -24,7 +24,7 @@ public interface RewatchRepository {
 
     public suspend fun openSessionForShow(showId: Long): RewatchSession?
 
-    public fun playCountForEpisode(episodeId: Long): Long
+    public fun observeEpisodeRewatches(episodeId: Long): Flow<Long>
 
     public suspend fun supportsRewatch(): Boolean
 

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchSessionDao.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchSessionDao.kt
@@ -19,7 +19,7 @@ public interface RewatchSessionDao {
 
     public fun setProviderSessionId(sessionId: Long, providerSessionId: Long)
 
-    public fun playCountForEpisode(episodeId: Long): Long
+    public fun observeEpisodeRewatches(episodeId: Long): Flow<Long>
 
     public fun unsentEpisodes(): List<UnsentRewatchEpisode>
 

--- a/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchRepository.kt
+++ b/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchRepository.kt
@@ -117,7 +117,7 @@ public class DefaultRewatchRepository(
         return rewatchSessionDao.openSessionForShow(localShowId)
     }
 
-    override fun playCountForEpisode(episodeId: Long): Long = rewatchSessionDao.playCountForEpisode(episodeId)
+    override fun observeEpisodeRewatches(episodeId: Long): Flow<Long> = rewatchSessionDao.observeEpisodeRewatches(episodeId)
 
     override suspend fun supportsRewatch(): Boolean = activeSource()?.supportsRewatch() ?: true
 

--- a/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchSessionDao.kt
+++ b/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchSessionDao.kt
@@ -2,6 +2,7 @@ package com.thomaskioko.tvmaniac.data.rewatch.implementation
 
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
+import app.cash.sqldelight.coroutines.mapToOne
 import app.cash.sqldelight.coroutines.mapToOneOrNull
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.data.rewatch.api.OpenRewatchSession
@@ -84,7 +85,10 @@ public class DefaultRewatchSessionDao(
         queries.setProviderSessionId(sessionId = sessionId, providerSessionId = providerSessionId)
     }
 
-    override fun playCountForEpisode(episodeId: Long): Long = queries.playCountForEpisode(Id(episodeId)).executeAsOne()
+    override fun observeEpisodeRewatches(episodeId: Long): Flow<Long> =
+        queries.observeEpisodeRewatches(Id(episodeId))
+            .asFlow()
+            .mapToOne(dispatchers.databaseRead)
 
     override fun unsentEpisodes(): List<UnsentRewatchEpisode> =
         queries.unsentEpisodes().executeAsList().map { it.toUnsentRewatchEpisode() }

--- a/data/rewatch/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchRepositoryTest.kt
+++ b/data/rewatch/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchRepositoryTest.kt
@@ -136,7 +136,7 @@ internal class DefaultRewatchRepositoryTest : BaseDatabaseTest() {
             watchedAt = REWATCHED_AT,
         )
 
-        repository.playCountForEpisode(EPISODE_ID) shouldBe 2L
+        repository.observeEpisodeRewatches(EPISODE_ID).first() shouldBe 1L
     }
 
     @Test

--- a/data/rewatch/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchSessionDaoTest.kt
+++ b/data/rewatch/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchSessionDaoTest.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
@@ -97,17 +98,17 @@ internal class DefaultRewatchSessionDaoTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun `should return one given no rewatch session exists for an episode`() = runTest {
-        dao.playCountForEpisode(EPISODE_ID) shouldBe 1L
+    fun `should return no rewatches given no rewatch session exists for an episode`() = runTest {
+        dao.observeEpisodeRewatches(EPISODE_ID).first() shouldBe 0L
     }
 
     @Test
-    fun `should return one plus session rows given an episode was watched again`() = runTest {
+    fun `should count the session row given an episode was watched again`() = runTest {
         val sessionId = dao.openSession(showId = showId, startedAt = STARTED_AT)
 
         dao.addEpisodeToSession(sessionId = sessionId, episodeId = EPISODE_ID, watchedAt = REWATCHED_AT)
 
-        dao.playCountForEpisode(EPISODE_ID) shouldBe 2L
+        dao.observeEpisodeRewatches(EPISODE_ID).first() shouldBe 1L
     }
 
     @Test
@@ -117,7 +118,7 @@ internal class DefaultRewatchSessionDaoTest : BaseDatabaseTest() {
         val secondSessionId = dao.openSession(showId = showId, startedAt = REWATCHED_AT)
         dao.addEpisodeToSession(sessionId = secondSessionId, episodeId = EPISODE_ID, watchedAt = SECOND_REWATCHED_AT)
 
-        dao.playCountForEpisode(EPISODE_ID) shouldBe 3L
+        dao.observeEpisodeRewatches(EPISODE_ID).first() shouldBe 2L
     }
 
     @Test
@@ -233,7 +234,7 @@ internal class DefaultRewatchSessionDaoTest : BaseDatabaseTest() {
             awaitItem().shouldBeEmpty()
             cancelAndConsumeRemainingEvents()
         }
-        dao.playCountForEpisode(EPISODE_ID) shouldBe 1L
+        dao.observeEpisodeRewatches(EPISODE_ID).first() shouldBe 0L
     }
 
     private fun addShow(tmdbId: Long): Long {

--- a/data/rewatch/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/testing/FakeRewatchRepository.kt
+++ b/data/rewatch/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/testing/FakeRewatchRepository.kt
@@ -13,7 +13,7 @@ public class FakeRewatchRepository : RewatchRepository {
 
     private var nextSessionId: Long = 1
     private val sessionsByShow = MutableStateFlow<Map<Long, List<RewatchSession>>>(emptyMap())
-    private val playCountsByEpisode = MutableStateFlow<Map<Long, Long>>(emptyMap())
+    private val rewatchesByEpisode = MutableStateFlow<Map<Long, Long>>(emptyMap())
     private val statusByShow = MutableStateFlow<Map<Long, RewatchStatus>>(emptyMap())
     private var supportsRewatchValue: Boolean = true
     private var remoteSessionsByShow: Map<Long, List<RemoteRewatchSession>> = emptyMap()
@@ -29,8 +29,8 @@ public class FakeRewatchRepository : RewatchRepository {
         sessionsByShow.value += (showId to sessions)
     }
 
-    public fun setPlayCountForEpisode(episodeId: Long, playCount: Long) {
-        playCountsByEpisode.value += (episodeId to playCount)
+    public fun setRewatchesForEpisode(episodeId: Long, rewatches: Long) {
+        rewatchesByEpisode.value += (episodeId to rewatches)
     }
 
     public fun setRewatchStatusForShow(showId: Long, status: RewatchStatus) {
@@ -89,7 +89,8 @@ public class FakeRewatchRepository : RewatchRepository {
     override suspend fun openSessionForShow(showId: Long): RewatchSession? =
         sessionsByShow.value[showId].orEmpty().firstOrNull { it.closedAt == null }
 
-    override fun playCountForEpisode(episodeId: Long): Long = playCountsByEpisode.value[episodeId] ?: 1L
+    override fun observeEpisodeRewatches(episodeId: Long): Flow<Long> =
+        rewatchesByEpisode.asStateFlow().map { it[episodeId] ?: 0L }
 
     override suspend fun supportsRewatch(): Boolean = supportsRewatchValue
 

--- a/domain/rewatch/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/rewatch/ObserveEpisodeRewatchesInteractor.kt
+++ b/domain/rewatch/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/rewatch/ObserveEpisodeRewatchesInteractor.kt
@@ -1,0 +1,15 @@
+package com.thomaskioko.tvmaniac.domain.rewatch
+
+import com.thomaskioko.tvmaniac.core.base.interactor.SubjectInteractor
+import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchRepository
+import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.flow.Flow
+
+@Inject
+public class ObserveEpisodeRewatchesInteractor(
+    private val rewatchRepository: RewatchRepository,
+) : SubjectInteractor<Long, Long>() {
+
+    override fun createObservable(params: Long): Flow<Long> =
+        rewatchRepository.observeEpisodeRewatches(params)
+}

--- a/domain/rewatch/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/rewatch/WatchAgainInteractor.kt
+++ b/domain/rewatch/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/rewatch/WatchAgainInteractor.kt
@@ -2,16 +2,19 @@ package com.thomaskioko.tvmaniac.domain.rewatch
 
 import com.thomaskioko.tvmaniac.core.base.interactor.Interactor
 import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchRepository
+import com.thomaskioko.tvmaniac.util.api.DateTimeProvider
 import dev.zacsweers.metro.Inject
 
 @Inject
 public class WatchAgainInteractor(
     private val rewatchRepository: RewatchRepository,
+    private val dateTimeProvider: DateTimeProvider,
 ) : Interactor<WatchAgainInteractor.Param>() {
 
     override suspend fun doWork(params: Param) {
+        val watchedAt = dateTimeProvider.nowMillis()
         val sessionId = rewatchRepository.openSessionForShow(params.showId)?.id
-            ?: rewatchRepository.startSession(showId = params.showId, startedAt = params.watchedAt)
+            ?: rewatchRepository.startSession(showId = params.showId, startedAt = watchedAt)
             ?: return
 
         rewatchRepository.addEpisodeToSession(
@@ -20,7 +23,7 @@ public class WatchAgainInteractor(
             episodeId = params.episodeId,
             seasonNumber = params.seasonNumber,
             episodeNumber = params.episodeNumber,
-            watchedAt = params.watchedAt,
+            watchedAt = watchedAt,
         )
     }
 
@@ -29,6 +32,5 @@ public class WatchAgainInteractor(
         val episodeId: Long,
         val seasonNumber: Long,
         val episodeNumber: Long,
-        val watchedAt: Long,
     )
 }

--- a/domain/rewatch/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/rewatch/WatchAgainInteractorTest.kt
+++ b/domain/rewatch/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/rewatch/WatchAgainInteractorTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import com.thomaskioko.tvmaniac.core.view.InvokeStarted
 import com.thomaskioko.tvmaniac.core.view.InvokeSuccess
 import com.thomaskioko.tvmaniac.data.rewatch.testing.FakeRewatchRepository
+import com.thomaskioko.tvmaniac.util.testing.FakeDateTimeProvider
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -11,9 +12,11 @@ import kotlin.test.Test
 internal class WatchAgainInteractorTest {
 
     private val rewatchRepository = FakeRewatchRepository()
+    private val dateTimeProvider = FakeDateTimeProvider()
 
     private val interactor = WatchAgainInteractor(
         rewatchRepository = rewatchRepository,
+        dateTimeProvider = dateTimeProvider,
     )
 
     @Test
@@ -59,13 +62,15 @@ internal class WatchAgainInteractorTest {
         rewatchRepository.lastAddEpisodeSessionId shouldBe firstSessionId
     }
 
-    private fun episodeWatch(watchedAt: Long): WatchAgainInteractor.Param = WatchAgainInteractor.Param(
-        showId = SHOW_ID,
-        episodeId = EPISODE_ID,
-        seasonNumber = 1L,
-        episodeNumber = 3L,
-        watchedAt = watchedAt,
-    )
+    private fun episodeWatch(watchedAt: Long): WatchAgainInteractor.Param {
+        dateTimeProvider.setCurrentTimeMillis(watchedAt)
+        return WatchAgainInteractor.Param(
+            showId = SHOW_ID,
+            episodeId = EPISODE_ID,
+            seasonNumber = 1L,
+            episodeNumber = 3L,
+        )
+    }
 
     private companion object {
         private const val SHOW_ID = 84958L

--- a/features/episode-sheet/presenter/README.md
+++ b/features/episode-sheet/presenter/README.md
@@ -30,6 +30,10 @@ graph TB
     direction TB
     :core:tasks:api[api]:::multiplatform
   end
+  subgraph :core:util
+    direction TB
+    :core:util:api[api]:::multiplatform
+  end
   subgraph :data:account-manager
     direction TB
     :data:account-manager:api[api]:::multiplatform
@@ -58,6 +62,10 @@ graph TB
     direction TB
     :data:ratings:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:subscription
     direction TB
     :data:subscription:api[api]:::multiplatform
@@ -71,6 +79,7 @@ graph TB
     :domain:episode[episode]:::multiplatform
     :domain:followedshows[followedshows]:::multiplatform
     :domain:ratings[ratings]:::multiplatform
+    :domain:rewatch[rewatch]:::multiplatform
   end
   subgraph :features:episode-sheet
     direction TB
@@ -118,6 +127,8 @@ graph TB
   :data:ratings:api --> :data:account-manager:api
   :data:ratings:api --> :data:database:sqldelight
   :data:ratings:api --> :data:followedshows:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :domain:episode --> :core:base
   :domain:episode --> :core:logger:api
   :domain:episode --> :core:syncstate:api
@@ -134,13 +145,18 @@ graph TB
   :domain:ratings --> :data:datastore:api
   :domain:ratings --> :data:ratings:api
   :domain:ratings --> :data:subscription:api
+  :domain:rewatch --> :core:base
+  :domain:rewatch --> :core:util:api
+  :domain:rewatch --> :data:rewatch:api
   :features:episode-sheet:nav --> :navigation:api
   :features:episode-sheet:presenter --> :core:base
   :features:episode-sheet:presenter --> :core:logger:api
   :features:episode-sheet:presenter --> :core:view
+  :features:episode-sheet:presenter --> :data:datastore:api
   :features:episode-sheet:presenter --> :domain:episode
   :features:episode-sheet:presenter --> :domain:followedshows
   :features:episode-sheet:presenter --> :domain:ratings
+  :features:episode-sheet:presenter --> :domain:rewatch
   :features:episode-sheet:presenter --> :features:episode-sheet:nav
   :features:episode-sheet:presenter --> :features:rating-sheet:nav
   :features:episode-sheet:presenter -.-> :features:season-details:nav

--- a/features/episode-sheet/presenter/build.gradle.kts
+++ b/features/episode-sheet/presenter/build.gradle.kts
@@ -18,6 +18,8 @@ kotlin {
                 api(projects.domain.episode)
                 api(projects.domain.followedshows)
                 api(projects.domain.ratings)
+                api(projects.data.datastore.api)
+                api(projects.domain.rewatch)
                 api(projects.features.episodeSheet.nav)
                 api(projects.features.ratingSheet.nav)
                 api(projects.i18n.api)
@@ -44,6 +46,8 @@ kotlin {
                 implementation(projects.data.library.testing)
                 implementation(projects.i18n.testing)
                 implementation(projects.data.datastore.testing)
+                implementation(projects.data.rewatch.testing)
+                implementation(projects.core.util.testing)
                 implementation(projects.data.subscription.testing)
                 implementation(projects.navigation.testing)
             }

--- a/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetAction.kt
+++ b/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetAction.kt
@@ -1,7 +1,8 @@
 package com.thomaskioko.tvmaniac.presentation.episodedetail
 
 public sealed interface EpisodeSheetAction {
-    public data object ToggleWatched : EpisodeSheetAction
+    public data object MarkWatched : EpisodeSheetAction
+    public data object MarkUnwatched : EpisodeSheetAction
     public data object OpenShow : EpisodeSheetAction
     public data object OpenSeason : EpisodeSheetAction
     public data object Unfollow : EpisodeSheetAction

--- a/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetMapper.kt
+++ b/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetMapper.kt
@@ -9,6 +9,8 @@ import kotlinx.collections.immutable.toImmutableList
 internal fun EpisodeById.toState(
     source: ScreenSource,
     localizer: Localizer,
+    multiplePlaysEnabled: Boolean,
+    rewatches: Long,
 ): EpisodeDetailSheetState {
     val isWatched = is_watched != 0L
     return EpisodeDetailSheetState(
@@ -21,16 +23,23 @@ internal fun EpisodeById.toState(
         rating = ratings.takeIf { it > 0 },
         voteCount = vote_count.takeIf { it > 0 },
         isWatched = isWatched,
-        availableActions = availableActions(source, isWatched, localizer),
+        playCount = if (isWatched) (rewatches + 1).toInt() else null,
+        availableActions = availableActions(source, isWatched, multiplePlaysEnabled, localizer),
     )
 }
 
 private fun availableActions(
     source: ScreenSource,
     isWatched: Boolean,
+    multiplePlaysEnabled: Boolean,
     localizer: Localizer,
 ) = buildList {
-    add(EpisodeSheetActionItem.TOGGLE_WATCHED.toUi(isWatched, localizer))
+    if (!isWatched || multiplePlaysEnabled) {
+        add(EpisodeSheetActionItem.MARK_WATCHED.toUi(isWatched, localizer))
+    }
+    if (isWatched) {
+        add(EpisodeSheetActionItem.MARK_UNWATCHED.toUi(isWatched, localizer))
+    }
     if (source != ScreenSource.SEASON_DETAILS) {
         add(EpisodeSheetActionItem.OPEN_SHOW.toUi(isWatched, localizer))
         add(EpisodeSheetActionItem.OPEN_SEASON.toUi(isWatched, localizer))
@@ -47,8 +56,9 @@ private fun EpisodeSheetActionItem.toUi(
 )
 
 private fun EpisodeSheetActionItem.labelKey(isWatched: Boolean): StringResourceKey = when (this) {
-    EpisodeSheetActionItem.TOGGLE_WATCHED ->
-        if (isWatched) StringResourceKey.LabelEpisodeActionMarkUnwatched else StringResourceKey.LabelEpisodeActionMarkWatched
+    EpisodeSheetActionItem.MARK_WATCHED ->
+        if (isWatched) StringResourceKey.LabelActionWatchAgain else StringResourceKey.LabelEpisodeActionMarkWatched
+    EpisodeSheetActionItem.MARK_UNWATCHED -> StringResourceKey.LabelEpisodeActionMarkUnwatched
     EpisodeSheetActionItem.OPEN_SHOW -> StringResourceKey.LabelEpisodeActionOpenShow
     EpisodeSheetActionItem.OPEN_SEASON -> StringResourceKey.LabelEpisodeActionOpenSeason
     EpisodeSheetActionItem.UNFOLLOW -> StringResourceKey.LabelEpisodeActionUnfollowShow

--- a/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenter.kt
+++ b/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenter.kt
@@ -5,6 +5,7 @@ import com.arkivanov.decompose.value.Value
 import com.thomaskioko.tvmaniac.core.base.ActivityScope
 import com.thomaskioko.tvmaniac.core.base.coroutines.AppScopeLauncher
 import com.thomaskioko.tvmaniac.core.base.extensions.asValue
+import com.thomaskioko.tvmaniac.core.base.extensions.combine
 import com.thomaskioko.tvmaniac.core.base.extensions.coroutineScope
 import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.core.view.ErrorToStringMapper
@@ -12,6 +13,7 @@ import com.thomaskioko.tvmaniac.core.view.ObservableLoadingCounter
 import com.thomaskioko.tvmaniac.core.view.UiMessageManager
 import com.thomaskioko.tvmaniac.core.view.collectStatus
 import com.thomaskioko.tvmaniac.data.ratings.api.RatingEntityType
+import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
 import com.thomaskioko.tvmaniac.db.EpisodeById
 import com.thomaskioko.tvmaniac.domain.episode.MarkEpisodeUnwatchedInteractor
 import com.thomaskioko.tvmaniac.domain.episode.MarkEpisodeUnwatchedParams
@@ -21,6 +23,8 @@ import com.thomaskioko.tvmaniac.domain.episode.ObserveEpisodeByIdInteractor
 import com.thomaskioko.tvmaniac.domain.followedshows.UnfollowShowInteractor
 import com.thomaskioko.tvmaniac.domain.ratings.ObserveRatingInteractor
 import com.thomaskioko.tvmaniac.domain.ratings.ShouldPromptForRatingInteractor
+import com.thomaskioko.tvmaniac.domain.rewatch.ObserveEpisodeRewatchesInteractor
+import com.thomaskioko.tvmaniac.domain.rewatch.WatchAgainInteractor
 import com.thomaskioko.tvmaniac.espisodedetails.nav.model.EpisodeSheetParam
 import com.thomaskioko.tvmaniac.espisodedetails.nav.model.EpisodeSheetRoute
 import com.thomaskioko.tvmaniac.i18n.api.Localizer
@@ -38,7 +42,6 @@ import io.github.thomaskioko.codegen.annotations.DestinationKind
 import io.github.thomaskioko.codegen.annotations.NavDestination
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -53,10 +56,13 @@ public class EpisodeSheetPresenter internal constructor(
     componentContext: ComponentContext,
     observeEpisodeByIdInteractor: ObserveEpisodeByIdInteractor,
     observeRatingInteractor: ObserveRatingInteractor,
+    private val observeEpisodeRewatchesInteractor: ObserveEpisodeRewatchesInteractor,
     private val navigator: Navigator,
     private val markEpisodeWatchedInteractor: MarkEpisodeWatchedInteractor,
     private val shouldPromptForRatingInteractor: ShouldPromptForRatingInteractor,
     private val markEpisodeUnwatchedInteractor: MarkEpisodeUnwatchedInteractor,
+    private val watchAgainInteractor: WatchAgainInteractor,
+    private val datastoreRepository: DatastoreRepository,
     private val unfollowShowInteractor: UnfollowShowInteractor,
     private val errorToStringMapper: ErrorToStringMapper,
     private val localizer: Localizer,
@@ -74,9 +80,16 @@ public class EpisodeSheetPresenter internal constructor(
         uiMessageManager.message,
         actionLoadingState.observable,
         observeRatingInteractor.flow,
-    ) { episode, message, isTogglingWatched, userRating ->
+        observeEpisodeRewatchesInteractor.flow,
+        datastoreRepository.observeMultiplePlaysEnabled(),
+    ) { episode, message, isTogglingWatched, userRating, rewatches, multiplePlaysEnabled ->
         currentEpisode = episode
-        val current = episode?.toState(param.source, localizer) ?: EpisodeDetailSheetState(isLoading = true)
+        val current = episode?.toState(
+            source = param.source,
+            localizer = localizer,
+            multiplePlaysEnabled = multiplePlaysEnabled,
+            rewatches = rewatches,
+        ) ?: EpisodeDetailSheetState(isLoading = true)
         current.copy(
             message = message,
             isTogglingWatched = isTogglingWatched,
@@ -93,11 +106,13 @@ public class EpisodeSheetPresenter internal constructor(
     init {
         observeEpisodeByIdInteractor(param.episodeId)
         observeRatingInteractor(ObserveRatingInteractor.Param(RatingEntityType.EPISODE, param.episodeId))
+        observeEpisodeRewatchesInteractor(param.episodeId)
     }
 
     public fun dispatch(action: EpisodeSheetAction) {
         when (action) {
-            is EpisodeSheetAction.ToggleWatched -> toggleWatched()
+            is EpisodeSheetAction.MarkWatched -> markWatched()
+            is EpisodeSheetAction.MarkUnwatched -> markUnwatched()
             is EpisodeSheetAction.OpenShow -> openShow()
             is EpisodeSheetAction.OpenSeason -> openSeason()
             is EpisodeSheetAction.Unfollow -> unfollowShow()
@@ -114,16 +129,18 @@ public class EpisodeSheetPresenter internal constructor(
         }
     }
 
-    private fun toggleWatched() {
+    private fun markWatched() {
         val episode = currentEpisode ?: return
         if (state.value.isTogglingWatched) return
         val wasWatched = episode.is_watched != 0L
         appScopeLauncher.launch(TAG) {
             val markStatus = if (wasWatched) {
-                markEpisodeUnwatchedInteractor(
-                    MarkEpisodeUnwatchedParams(
+                watchAgainInteractor(
+                    WatchAgainInteractor.Param(
                         showId = episode.show_id.id,
                         episodeId = episode.episode_id.id,
+                        seasonNumber = episode.season_number,
+                        episodeNumber = episode.episode_number,
                     ),
                 )
             } else {
@@ -156,6 +173,20 @@ public class EpisodeSheetPresenter internal constructor(
                     )
                 }
             }
+        }
+    }
+
+    private fun markUnwatched() {
+        val episode = currentEpisode ?: return
+        if (state.value.isTogglingWatched) return
+        appScopeLauncher.launch(TAG) {
+            markEpisodeUnwatchedInteractor(
+                MarkEpisodeUnwatchedParams(
+                    showId = episode.show_id.id,
+                    episodeId = episode.episode_id.id,
+                ),
+            ).collectStatus(actionLoadingState, logger, uiMessageManager, errorToStringMapper = errorToStringMapper)
+            coroutineScope.launch { navigator.dismissOverlay() }
         }
     }
 

--- a/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetState.kt
+++ b/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetState.kt
@@ -15,6 +15,7 @@ public data class EpisodeDetailSheetState(
     val voteCount: Long? = null,
     val isWatched: Boolean = false,
     val isTogglingWatched: Boolean = false,
+    val playCount: Int? = null,
     val userRating: Int? = null,
     val availableActions: ImmutableList<EpisodeSheetActionUi> = persistentListOf(),
     val message: UiMessage? = null,
@@ -26,7 +27,8 @@ public data class EpisodeSheetActionUi(
 )
 
 public enum class EpisodeSheetActionItem {
-    TOGGLE_WATCHED,
+    MARK_WATCHED,
+    MARK_UNWATCHED,
     OPEN_SHOW,
     OPEN_SEASON,
     UNFOLLOW,

--- a/features/episode-sheet/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenterTest.kt
+++ b/features/episode-sheet/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenterTest.kt
@@ -11,6 +11,7 @@ import com.thomaskioko.tvmaniac.data.library.testing.FakeLibraryRepository
 import com.thomaskioko.tvmaniac.data.ratings.api.EpisodeRating
 import com.thomaskioko.tvmaniac.data.ratings.api.RatingEntityType
 import com.thomaskioko.tvmaniac.data.ratings.testing.FakeRatingsRepository
+import com.thomaskioko.tvmaniac.data.rewatch.testing.FakeRewatchRepository
 import com.thomaskioko.tvmaniac.datastore.testing.FakeDatastoreRepository
 import com.thomaskioko.tvmaniac.db.EpisodeById
 import com.thomaskioko.tvmaniac.db.Id
@@ -20,6 +21,8 @@ import com.thomaskioko.tvmaniac.domain.episode.ObserveEpisodeByIdInteractor
 import com.thomaskioko.tvmaniac.domain.followedshows.UnfollowShowInteractor
 import com.thomaskioko.tvmaniac.domain.ratings.ObserveRatingInteractor
 import com.thomaskioko.tvmaniac.domain.ratings.ShouldPromptForRatingInteractor
+import com.thomaskioko.tvmaniac.domain.rewatch.ObserveEpisodeRewatchesInteractor
+import com.thomaskioko.tvmaniac.domain.rewatch.WatchAgainInteractor
 import com.thomaskioko.tvmaniac.episodes.testing.FakeEpisodeRepository
 import com.thomaskioko.tvmaniac.espisodedetails.nav.model.EpisodeSheetParam
 import com.thomaskioko.tvmaniac.espisodedetails.nav.model.ScreenSource
@@ -31,9 +34,11 @@ import com.thomaskioko.tvmaniac.ratingsheet.nav.RatingSheetRoute
 import com.thomaskioko.tvmaniac.seasondetails.nav.SeasonDetailsRoute
 import com.thomaskioko.tvmaniac.showdetails.nav.ShowDetailsRoute
 import com.thomaskioko.tvmaniac.subscription.testing.FakeSubscriptionManager
+import com.thomaskioko.tvmaniac.util.testing.FakeDateTimeProvider
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.CoroutineScope
@@ -60,6 +65,8 @@ internal class EpisodeSheetPresenterTest {
 
     private val navigator = FakeNavigator()
     private val datastoreRepository = FakeDatastoreRepository()
+    private val rewatchRepository = FakeRewatchRepository()
+    private val dateTimeProvider = FakeDateTimeProvider()
     private val shouldPromptForRatingInteractor = ShouldPromptForRatingInteractor(
         datastoreRepository = datastoreRepository,
         subscriptionManager = FakeSubscriptionManager(),
@@ -148,7 +155,7 @@ internal class EpisodeSheetPresenterTest {
             val state = awaitItem()
 
             state.availableActions.map { it.item } shouldContainExactly listOf(
-                EpisodeSheetActionItem.TOGGLE_WATCHED,
+                EpisodeSheetActionItem.MARK_WATCHED,
                 EpisodeSheetActionItem.OPEN_SHOW,
                 EpisodeSheetActionItem.OPEN_SEASON,
                 EpisodeSheetActionItem.UNFOLLOW,
@@ -168,7 +175,7 @@ internal class EpisodeSheetPresenterTest {
             val state = awaitItem()
 
             state.availableActions.map { it.item } shouldContainExactly listOf(
-                EpisodeSheetActionItem.TOGGLE_WATCHED,
+                EpisodeSheetActionItem.MARK_WATCHED,
                 EpisodeSheetActionItem.OPEN_SHOW,
                 EpisodeSheetActionItem.OPEN_SEASON,
                 EpisodeSheetActionItem.UNFOLLOW,
@@ -188,7 +195,7 @@ internal class EpisodeSheetPresenterTest {
             val state = awaitItem()
 
             state.availableActions.map { it.item } shouldContainExactly listOf(
-                EpisodeSheetActionItem.TOGGLE_WATCHED,
+                EpisodeSheetActionItem.MARK_WATCHED,
                 EpisodeSheetActionItem.OPEN_SHOW,
                 EpisodeSheetActionItem.OPEN_SEASON,
                 EpisodeSheetActionItem.UNFOLLOW,
@@ -197,7 +204,7 @@ internal class EpisodeSheetPresenterTest {
     }
 
     @Test
-    fun `should show only toggle watched given source is SEASON_DETAILS`() = runTest {
+    fun `should show only the watched action given source is SEASON_DETAILS`() = runTest {
         episodeRepository.setEpisodeById(testEpisode())
 
         val presenter = createPresenter(source = ScreenSource.SEASON_DETAILS)
@@ -208,13 +215,13 @@ internal class EpisodeSheetPresenterTest {
             val state = awaitItem()
 
             state.availableActions.map { it.item } shouldContainExactly listOf(
-                EpisodeSheetActionItem.TOGGLE_WATCHED,
+                EpisodeSheetActionItem.MARK_WATCHED,
             )
         }
     }
 
     @Test
-    fun `should mark episode as watched given ToggleWatched is dispatched and episode is unwatched`() = runTest {
+    fun `should mark episode as watched given MarkWatched is dispatched and episode is unwatched`() = runTest {
         episodeRepository.setEpisodeById(testEpisode(isWatched = false))
 
         val presenter = createPresenter()
@@ -224,7 +231,7 @@ internal class EpisodeSheetPresenterTest {
             testDispatcher.scheduler.advanceUntilIdle()
             awaitItem()
 
-            presenter.dispatch(EpisodeSheetAction.ToggleWatched)
+            presenter.dispatch(EpisodeSheetAction.MarkWatched)
             testDispatcher.scheduler.advanceUntilIdle()
 
             val call = episodeRepository.lastMarkEpisodeWatchedCall
@@ -252,7 +259,7 @@ internal class EpisodeSheetPresenterTest {
             testDispatcher.scheduler.advanceUntilIdle()
             awaitItem()
 
-            presenter.dispatch(EpisodeSheetAction.ToggleWatched)
+            presenter.dispatch(EpisodeSheetAction.MarkWatched)
             testDispatcher.scheduler.advanceUntilIdle()
 
             val route = navigator.lastActivatedOverlay.shouldBeInstanceOf<RatingSheetRoute>()
@@ -273,7 +280,7 @@ internal class EpisodeSheetPresenterTest {
             testDispatcher.scheduler.advanceUntilIdle()
             awaitItem()
 
-            presenter.dispatch(EpisodeSheetAction.ToggleWatched)
+            presenter.dispatch(EpisodeSheetAction.MarkWatched)
             testDispatcher.scheduler.advanceUntilIdle()
 
             navigator.activatedOverlays.shouldBeEmpty()
@@ -282,7 +289,7 @@ internal class EpisodeSheetPresenterTest {
     }
 
     @Test
-    fun `should not open the rating sheet given the episode is marked unwatched`() = runTest {
+    fun `should not open the rating sheet given the episode is watched again`() = runTest {
         datastoreRepository.saveQuickRateEnabled(true)
         episodeRepository.setEpisodeById(testEpisode(isWatched = true))
 
@@ -293,7 +300,7 @@ internal class EpisodeSheetPresenterTest {
             testDispatcher.scheduler.advanceUntilIdle()
             awaitItem()
 
-            presenter.dispatch(EpisodeSheetAction.ToggleWatched)
+            presenter.dispatch(EpisodeSheetAction.MarkWatched)
             testDispatcher.scheduler.advanceUntilIdle()
 
             navigator.activatedOverlays.shouldBeEmpty()
@@ -302,7 +309,7 @@ internal class EpisodeSheetPresenterTest {
     }
 
     @Test
-    fun `should mark episode as unwatched given ToggleWatched is dispatched and episode is watched`() = runTest {
+    fun `should mark episode as unwatched given MarkUnwatched is dispatched`() = runTest {
         episodeRepository.setEpisodeById(testEpisode(isWatched = true))
 
         val presenter = createPresenter()
@@ -312,7 +319,7 @@ internal class EpisodeSheetPresenterTest {
             testDispatcher.scheduler.advanceUntilIdle()
             awaitItem()
 
-            presenter.dispatch(EpisodeSheetAction.ToggleWatched)
+            presenter.dispatch(EpisodeSheetAction.MarkUnwatched)
             testDispatcher.scheduler.advanceUntilIdle()
 
             val call = episodeRepository.lastMarkEpisodeUnwatchedCall
@@ -326,7 +333,7 @@ internal class EpisodeSheetPresenterTest {
     }
 
     @Test
-    fun `should keep sheet until mark completes then dismiss given ToggleWatched is dispatched`() = runTest {
+    fun `should keep sheet until mark completes then dismiss given MarkWatched is dispatched`() = runTest {
         episodeRepository.setEpisodeById(testEpisode(isWatched = false))
 
         val presenter = createPresenter()
@@ -336,7 +343,7 @@ internal class EpisodeSheetPresenterTest {
             testDispatcher.scheduler.advanceUntilIdle()
             awaitItem()
 
-            presenter.dispatch(EpisodeSheetAction.ToggleWatched)
+            presenter.dispatch(EpisodeSheetAction.MarkWatched)
 
             navigator.overlayDismissCount shouldBe 0
             episodeRepository.lastMarkEpisodeWatchedCall.shouldBeNull()
@@ -482,6 +489,9 @@ internal class EpisodeSheetPresenterTest {
             markEpisodeWatchedInteractor = MarkEpisodeWatchedInteractor(episodeRepository),
             shouldPromptForRatingInteractor = shouldPromptForRatingInteractor,
             markEpisodeUnwatchedInteractor = MarkEpisodeUnwatchedInteractor(episodeRepository),
+            observeEpisodeRewatchesInteractor = ObserveEpisodeRewatchesInteractor(rewatchRepository),
+            watchAgainInteractor = WatchAgainInteractor(rewatchRepository, dateTimeProvider),
+            datastoreRepository = datastoreRepository,
             unfollowShowInteractor = UnfollowShowInteractor(
                 followedShowsRepository = followedShowsRepository,
                 libraryRepository = FakeLibraryRepository(),
@@ -492,6 +502,123 @@ internal class EpisodeSheetPresenterTest {
             logger = logger,
             appScopeLauncher = appScopeLauncher,
         )
+    }
+
+    @Test
+    fun `should report no play count given the episode was never watched`() = runTest {
+        episodeRepository.setEpisodeById(testEpisode(isWatched = false))
+
+        val presenter = createPresenter()
+
+        presenter.state.test {
+            awaitItem()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            expectMostRecentItem().playCount.shouldBeNull()
+        }
+    }
+
+    @Test
+    fun `should report one play given the episode was watched once`() = runTest {
+        episodeRepository.setEpisodeById(testEpisode(isWatched = true))
+
+        val presenter = createPresenter()
+
+        presenter.state.test {
+            awaitItem()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            expectMostRecentItem().playCount shouldBe 1
+        }
+    }
+
+    @Test
+    fun `should count every viewing given the episode was watched again`() = runTest {
+        episodeRepository.setEpisodeById(testEpisode(isWatched = true))
+        rewatchRepository.setRewatchesForEpisode(episodeId = 1L, rewatches = 2L)
+
+        val presenter = createPresenter()
+
+        presenter.state.test {
+            awaitItem()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            expectMostRecentItem().playCount shouldBe 3
+        }
+    }
+
+    @Test
+    fun `should offer removing a viewing given the episode is watched`() = runTest {
+        episodeRepository.setEpisodeById(testEpisode(isWatched = true))
+
+        val presenter = createPresenter(source = ScreenSource.SEASON_DETAILS)
+
+        presenter.state.test {
+            awaitItem()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            expectMostRecentItem().availableActions.map { it.item } shouldContainExactly listOf(
+                EpisodeSheetActionItem.MARK_WATCHED,
+                EpisodeSheetActionItem.MARK_UNWATCHED,
+            )
+        }
+    }
+
+    @Test
+    fun `should hide the watched action given the episode is watched and multiple plays are off`() = runTest {
+        datastoreRepository.saveMultiplePlaysEnabled(false)
+        episodeRepository.setEpisodeById(testEpisode(isWatched = true))
+
+        val presenter = createPresenter(source = ScreenSource.SEASON_DETAILS)
+
+        presenter.state.test {
+            awaitItem()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            expectMostRecentItem().availableActions.map { it.item } shouldContainExactly listOf(
+                EpisodeSheetActionItem.MARK_UNWATCHED,
+            )
+        }
+    }
+
+    @Test
+    fun `should record a viewing given the episode is watched again`() = runTest {
+        episodeRepository.setEpisodeById(testEpisode(isWatched = true))
+
+        val presenter = createPresenter()
+
+        presenter.state.test {
+            awaitItem()
+            testDispatcher.scheduler.advanceUntilIdle()
+            awaitItem()
+
+            presenter.dispatch(EpisodeSheetAction.MarkWatched)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            rewatchRepository.lastAddEpisodeSessionId.shouldNotBeNull()
+            episodeRepository.lastMarkEpisodeUnwatchedCall.shouldBeNull()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `should reuse the open session given a rewatch is already under way`() = runTest {
+        episodeRepository.setEpisodeById(testEpisode(isWatched = true))
+        val sessionId = rewatchRepository.startSession(showId = 100L, startedAt = 1L)
+
+        val presenter = createPresenter()
+
+        presenter.state.test {
+            awaitItem()
+            testDispatcher.scheduler.advanceUntilIdle()
+            awaitItem()
+
+            presenter.dispatch(EpisodeSheetAction.MarkWatched)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            rewatchRepository.lastAddEpisodeSessionId shouldBe sessionId
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     private fun testEpisode(

--- a/features/episode-sheet/ui/README.md
+++ b/features/episode-sheet/ui/README.md
@@ -32,6 +32,10 @@ graph TB
     direction TB
     :core:tasks:api[api]:::multiplatform
   end
+  subgraph :core:util
+    direction TB
+    :core:util:api[api]:::multiplatform
+  end
   subgraph :data:account-manager
     direction TB
     :data:account-manager:api[api]:::multiplatform
@@ -60,6 +64,10 @@ graph TB
     direction TB
     :data:ratings:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:subscription
     direction TB
     :data:subscription:api[api]:::multiplatform
@@ -73,6 +81,7 @@ graph TB
     :domain:episode[episode]:::multiplatform
     :domain:followedshows[followedshows]:::multiplatform
     :domain:ratings[ratings]:::multiplatform
+    :domain:rewatch[rewatch]:::multiplatform
     :domain:theme[theme]:::multiplatform
   end
   subgraph :features:episode-sheet
@@ -126,6 +135,8 @@ graph TB
   :data:ratings:api --> :data:account-manager:api
   :data:ratings:api --> :data:database:sqldelight
   :data:ratings:api --> :data:followedshows:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :domain:episode --> :core:base
   :domain:episode --> :core:logger:api
   :domain:episode --> :core:syncstate:api
@@ -142,14 +153,19 @@ graph TB
   :domain:ratings --> :data:datastore:api
   :domain:ratings --> :data:ratings:api
   :domain:ratings --> :data:subscription:api
+  :domain:rewatch --> :core:base
+  :domain:rewatch --> :core:util:api
+  :domain:rewatch --> :data:rewatch:api
   :domain:theme --> :i18n:generator
   :features:episode-sheet:nav --> :navigation:api
   :features:episode-sheet:presenter --> :core:base
   :features:episode-sheet:presenter --> :core:logger:api
   :features:episode-sheet:presenter --> :core:view
+  :features:episode-sheet:presenter --> :data:datastore:api
   :features:episode-sheet:presenter --> :domain:episode
   :features:episode-sheet:presenter --> :domain:followedshows
   :features:episode-sheet:presenter --> :domain:ratings
+  :features:episode-sheet:presenter --> :domain:rewatch
   :features:episode-sheet:presenter --> :features:episode-sheet:nav
   :features:episode-sheet:presenter --> :features:rating-sheet:nav
   :features:episode-sheet:presenter -.-> :features:season-details:nav

--- a/features/episode-sheet/ui/src/main/java/com/thomaskioko/tvmaniac/episodedetail/ui/EpisodeSheet.kt
+++ b/features/episode-sheet/ui/src/main/java/com/thomaskioko/tvmaniac/episodedetail/ui/EpisodeSheet.kt
@@ -3,6 +3,7 @@ package com.thomaskioko.tvmaniac.episodedetail.ui
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.LinkOff
 import androidx.compose.material.icons.outlined.Movie
 import androidx.compose.material.icons.outlined.StarOutline
@@ -84,7 +85,7 @@ private fun EpisodeSheetActions(
     val performHaptic = rememberHapticFeedback()
 
     state.availableActions.forEachIndexed { index, action ->
-        val isToggling = action.item == EpisodeSheetActionItem.TOGGLE_WATCHED && state.isTogglingWatched
+        val isToggling = action.item == EpisodeSheetActionItem.MARK_WATCHED && state.isTogglingWatched
         SheetActionItem(
             modifier = Modifier.testTag(EpisodeSheetTestTags.actionItem(action.item.name)),
             icon = action.item.icon,
@@ -92,7 +93,7 @@ private fun EpisodeSheetActions(
             enabled = !isToggling,
             showProgress = isToggling,
             onClick = {
-                if (action.item == EpisodeSheetActionItem.TOGGLE_WATCHED) performHaptic()
+                if (action.item == EpisodeSheetActionItem.MARK_WATCHED) performHaptic()
                 onAction(action.item.toAction())
             },
         )
@@ -123,14 +124,16 @@ internal fun EpisodeDetailSheetState.toEpisodeDetailInfo() = EpisodeDetailInfo(
 
 private val EpisodeSheetActionItem.icon: ImageVector
     get() = when (this) {
-        EpisodeSheetActionItem.TOGGLE_WATCHED -> Icons.Outlined.Check
+        EpisodeSheetActionItem.MARK_WATCHED -> Icons.Outlined.Check
+        EpisodeSheetActionItem.MARK_UNWATCHED -> Icons.Outlined.Close
         EpisodeSheetActionItem.OPEN_SHOW -> Icons.Outlined.Tv
         EpisodeSheetActionItem.OPEN_SEASON -> Icons.Outlined.Movie
         EpisodeSheetActionItem.UNFOLLOW -> Icons.Outlined.LinkOff
     }
 
 private fun EpisodeSheetActionItem.toAction(): EpisodeSheetAction = when (this) {
-    EpisodeSheetActionItem.TOGGLE_WATCHED -> EpisodeSheetAction.ToggleWatched
+    EpisodeSheetActionItem.MARK_WATCHED -> EpisodeSheetAction.MarkWatched
+    EpisodeSheetActionItem.MARK_UNWATCHED -> EpisodeSheetAction.MarkUnwatched
     EpisodeSheetActionItem.OPEN_SHOW -> EpisodeSheetAction.OpenShow
     EpisodeSheetActionItem.OPEN_SEASON -> EpisodeSheetAction.OpenSeason
     EpisodeSheetActionItem.UNFOLLOW -> EpisodeSheetAction.Unfollow
@@ -151,7 +154,7 @@ private fun EpisodeDetailContentAllActionsPreview() {
             voteCount = 1234,
             isWatched = false,
             availableActions = persistentListOf(
-                EpisodeSheetActionUi(EpisodeSheetActionItem.TOGGLE_WATCHED, "Mark watched"),
+                EpisodeSheetActionUi(EpisodeSheetActionItem.MARK_WATCHED, "Mark watched"),
                 EpisodeSheetActionUi(EpisodeSheetActionItem.OPEN_SHOW, "Open show"),
                 EpisodeSheetActionUi(EpisodeSheetActionItem.OPEN_SEASON, "Open season"),
                 EpisodeSheetActionUi(EpisodeSheetActionItem.UNFOLLOW, "Unfollow show"),
@@ -176,7 +179,7 @@ private fun EpisodeDetailContentRatedPreview() {
             isWatched = true,
             userRating = 9,
             availableActions = persistentListOf(
-                EpisodeSheetActionUi(EpisodeSheetActionItem.TOGGLE_WATCHED, "Mark unwatched"),
+                EpisodeSheetActionUi(EpisodeSheetActionItem.MARK_WATCHED, "Mark unwatched"),
                 EpisodeSheetActionUi(EpisodeSheetActionItem.OPEN_SHOW, "Open show"),
                 EpisodeSheetActionUi(EpisodeSheetActionItem.OPEN_SEASON, "Open season"),
                 EpisodeSheetActionUi(EpisodeSheetActionItem.UNFOLLOW, "Unfollow show"),
@@ -200,7 +203,7 @@ private fun EpisodeDetailContentWatchedPreview() {
             voteCount = 856,
             isWatched = true,
             availableActions = persistentListOf(
-                EpisodeSheetActionUi(EpisodeSheetActionItem.TOGGLE_WATCHED, "Mark unwatched"),
+                EpisodeSheetActionUi(EpisodeSheetActionItem.MARK_WATCHED, "Mark unwatched"),
                 EpisodeSheetActionUi(EpisodeSheetActionItem.OPEN_SHOW, "Open show"),
                 EpisodeSheetActionUi(EpisodeSheetActionItem.OPEN_SEASON, "Open season"),
                 EpisodeSheetActionUi(EpisodeSheetActionItem.UNFOLLOW, "Unfollow show"),
@@ -222,7 +225,7 @@ private fun EpisodeDetailContentSeasonDetailsPreview() {
             overview = "King Viserys hosts a tournament to celebrate the birth of his heir.",
             isWatched = false,
             availableActions = persistentListOf(
-                EpisodeSheetActionUi(EpisodeSheetActionItem.TOGGLE_WATCHED, "Mark watched"),
+                EpisodeSheetActionUi(EpisodeSheetActionItem.MARK_WATCHED, "Mark watched"),
             ),
         ),
     )

--- a/features/episode-sheet/ui/src/test/kotlin/com/thomaskioko/tvmaniac/episodedetail/roborrazi/EpisodeSheetScreenshotTest.kt
+++ b/features/episode-sheet/ui/src/test/kotlin/com/thomaskioko/tvmaniac/episodedetail/roborrazi/EpisodeSheetScreenshotTest.kt
@@ -42,7 +42,7 @@ class EpisodeSheetScreenshotTest {
                         voteCount = 1234,
                         isWatched = false,
                         availableActions = persistentListOf(
-                            EpisodeSheetActionUi(EpisodeSheetActionItem.TOGGLE_WATCHED, "Mark watched"),
+                            EpisodeSheetActionUi(EpisodeSheetActionItem.MARK_WATCHED, "Mark watched"),
                             EpisodeSheetActionUi(EpisodeSheetActionItem.OPEN_SHOW, "Open show"),
                             EpisodeSheetActionUi(EpisodeSheetActionItem.OPEN_SEASON, "Open season"),
                             EpisodeSheetActionUi(EpisodeSheetActionItem.UNFOLLOW, "Unfollow show"),
@@ -69,7 +69,7 @@ class EpisodeSheetScreenshotTest {
                         isWatched = true,
                         userRating = 9,
                         availableActions = persistentListOf(
-                            EpisodeSheetActionUi(EpisodeSheetActionItem.TOGGLE_WATCHED, "Mark unwatched"),
+                            EpisodeSheetActionUi(EpisodeSheetActionItem.MARK_WATCHED, "Mark unwatched"),
                             EpisodeSheetActionUi(EpisodeSheetActionItem.OPEN_SHOW, "Open show"),
                             EpisodeSheetActionUi(EpisodeSheetActionItem.OPEN_SEASON, "Open season"),
                             EpisodeSheetActionUi(EpisodeSheetActionItem.UNFOLLOW, "Unfollow show"),
@@ -95,7 +95,7 @@ class EpisodeSheetScreenshotTest {
                         voteCount = 856,
                         isWatched = true,
                         availableActions = persistentListOf(
-                            EpisodeSheetActionUi(EpisodeSheetActionItem.TOGGLE_WATCHED, "Mark unwatched"),
+                            EpisodeSheetActionUi(EpisodeSheetActionItem.MARK_WATCHED, "Mark unwatched"),
                             EpisodeSheetActionUi(EpisodeSheetActionItem.OPEN_SHOW, "Open show"),
                             EpisodeSheetActionUi(EpisodeSheetActionItem.OPEN_SEASON, "Open season"),
                             EpisodeSheetActionUi(EpisodeSheetActionItem.UNFOLLOW, "Unfollow show"),
@@ -119,7 +119,7 @@ class EpisodeSheetScreenshotTest {
                         overview = "King Viserys hosts a tournament to celebrate the birth of his heir.",
                         isWatched = false,
                         availableActions = persistentListOf(
-                            EpisodeSheetActionUi(EpisodeSheetActionItem.TOGGLE_WATCHED, "Mark watched"),
+                            EpisodeSheetActionUi(EpisodeSheetActionItem.MARK_WATCHED, "Mark watched"),
                         ),
                     ),
                 )
@@ -141,7 +141,7 @@ class EpisodeSheetScreenshotTest {
                         voteCount = 2500,
                         isWatched = false,
                         availableActions = persistentListOf(
-                            EpisodeSheetActionUi(EpisodeSheetActionItem.TOGGLE_WATCHED, "Mark watched"),
+                            EpisodeSheetActionUi(EpisodeSheetActionItem.MARK_WATCHED, "Mark watched"),
                             EpisodeSheetActionUi(EpisodeSheetActionItem.OPEN_SHOW, "Open show"),
                             EpisodeSheetActionUi(EpisodeSheetActionItem.OPEN_SEASON, "Open season"),
                             EpisodeSheetActionUi(EpisodeSheetActionItem.UNFOLLOW, "Unfollow show"),

--- a/ios-framework/README.md
+++ b/ios-framework/README.md
@@ -1073,9 +1073,11 @@ graph TB
   :features:episode-sheet:presenter --> :core:base
   :features:episode-sheet:presenter --> :core:logger:api
   :features:episode-sheet:presenter --> :core:view
+  :features:episode-sheet:presenter --> :data:datastore:api
   :features:episode-sheet:presenter --> :domain:episode
   :features:episode-sheet:presenter --> :domain:followedshows
   :features:episode-sheet:presenter --> :domain:ratings
+  :features:episode-sheet:presenter --> :domain:rewatch
   :features:episode-sheet:presenter --> :features:episode-sheet:nav
   :features:episode-sheet:presenter --> :features:rating-sheet:nav
   :features:episode-sheet:presenter -.-> :features:season-details:nav

--- a/ios/Packages/EpisodeDetail/Sources/EpisodeDetail/EpisodeDetailSheetView.swift
+++ b/ios/Packages/EpisodeDetail/Sources/EpisodeDetail/EpisodeDetailSheetView.swift
@@ -72,7 +72,7 @@ public struct EpisodeDetailSheetView: View {
     @ViewBuilder
     private func actionView(for action: EpisodeSheetActionUi) -> some View {
         switch action.item {
-        case .toggleWatched:
+        case .markWatched:
             SheetActionItem(
                 icon: state.isWatched ? "checkmark.circle.fill" : "checkmark.circle",
                 label: action.label,
@@ -80,8 +80,15 @@ public struct EpisodeDetailSheetView: View {
                 showProgress: state.isTogglingWatched,
                 action: {
                     Haptics.impact(isEnabled: hapticFeedbackEnabled)
-                    presenter.dispatch(action: EpisodeSheetActionToggleWatched())
+                    presenter.dispatch(action: EpisodeSheetActionMarkWatched())
                 }
+            )
+        case .markUnwatched:
+            SheetActionItem(
+                icon: "xmark.circle",
+                label: action.label,
+                isEnabled: !state.isTogglingWatched,
+                action: { presenter.dispatch(action: EpisodeSheetActionMarkUnwatched()) }
             )
         case .openShow:
             SheetActionItem(


### PR DESCRIPTION
## Description
This PR changes the episode sheet so that marking an episode watched always records a viewing, following the model the official Trakt app uses. Removing a viewing becomes its own action, and the sheet counts how many times an episode has been seen.

## Changes
- Label the watched action Watch again for an episode already seen, and record another viewing instead of unwatching it.
- Add a separate action for removing a viewing, offered only for an episode already watched.
- Hide the watched action for a seen episode while the multiple plays setting is off.
- Count every viewing on the episode sheet, and report none for an episode that was never watched.
- Close a rewatch started from show details once every episode has been seen again.
