### PR TITLE
feat: Add Episode confirmation

### DIFF
--- a/core/test-tags/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testtags/episodesheet/EpisodeSheetTestTags.kt
+++ b/core/test-tags/src/commonMain/kotlin/com/thomaskioko/tvmaniac/testtags/episodesheet/EpisodeSheetTestTags.kt
@@ -4,5 +4,7 @@ public object EpisodeSheetTestTags {
     public const val SHEET_TEST_TAG: String = "episode_sheet"
     public const val TITLE_TEST_TAG: String = "episode_sheet_title"
     public const val PLAY_COUNT_TEST_TAG: String = "episode_sheet_play_count"
+    public const val REMOVE_WATCH_CONFIRM_TEST_TAG: String = "episode_sheet_remove_watch_confirm"
+    public const val REMOVE_WATCH_DISMISS_TEST_TAG: String = "episode_sheet_remove_watch_dismiss"
     public fun actionItem(name: String): String = "episode_sheet_action_${name.lowercase()}"
 }

--- a/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetAction.kt
+++ b/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetAction.kt
@@ -3,6 +3,8 @@ package com.thomaskioko.tvmaniac.presentation.episodedetail
 public sealed interface EpisodeSheetAction {
     public data object MarkWatched : EpisodeSheetAction
     public data object MarkUnwatched : EpisodeSheetAction
+    public data object RemoveWatchConfirmed : EpisodeSheetAction
+    public data object RemoveWatchDismissed : EpisodeSheetAction
     public data object OpenShow : EpisodeSheetAction
     public data object OpenSeason : EpisodeSheetAction
     public data object Unfollow : EpisodeSheetAction

--- a/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetMapper.kt
+++ b/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetMapper.kt
@@ -28,6 +28,16 @@ internal fun EpisodeById.toState(
     )
 }
 
