### PR TITLE
fix: Clear removed episode

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1111,6 +1111,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:favorites --> :core:base
   :domain:favorites --> :data:favorites:api
   :domain:feature-flags --> :core:base

--- a/core/integration/infra/README.md
+++ b/core/integration/infra/README.md
@@ -694,6 +694,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:library --> :core:base
   :domain:library --> :core:logger:api
   :domain:library --> :core:network-util:api

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Rewatch.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Rewatch.sq
@@ -103,6 +103,10 @@ SELECT COUNT(*) AS rewatch_count
 FROM rewatch_session_episode
 WHERE episode_id = :episodeId;
 
+removeEpisodeRewatches:
+DELETE FROM rewatch_session_episode
+WHERE episode_id = :episodeId;
+
 unsentEpisodes:
 SELECT
     rse.id AS row_id,

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchRepository.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchRepository.kt
@@ -26,6 +26,8 @@ public interface RewatchRepository {
 
     public fun observeEpisodeRewatches(episodeId: Long): Flow<Long>
 
+    public suspend fun removeEpisodeRewatches(episodeId: Long)
+
     public suspend fun supportsRewatch(): Boolean
 
     public suspend fun syncPendingRewatches()

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchSessionDao.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchSessionDao.kt
@@ -21,6 +21,8 @@ public interface RewatchSessionDao {
 
     public fun observeEpisodeRewatches(episodeId: Long): Flow<Long>
 
+    public fun removeEpisodeRewatches(episodeId: Long)
+
     public fun unsentEpisodes(): List<UnsentRewatchEpisode>
 
     public fun markEpisodeSynced(rowId: Long, syncedAt: Long)

--- a/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchRepository.kt
+++ b/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchRepository.kt
@@ -119,6 +119,10 @@ public class DefaultRewatchRepository(
 
     override fun observeEpisodeRewatches(episodeId: Long): Flow<Long> = rewatchSessionDao.observeEpisodeRewatches(episodeId)
 
+    override suspend fun removeEpisodeRewatches(episodeId: Long) {
+        rewatchSessionDao.removeEpisodeRewatches(episodeId)
+    }
+
     override suspend fun supportsRewatch(): Boolean = activeSource()?.supportsRewatch() ?: true
 
     override suspend fun syncPendingRewatches() {

--- a/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchSessionDao.kt
+++ b/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchSessionDao.kt
@@ -90,6 +90,10 @@ public class DefaultRewatchSessionDao(
             .asFlow()
             .mapToOne(dispatchers.databaseRead)
 
+    override fun removeEpisodeRewatches(episodeId: Long) {
+        queries.removeEpisodeRewatches(Id(episodeId))
+    }
+
     override fun unsentEpisodes(): List<UnsentRewatchEpisode> =
         queries.unsentEpisodes().executeAsList().map { it.toUnsentRewatchEpisode() }
 

--- a/data/rewatch/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/testing/FakeRewatchRepository.kt
+++ b/data/rewatch/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/testing/FakeRewatchRepository.kt
@@ -92,6 +92,10 @@ public class FakeRewatchRepository : RewatchRepository {
     override fun observeEpisodeRewatches(episodeId: Long): Flow<Long> =
         rewatchesByEpisode.asStateFlow().map { it[episodeId] ?: 0L }
 
+    override suspend fun removeEpisodeRewatches(episodeId: Long) {
+        rewatchesByEpisode.value -= episodeId
+    }
+
     override suspend fun supportsRewatch(): Boolean = supportsRewatchValue
 
     override suspend fun syncPendingRewatches() {

--- a/domain/account-switcher/README.md
+++ b/domain/account-switcher/README.md
@@ -78,6 +78,10 @@ graph TB
     direction TB
     :data:request-manager:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -149,6 +153,8 @@ graph TB
   :data:library:api --> :data:account-manager:api
   :data:library:api --> :data:database:sqldelight
   :data:library:api --> :data:datastore:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :data:seasons:api --> :data:database:sqldelight
   :data:showdetails:api --> :data:database:sqldelight
@@ -193,6 +199,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:library --> :core:base
   :domain:library --> :core:logger:api
   :domain:library --> :core:network-util:api

--- a/domain/continue-watching/README.md
+++ b/domain/continue-watching/README.md
@@ -74,6 +74,10 @@ graph TB
     direction TB
     :data:request-manager:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -134,6 +138,8 @@ graph TB
   :data:library:api --> :data:account-manager:api
   :data:library:api --> :data:database:sqldelight
   :data:library:api --> :data:datastore:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :data:seasons:api --> :data:database:sqldelight
   :data:showdetails:api --> :data:database:sqldelight
@@ -166,6 +172,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:showdetails --> :core:base
   :domain:showdetails --> :core:util:api
   :domain:showdetails --> :data:cast:api

--- a/domain/episode/README.md
+++ b/domain/episode/README.md
@@ -54,6 +54,10 @@ graph TB
     direction TB
     :data:library:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:upnext
     direction TB
     :data:upnext:api[api]:::multiplatform
@@ -82,6 +86,8 @@ graph TB
   :data:library:api --> :data:account-manager:api
   :data:library:api --> :data:database:sqldelight
   :data:library:api --> :data:datastore:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :domain:episode --> :core:base
   :domain:episode --> :core:logger:api
   :domain:episode --> :core:syncstate:api
@@ -91,6 +97,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
 
 classDef application fill:#CAFFBF,stroke:#000,stroke-width:2px,color:#000;
 classDef multiplatform fill:#FFD6A5,stroke:#000,stroke-width:2px,color:#000;

--- a/domain/episode/build.gradle.kts
+++ b/domain/episode/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
                 api(projects.data.database.sqldelight)
                 api(projects.data.episode.api)
                 api(projects.data.library.api)
+                api(projects.data.rewatch.api)
 
                 implementation(projects.core.view)
             }
@@ -33,6 +34,7 @@ kotlin {
                 implementation(projects.data.accountManager.testing)
                 implementation(projects.data.episode.testing)
                 implementation(projects.data.library.testing)
+                implementation(projects.data.rewatch.testing)
             }
         }
     }

--- a/domain/episode/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/episode/MarkEpisodeUnwatchedInteractor.kt
+++ b/domain/episode/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/episode/MarkEpisodeUnwatchedInteractor.kt
@@ -1,12 +1,14 @@
 package com.thomaskioko.tvmaniac.domain.episode
 
 import com.thomaskioko.tvmaniac.core.base.interactor.Interactor
+import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchRepository
 import com.thomaskioko.tvmaniac.episodes.api.EpisodeRepository
 import dev.zacsweers.metro.Inject
 
 @Inject
 public class MarkEpisodeUnwatchedInteractor(
     private val episodeRepository: EpisodeRepository,
+    private val rewatchRepository: RewatchRepository,
 ) : Interactor<MarkEpisodeUnwatchedParams>() {
 
     override suspend fun doWork(params: MarkEpisodeUnwatchedParams) {
@@ -14,6 +16,7 @@ public class MarkEpisodeUnwatchedInteractor(
             showId = params.showId,
             episodeId = params.episodeId,
         )
+        rewatchRepository.removeEpisodeRewatches(params.episodeId)
     }
 }
 

--- a/domain/episode/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/episode/MarkEpisodeUnwatchedInteractorTest.kt
+++ b/domain/episode/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/episode/MarkEpisodeUnwatchedInteractorTest.kt
@@ -1,0 +1,61 @@
+package com.thomaskioko.tvmaniac.domain.episode
+
+import app.cash.turbine.test
+import com.thomaskioko.tvmaniac.core.view.InvokeStarted
+import com.thomaskioko.tvmaniac.core.view.InvokeSuccess
+import com.thomaskioko.tvmaniac.data.rewatch.testing.FakeRewatchRepository
+import com.thomaskioko.tvmaniac.episodes.testing.FakeEpisodeRepository
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class MarkEpisodeUnwatchedInteractorTest {
+    private val episodeRepository = FakeEpisodeRepository()
+    private val rewatchRepository = FakeRewatchRepository()
+
+    private val interactor = MarkEpisodeUnwatchedInteractor(
+        episodeRepository = episodeRepository,
+        rewatchRepository = rewatchRepository,
+    )
+
+    @Test
+    fun `should mark episode as unwatched given params are valid`() = runTest {
+        val params = MarkEpisodeUnwatchedParams(showId = 84958, episodeId = 123456)
+
+        interactor(params).test {
+            awaitItem() shouldBe InvokeStarted
+            awaitItem() shouldBe InvokeSuccess
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `should clear recorded plays given the episode is unwatched`() = runTest {
+        rewatchRepository.setRewatchesForEpisode(episodeId = 123456, rewatches = 2)
+
+        val params = MarkEpisodeUnwatchedParams(showId = 84958, episodeId = 123456)
+
+        interactor(params).test {
+            awaitItem() shouldBe InvokeStarted
+            awaitItem() shouldBe InvokeSuccess
+            awaitComplete()
+        }
+
+        rewatchRepository.observeEpisodeRewatches(123456).first() shouldBe 0L
+    }
+
+    @Test
+    fun `should keep plays of other episodes given one episode is unwatched`() = runTest {
+        rewatchRepository.setRewatchesForEpisode(episodeId = 123456, rewatches = 2)
+        rewatchRepository.setRewatchesForEpisode(episodeId = 123457, rewatches = 3)
+
+        interactor(MarkEpisodeUnwatchedParams(showId = 84958, episodeId = 123456)).test {
+            awaitItem() shouldBe InvokeStarted
+            awaitItem() shouldBe InvokeSuccess
+            awaitComplete()
+        }
+
+        rewatchRepository.observeEpisodeRewatches(123457).first() shouldBe 3L
+    }
+}

--- a/features/continue-watching/presenter/README.md
+++ b/features/continue-watching/presenter/README.md
@@ -78,6 +78,10 @@ graph TB
     direction TB
     :data:request-manager:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -177,6 +181,8 @@ graph TB
   :data:ratings:api --> :data:account-manager:api
   :data:ratings:api --> :data:database:sqldelight
   :data:ratings:api --> :data:followedshows:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :data:seasons:api --> :data:database:sqldelight
   :data:showdetails:api --> :data:database:sqldelight
@@ -210,6 +216,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:followedshows --> :core:base
   :domain:followedshows --> :data:followedshows:api
   :domain:followedshows --> :data:library:api

--- a/features/continue-watching/ui/README.md
+++ b/features/continue-watching/ui/README.md
@@ -80,6 +80,10 @@ graph TB
     direction TB
     :data:request-manager:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -184,6 +188,8 @@ graph TB
   :data:ratings:api --> :data:account-manager:api
   :data:ratings:api --> :data:database:sqldelight
   :data:ratings:api --> :data:followedshows:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :data:seasons:api --> :data:database:sqldelight
   :data:showdetails:api --> :data:database:sqldelight
@@ -217,6 +223,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:followedshows --> :core:base
   :domain:followedshows --> :data:followedshows:api
   :domain:followedshows --> :data:library:api

--- a/features/debug/presenter/README.md
+++ b/features/debug/presenter/README.md
@@ -78,6 +78,10 @@ graph TB
     direction TB
     :data:request-manager:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -158,6 +162,8 @@ graph TB
   :data:library:api --> :data:account-manager:api
   :data:library:api --> :data:database:sqldelight
   :data:library:api --> :data:datastore:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :data:seasons:api --> :data:database:sqldelight
   :data:showdetails:api --> :data:database:sqldelight
@@ -190,6 +196,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:library --> :core:base
   :domain:library --> :core:logger:api
   :domain:library --> :core:network-util:api

--- a/features/debug/ui/README.md
+++ b/features/debug/ui/README.md
@@ -80,6 +80,10 @@ graph TB
     direction TB
     :data:request-manager:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -166,6 +170,8 @@ graph TB
   :data:library:api --> :data:account-manager:api
   :data:library:api --> :data:database:sqldelight
   :data:library:api --> :data:datastore:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :data:seasons:api --> :data:database:sqldelight
   :data:showdetails:api --> :data:database:sqldelight
@@ -198,6 +204,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:library --> :core:base
   :domain:library --> :core:logger:api
   :domain:library --> :core:network-util:api

--- a/features/discover/presenter/README.md
+++ b/features/discover/presenter/README.md
@@ -86,6 +86,10 @@ graph TB
     direction TB
     :data:request-manager:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -216,6 +220,8 @@ graph TB
   :data:popularshows:api --> :core:base
   :data:popularshows:api --> :data:database:sqldelight
   :data:popularshows:api --> :data:shows:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :data:seasons:api --> :data:database:sqldelight
   :data:showdetails:api --> :data:database:sqldelight
@@ -269,6 +275,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:followedshows --> :core:base
   :domain:followedshows --> :data:followedshows:api
   :domain:followedshows --> :data:library:api

--- a/features/discover/ui/README.md
+++ b/features/discover/ui/README.md
@@ -88,6 +88,10 @@ graph TB
     direction TB
     :data:request-manager:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -224,6 +228,8 @@ graph TB
   :data:popularshows:api --> :core:base
   :data:popularshows:api --> :data:database:sqldelight
   :data:popularshows:api --> :data:shows:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :data:seasons:api --> :data:database:sqldelight
   :data:showdetails:api --> :data:database:sqldelight
@@ -277,6 +283,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:followedshows --> :core:base
   :domain:followedshows --> :data:followedshows:api
   :domain:followedshows --> :data:library:api

--- a/features/episode-sheet/presenter/README.md
+++ b/features/episode-sheet/presenter/README.md
@@ -138,6 +138,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:followedshows --> :core:base
   :domain:followedshows --> :data:followedshows:api
   :domain:followedshows --> :data:library:api

--- a/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenter.kt
+++ b/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenter.kt
@@ -76,6 +76,7 @@ public class EpisodeSheetPresenter internal constructor(
     private val actionLoadingState = ObservableLoadingCounter()
     private val showRemoveWatchConfirmation = MutableStateFlow(false)
     private var currentEpisode: EpisodeById? = null
+    private var isMarking: Boolean = false
 
     public val state: StateFlow<EpisodeDetailSheetState> = combine(
         observeEpisodeByIdInteractor.flow,
@@ -144,7 +145,8 @@ public class EpisodeSheetPresenter internal constructor(
 
     private fun markWatched() {
         val episode = currentEpisode ?: return
-        if (state.value.isTogglingWatched) return
+        if (isMarking) return
+        isMarking = true
         val wasWatched = episode.is_watched != 0L
         appScopeLauncher.launch(TAG) {
             val markStatus = if (wasWatched) {
@@ -167,6 +169,7 @@ public class EpisodeSheetPresenter internal constructor(
                 )
             }
             markStatus.collectStatus(actionLoadingState, logger, uiMessageManager, errorToStringMapper = errorToStringMapper)
+            isMarking = false
             val shouldRate = !wasWatched && shouldPromptForRatingInteractor(
                 ShouldPromptForRatingInteractor.Param(
                     showId = episode.show_id.id,
@@ -191,7 +194,8 @@ public class EpisodeSheetPresenter internal constructor(
 
     private fun markUnwatched() {
         val episode = currentEpisode ?: return
-        if (state.value.isTogglingWatched) return
+        if (isMarking) return
+        isMarking = true
         appScopeLauncher.launch(TAG) {
             markEpisodeUnwatchedInteractor(
                 MarkEpisodeUnwatchedParams(
@@ -199,6 +203,7 @@ public class EpisodeSheetPresenter internal constructor(
                     episodeId = episode.episode_id.id,
                 ),
             ).collectStatus(actionLoadingState, logger, uiMessageManager, errorToStringMapper = errorToStringMapper)
+            isMarking = false
             coroutineScope.launch { navigator.dismissOverlay() }
         }
     }

--- a/features/episode-sheet/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenterTest.kt
+++ b/features/episode-sheet/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenterTest.kt
@@ -537,7 +537,7 @@ internal class EpisodeSheetPresenterTest {
             observeRatingInteractor = ObserveRatingInteractor(ratingsRepository),
             markEpisodeWatchedInteractor = MarkEpisodeWatchedInteractor(episodeRepository),
             shouldPromptForRatingInteractor = shouldPromptForRatingInteractor,
-            markEpisodeUnwatchedInteractor = MarkEpisodeUnwatchedInteractor(episodeRepository),
+            markEpisodeUnwatchedInteractor = MarkEpisodeUnwatchedInteractor(episodeRepository, rewatchRepository),
             observeEpisodeRewatchesInteractor = ObserveEpisodeRewatchesInteractor(rewatchRepository),
             watchAgainInteractor = WatchAgainInteractor(rewatchRepository, dateTimeProvider),
             datastoreRepository = datastoreRepository,

--- a/features/episode-sheet/ui/README.md
+++ b/features/episode-sheet/ui/README.md
@@ -146,6 +146,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:followedshows --> :core:base
   :domain:followedshows --> :data:followedshows:api
   :domain:followedshows --> :data:library:api

--- a/features/my-shows/presenter/README.md
+++ b/features/my-shows/presenter/README.md
@@ -78,6 +78,10 @@ graph TB
     direction TB
     :data:request-manager:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -191,6 +195,8 @@ graph TB
   :data:ratings:api --> :data:account-manager:api
   :data:ratings:api --> :data:database:sqldelight
   :data:ratings:api --> :data:followedshows:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :data:seasons:api --> :data:database:sqldelight
   :data:showdetails:api --> :data:database:sqldelight
@@ -226,6 +232,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:followedshows --> :core:base
   :domain:followedshows --> :data:followedshows:api
   :domain:followedshows --> :data:library:api

--- a/features/my-shows/ui/README.md
+++ b/features/my-shows/ui/README.md
@@ -80,6 +80,10 @@ graph TB
     direction TB
     :data:request-manager:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -201,6 +205,8 @@ graph TB
   :data:ratings:api --> :data:account-manager:api
   :data:ratings:api --> :data:database:sqldelight
   :data:ratings:api --> :data:followedshows:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :data:seasons:api --> :data:database:sqldelight
   :data:showdetails:api --> :data:database:sqldelight
@@ -236,6 +242,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:followedshows --> :core:base
   :domain:followedshows --> :data:followedshows:api
   :domain:followedshows --> :data:library:api

--- a/features/profile/presenter/README.md
+++ b/features/profile/presenter/README.md
@@ -78,6 +78,10 @@ graph TB
     direction TB
     :data:request-manager:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -177,6 +181,8 @@ graph TB
   :data:library:api --> :data:account-manager:api
   :data:library:api --> :data:database:sqldelight
   :data:library:api --> :data:datastore:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :data:seasons:api --> :data:database:sqldelight
   :data:showdetails:api --> :data:database:sqldelight
@@ -212,6 +218,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:favorites --> :core:base
   :domain:favorites --> :data:favorites:api
   :domain:library --> :core:base

--- a/features/profile/ui/README.md
+++ b/features/profile/ui/README.md
@@ -80,6 +80,10 @@ graph TB
     direction TB
     :data:request-manager:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -185,6 +189,8 @@ graph TB
   :data:library:api --> :data:account-manager:api
   :data:library:api --> :data:database:sqldelight
   :data:library:api --> :data:datastore:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :data:seasons:api --> :data:database:sqldelight
   :data:showdetails:api --> :data:database:sqldelight
@@ -220,6 +226,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:favorites --> :core:base
   :domain:favorites --> :data:favorites:api
   :domain:library --> :core:base

--- a/features/progress/presenter/README.md
+++ b/features/progress/presenter/README.md
@@ -82,6 +82,10 @@ graph TB
     direction TB
     :data:request-manager:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -193,6 +197,8 @@ graph TB
   :data:ratings:api --> :data:account-manager:api
   :data:ratings:api --> :data:database:sqldelight
   :data:ratings:api --> :data:followedshows:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :data:seasons:api --> :data:database:sqldelight
   :data:showdetails:api --> :data:database:sqldelight
@@ -229,6 +235,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:followedshows --> :core:base
   :domain:followedshows --> :data:followedshows:api
   :domain:followedshows --> :data:library:api

--- a/features/progress/ui/README.md
+++ b/features/progress/ui/README.md
@@ -84,6 +84,10 @@ graph TB
     direction TB
     :data:request-manager:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -203,6 +207,8 @@ graph TB
   :data:ratings:api --> :data:account-manager:api
   :data:ratings:api --> :data:database:sqldelight
   :data:ratings:api --> :data:followedshows:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :data:seasons:api --> :data:database:sqldelight
   :data:showdetails:api --> :data:database:sqldelight
@@ -239,6 +245,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:followedshows --> :core:base
   :domain:followedshows --> :data:followedshows:api
   :domain:followedshows --> :data:library:api

--- a/features/root/presenter/README.md
+++ b/features/root/presenter/README.md
@@ -267,6 +267,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:library --> :core:base
   :domain:library --> :core:logger:api
   :domain:library --> :core:network-util:api

--- a/features/root/ui/README.md
+++ b/features/root/ui/README.md
@@ -275,6 +275,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:library --> :core:base
   :domain:library --> :core:logger:api
   :domain:library --> :core:network-util:api

--- a/features/season-details/presenter/README.md
+++ b/features/season-details/presenter/README.md
@@ -62,6 +62,10 @@ graph TB
     direction TB
     :data:ratings:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -122,6 +126,8 @@ graph TB
   :data:ratings:api --> :data:account-manager:api
   :data:ratings:api --> :data:database:sqldelight
   :data:ratings:api --> :data:followedshows:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :domain:episode --> :core:base
   :domain:episode --> :core:logger:api
@@ -132,6 +138,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:ratings --> :core:base
   :domain:ratings --> :data:datastore:api
   :domain:ratings --> :data:ratings:api

--- a/features/season-details/presenter/build.gradle.kts
+++ b/features/season-details/presenter/build.gradle.kts
@@ -41,6 +41,7 @@ kotlin {
                 implementation(projects.data.cast.testing)
                 implementation(projects.data.episode.testing)
                 implementation(projects.data.ratings.testing)
+                implementation(projects.data.rewatch.testing)
                 implementation(projects.data.seasondetails.testing)
                 implementation(projects.data.datastore.testing)
                 implementation(projects.data.subscription.testing)

--- a/features/season-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/SeasonPresenterTest.kt
+++ b/features/season-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/SeasonPresenterTest.kt
@@ -10,6 +10,7 @@ import com.thomaskioko.tvmaniac.data.cast.testing.FakeCastRepository
 import com.thomaskioko.tvmaniac.data.ratings.api.RatingEntityType
 import com.thomaskioko.tvmaniac.data.ratings.api.SeasonRating
 import com.thomaskioko.tvmaniac.data.ratings.testing.FakeRatingsRepository
+import com.thomaskioko.tvmaniac.data.rewatch.testing.FakeRewatchRepository
 import com.thomaskioko.tvmaniac.datastore.testing.FakeDatastoreRepository
 import com.thomaskioko.tvmaniac.db.Id
 import com.thomaskioko.tvmaniac.db.SeasonCast
@@ -67,6 +68,7 @@ class SeasonPresenterTest {
     private val seasonDetailsRepository = FakeSeasonDetailsRepository()
     private val castRepository = FakeCastRepository()
     private val episodeRepository = FakeEpisodeRepository()
+    private val rewatchRepository = FakeRewatchRepository()
     private val ratingsRepository = FakeRatingsRepository()
     private val navigator = FakeNavigator()
     private val datastoreRepository = FakeDatastoreRepository()
@@ -1376,6 +1378,7 @@ class SeasonPresenterTest {
             ),
             markEpisodeUnwatchedInteractor = MarkEpisodeUnwatchedInteractor(
                 episodeRepository = episodeRepository,
+                rewatchRepository = rewatchRepository,
             ),
             markSeasonWatchedInteractor = MarkSeasonWatchedInteractor(
                 episodeRepository = episodeRepository,

--- a/features/season-details/ui/README.md
+++ b/features/season-details/ui/README.md
@@ -64,6 +64,10 @@ graph TB
     direction TB
     :data:ratings:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -130,6 +134,8 @@ graph TB
   :data:ratings:api --> :data:account-manager:api
   :data:ratings:api --> :data:database:sqldelight
   :data:ratings:api --> :data:followedshows:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :domain:episode --> :core:base
   :domain:episode --> :core:logger:api
@@ -140,6 +146,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:ratings --> :core:base
   :domain:ratings --> :data:datastore:api
   :domain:ratings --> :data:ratings:api

--- a/features/settings/presenter/README.md
+++ b/features/settings/presenter/README.md
@@ -229,6 +229,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:library --> :core:base
   :domain:library --> :core:logger:api
   :domain:library --> :core:network-util:api

--- a/features/settings/ui/README.md
+++ b/features/settings/ui/README.md
@@ -236,6 +236,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:library --> :core:base
   :domain:library --> :core:logger:api
   :domain:library --> :core:network-util:api

--- a/features/show-details/presenter/README.md
+++ b/features/show-details/presenter/README.md
@@ -200,6 +200,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:notifications --> :core:base
   :domain:notifications --> :core:logger:api
   :domain:notifications --> :core:network-util:api

--- a/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/ShowDetailsPresenterTest.kt
+++ b/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/ShowDetailsPresenterTest.kt
@@ -366,6 +366,7 @@ internal class ShowDetailsPresenterTest {
             ),
             markEpisodeUnwatchedInteractor = MarkEpisodeUnwatchedInteractor(
                 episodeRepository = episodeRepository,
+                rewatchRepository = rewatchRepository,
             ),
             datastoreRepository = datastoreRepository,
             shouldPromptForRatingInteractor = shouldPromptForRatingInteractor,

--- a/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/seasonsepisodes/ShowDetailsSeasonsEpisodesPresenterTest.kt
+++ b/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/seasonsepisodes/ShowDetailsSeasonsEpisodesPresenterTest.kt
@@ -10,6 +10,7 @@ import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.logger.fixture.FakeLogger
 import com.thomaskioko.tvmaniac.core.view.ErrorToStringMapper
 import com.thomaskioko.tvmaniac.data.ratings.testing.FakeRatingsRepository
+import com.thomaskioko.tvmaniac.data.rewatch.testing.FakeRewatchRepository
 import com.thomaskioko.tvmaniac.data.showdetails.testing.FakeShowDetailsRepository
 import com.thomaskioko.tvmaniac.datastore.api.SeasonSortOrder
 import com.thomaskioko.tvmaniac.datastore.testing.FakeDatastoreRepository
@@ -63,6 +64,7 @@ internal class ShowDetailsSeasonsEpisodesPresenterTest {
     )
     private val seasonsRepository = FakeSeasonsRepository()
     private val episodeRepository = FakeEpisodeRepository()
+    private val rewatchRepository = FakeRewatchRepository()
     private val seasonDetailsRepository = FakeSeasonDetailsRepository()
     private val showDetailsRepository = FakeShowDetailsRepository()
     private val watchedEpisodeSyncRepository = FakeWatchedEpisodeSyncRepository()
@@ -349,6 +351,7 @@ internal class ShowDetailsSeasonsEpisodesPresenterTest {
             ),
             markEpisodeUnwatchedInteractor = MarkEpisodeUnwatchedInteractor(
                 episodeRepository = episodeRepository,
+                rewatchRepository = rewatchRepository,
             ),
             datastoreRepository = datastoreRepository,
             shouldPromptForRatingInteractor = shouldPromptForRatingInteractor,

--- a/features/show-details/ui/README.md
+++ b/features/show-details/ui/README.md
@@ -207,6 +207,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:notifications --> :core:base
   :domain:notifications --> :core:logger:api
   :domain:notifications --> :core:network-util:api

--- a/features/upnext/presenter/README.md
+++ b/features/upnext/presenter/README.md
@@ -78,6 +78,10 @@ graph TB
     direction TB
     :data:request-manager:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -176,6 +180,8 @@ graph TB
   :data:ratings:api --> :data:account-manager:api
   :data:ratings:api --> :data:database:sqldelight
   :data:ratings:api --> :data:followedshows:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :data:seasons:api --> :data:database:sqldelight
   :data:showdetails:api --> :data:database:sqldelight
@@ -208,6 +214,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:followedshows --> :core:base
   :domain:followedshows --> :data:followedshows:api
   :domain:followedshows --> :data:library:api

--- a/features/upnext/ui/README.md
+++ b/features/upnext/ui/README.md
@@ -80,6 +80,10 @@ graph TB
     direction TB
     :data:request-manager:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -183,6 +187,8 @@ graph TB
   :data:ratings:api --> :data:account-manager:api
   :data:ratings:api --> :data:database:sqldelight
   :data:ratings:api --> :data:followedshows:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :data:seasons:api --> :data:database:sqldelight
   :data:showdetails:api --> :data:database:sqldelight
@@ -215,6 +221,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:followedshows --> :core:base
   :domain:followedshows --> :data:followedshows:api
   :domain:followedshows --> :data:library:api

--- a/ios-framework/README.md
+++ b/ios-framework/README.md
@@ -910,6 +910,7 @@ graph TB
   :domain:episode --> :data:database:sqldelight
   :domain:episode --> :data:episode:api
   :domain:episode --> :data:library:api
+  :domain:episode --> :data:rewatch:api
   :domain:favorites --> :core:base
   :domain:favorites --> :data:favorites:api
   :domain:feature-flags --> :core:base


### PR DESCRIPTION
## Description
This PR corrects how the episode sheet counts plays, following a review of the slice. Both fixes come from paths the earlier tests did not cover.

## Bug Fixes
- Clear the plays an episode recorded when it is removed from watched, so an old count no longer carries over into the next viewing.
- Record a single play when watch again is tapped twice in quick succession.