+internal fun removeWatchConfirmation(
+    episodeTitle: String,
+    localizer: Localizer,
+): RemoveWatchConfirmation = RemoveWatchConfirmation(
+    title = localizer.getString(StringResourceKey.LabelRemoveWatchConfirmTitle),
+    message = localizer.getString(StringResourceKey.LabelRemoveWatchConfirmMessage, episodeTitle),
+    confirmLabel = localizer.getString(StringResourceKey.DialogButtonYes),
+    dismissLabel = localizer.getString(StringResourceKey.DialogButtonNo),
+)
+
 private fun availableActions(
     source: ScreenSource,
     isWatched: Boolean,

--- a/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenter.kt
+++ b/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenter.kt
@@ -40,6 +40,7 @@ import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
 import io.github.thomaskioko.codegen.annotations.DestinationKind
 import io.github.thomaskioko.codegen.annotations.NavDestination
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -73,6 +74,7 @@ public class EpisodeSheetPresenter internal constructor(
     private val coroutineScope = componentContext.coroutineScope()
     private val uiMessageManager = UiMessageManager()
     private val actionLoadingState = ObservableLoadingCounter()
+    private val showRemoveWatchConfirmation = MutableStateFlow(false)
     private var currentEpisode: EpisodeById? = null
 
     public val state: StateFlow<EpisodeDetailSheetState> = combine(
@@ -82,7 +84,8 @@ public class EpisodeSheetPresenter internal constructor(
         observeRatingInteractor.flow,
         observeEpisodeRewatchesInteractor.flow,
         datastoreRepository.observeMultiplePlaysEnabled(),
-    ) { episode, message, isTogglingWatched, userRating, rewatches, multiplePlaysEnabled ->
+        showRemoveWatchConfirmation,
+    ) { episode, message, isTogglingWatched, userRating, rewatches, multiplePlaysEnabled, confirmRemoval ->
         currentEpisode = episode
         val current = episode?.toState(
             source = param.source,
@@ -94,6 +97,11 @@ public class EpisodeSheetPresenter internal constructor(
             message = message,
             isTogglingWatched = isTogglingWatched,
             userRating = userRating,
+            removeWatchConfirmation = if (confirmRemoval) {
+                removeWatchConfirmation(current.episodeTitle, localizer)
+            } else {
+                null
+            },
         )
     }.stateIn(
         scope = coroutineScope,
@@ -112,7 +120,12 @@ public class EpisodeSheetPresenter internal constructor(
     public fun dispatch(action: EpisodeSheetAction) {
         when (action) {
             is EpisodeSheetAction.MarkWatched -> markWatched()
-            is EpisodeSheetAction.MarkUnwatched -> markUnwatched()
+            is EpisodeSheetAction.MarkUnwatched -> showRemoveWatchConfirmation.value = true
+            is EpisodeSheetAction.RemoveWatchDismissed -> showRemoveWatchConfirmation.value = false
+            is EpisodeSheetAction.RemoveWatchConfirmed -> {
+                showRemoveWatchConfirmation.value = false
+                markUnwatched()
+            }
             is EpisodeSheetAction.OpenShow -> openShow()
             is EpisodeSheetAction.OpenSeason -> openSeason()
             is EpisodeSheetAction.Unfollow -> unfollowShow()

--- a/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetState.kt
+++ b/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetState.kt
@@ -16,9 +16,17 @@ public data class EpisodeDetailSheetState(
     val isWatched: Boolean = false,
     val isTogglingWatched: Boolean = false,
     val playCount: Int? = null,
+    val removeWatchConfirmation: RemoveWatchConfirmation? = null,
     val userRating: Int? = null,
     val availableActions: ImmutableList<EpisodeSheetActionUi> = persistentListOf(),
     val message: UiMessage? = null,
+)
+
+public data class RemoveWatchConfirmation(
+    val title: String,
+    val message: String,
+    val confirmLabel: String,
+    val dismissLabel: String,
 )
 
 public data class EpisodeSheetActionUi(

--- a/features/episode-sheet/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenterTest.kt
+++ b/features/episode-sheet/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenterTest.kt
@@ -40,6 +40,7 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -309,7 +310,7 @@ internal class EpisodeSheetPresenterTest {
     }
 
     @Test
-    fun `should mark episode as unwatched given MarkUnwatched is dispatched`() = runTest {
+    fun `should ask for confirmation given MarkUnwatched is dispatched`() = runTest {
         episodeRepository.setEpisodeById(testEpisode(isWatched = true))
 
         val presenter = createPresenter()
@@ -322,12 +323,60 @@ internal class EpisodeSheetPresenterTest {
             presenter.dispatch(EpisodeSheetAction.MarkUnwatched)
             testDispatcher.scheduler.advanceUntilIdle()
 
+            awaitItem().removeWatchConfirmation shouldNotBe null
+            episodeRepository.lastMarkEpisodeUnwatchedCall shouldBe null
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `should mark episode as unwatched given RemoveWatchConfirmed is dispatched`() = runTest {
+        episodeRepository.setEpisodeById(testEpisode(isWatched = true))
+
+        val presenter = createPresenter()
+
+        presenter.state.test {
+            awaitItem()
+            testDispatcher.scheduler.advanceUntilIdle()
+            awaitItem()
+
+            presenter.dispatch(EpisodeSheetAction.MarkUnwatched)
+            testDispatcher.scheduler.advanceUntilIdle()
+            awaitItem()
+
+            presenter.dispatch(EpisodeSheetAction.RemoveWatchConfirmed)
+            testDispatcher.scheduler.advanceUntilIdle()
+
             val call = episodeRepository.lastMarkEpisodeUnwatchedCall
             call shouldBe com.thomaskioko.tvmaniac.episodes.testing.MarkEpisodeUnwatchedCall(
                 showId = 100L,
                 episodeId = 1L,
             )
             navigator.overlayDismissCount shouldBe 1
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `should keep episode watched given RemoveWatchDismissed is dispatched`() = runTest {
+        episodeRepository.setEpisodeById(testEpisode(isWatched = true))
+
+        val presenter = createPresenter()
+
+        presenter.state.test {
+            awaitItem()
+            testDispatcher.scheduler.advanceUntilIdle()
+            awaitItem()
+
+            presenter.dispatch(EpisodeSheetAction.MarkUnwatched)
+            testDispatcher.scheduler.advanceUntilIdle()
+            awaitItem()
+
+            presenter.dispatch(EpisodeSheetAction.RemoveWatchDismissed)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            awaitItem().removeWatchConfirmation shouldBe null
+            episodeRepository.lastMarkEpisodeUnwatchedCall shouldBe null
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/features/episode-sheet/ui/src/main/java/com/thomaskioko/tvmaniac/episodedetail/ui/EpisodeSheet.kt
+++ b/features/episode-sheet/ui/src/main/java/com/thomaskioko/tvmaniac/episodedetail/ui/EpisodeSheet.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.thomaskioko.tvmaniac.compose.components.ThemePreviews
+import com.thomaskioko.tvmaniac.compose.components.TvManiacAlertDialog
 import com.thomaskioko.tvmaniac.compose.components.TvManiacPreviewWrapperProvider
 import com.thomaskioko.tvmaniac.compose.util.rememberHapticFeedback
 import com.thomaskioko.tvmaniac.core.base.ActivityScope
@@ -61,6 +62,19 @@ public fun EpisodeSheet(
                 actions = { EpisodeSheetActions(state, presenter::dispatch) },
             )
         }
+    }
+
+    state.removeWatchConfirmation?.let { confirmation ->
+        TvManiacAlertDialog(
+            title = confirmation.title,
+            message = confirmation.message,
+            confirmButtonText = confirmation.confirmLabel,
+            dismissButtonText = confirmation.dismissLabel,
+            confirmButtonTestTag = EpisodeSheetTestTags.REMOVE_WATCH_CONFIRM_TEST_TAG,
+            dismissButtonTestTag = EpisodeSheetTestTags.REMOVE_WATCH_DISMISS_TEST_TAG,
+            onConfirm = { presenter.dispatch(EpisodeSheetAction.RemoveWatchConfirmed) },
+            onDismiss = { presenter.dispatch(EpisodeSheetAction.RemoveWatchDismissed) },
+        )
     }
 }
 

--- a/i18n/generator/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/base/strings.xml
@@ -518,6 +518,8 @@
     <string name="label_action_watch_again">Watch again</string>
     <string name="label_watch_again_confirm_title">Watch again?</string>
     <string name="label_watch_again_confirm_message">Episodes you mark from now on count towards a new rewatch of \"%1$s\".</string>
+    <string name="label_remove_watch_confirm_title">Remove from watched?</string>
+    <string name="label_remove_watch_confirm_message">\"%1$s\" will no longer count as watched.</string>
     <string name="label_action_rate">Rate</string>
     <string name="label_action_rate_episode">Rate episode</string>
     <string name="label_action_remove_rating">Remove rating</string>

--- a/i18n/generator/src/commonMain/moko-resources/de/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/de/strings.xml
@@ -510,6 +510,8 @@
     <string name="label_action_watch_again">Erneut ansehen</string>
     <string name="label_watch_again_confirm_title">Erneut ansehen?</string>
     <string name="label_watch_again_confirm_message">Ab jetzt markierte Folgen zählen zu einem neuen Durchlauf von \"%1$s\".</string>
+    <string name="label_remove_watch_confirm_title">Als ungesehen markieren?</string>
+    <string name="label_remove_watch_confirm_message">\"%1$s\" zählt dann nicht mehr als gesehen.</string>
     <string name="label_action_rate">Bewerten</string>
     <string name="label_action_rate_episode">Folge bewerten</string>
     <string name="label_action_remove_rating">Bewertung entfernen</string>

--- a/i18n/generator/src/commonMain/moko-resources/fr/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/fr/strings.xml
@@ -560,5 +560,8 @@
     <string name="label_watch_status_on_hold">En pause</string>
     <string name="label_watch_status_dropped">Abandonnées</string>
 
+    <string name="label_remove_watch_confirm_title">Retirer des épisodes vus ?</string>
+    <string name="label_remove_watch_confirm_message">\"%1$s\" ne comptera plus comme vu.</string>
+
     <string name="label_rewatch_simkl_free_tier">Simkl n\'enregistre pas les revisionnages sans forfait payant. Ce décompte reste sur cet appareil.</string>
 </resources>

--- a/ios/Packages/EpisodeDetail/Sources/EpisodeDetail/EpisodeDetailSheetView.swift
+++ b/ios/Packages/EpisodeDetail/Sources/EpisodeDetail/EpisodeDetailSheetView.swift
@@ -63,6 +63,26 @@ public struct EpisodeDetailSheetView: View {
                 presenter.dispatch(action: EpisodeSheetActionMessageShown(id: message.id))
             }
         }
+        .alert(
+            state.removeWatchConfirmation?.title ?? "",
+            isPresented: Binding(
+                get: { state.removeWatchConfirmation != nil },
+                set: { isPresented in
+                    if !isPresented { presenter.dispatch(action: EpisodeSheetActionRemoveWatchDismissed()) }
+                }
+            )
+        ) {
+            if let confirmation = state.removeWatchConfirmation {
+                Button(confirmation.confirmLabel, role: .destructive) {
+                    presenter.dispatch(action: EpisodeSheetActionRemoveWatchConfirmed())
+                }
+                Button(confirmation.dismissLabel, role: .cancel) {
+                    presenter.dispatch(action: EpisodeSheetActionRemoveWatchDismissed())
+                }
+            }
+        } message: {
+            Text(state.removeWatchConfirmation?.message ?? "")
+        }
     }
 
     private var rateActionLabel: String {


### PR DESCRIPTION
## Description
This PR asks for confirmation before an episode is removed from watched on the episode sheet. A viewing is now only removed once the choice is confirmed.

## Changes
- Ask for confirmation on the episode sheet before an episode is removed from watched.
- Show the same question and buttons on Android and iOS, with the wording coming from the episode sheet state.
- Add the confirmation strings in English, German and French.
