### PR TITLE
feat: Count every viewing in the watch statistics

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1192,6 +1192,7 @@ graph TB
   :domain:statistics --> :data:database:sqldelight
   :domain:statistics --> :data:episode:api
   :domain:statistics --> :data:ratings:api
+  :domain:statistics --> :data:rewatch:api
   :domain:statistics --> :data:watch-status:api
   :domain:sync-activity --> :core:base
   :domain:sync-activity --> :data:sync-activity:api

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Rewatch.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Rewatch.sq
@@ -107,6 +107,15 @@ removeEpisodeRewatches:
 DELETE FROM rewatch_session_episode
 WHERE episode_id = :episodeId;
 
+rewatchTotals:
+SELECT
+    COUNT(*) AS viewings,
+    CAST(COALESCE(SUM(COALESCE(episode.runtime, tvshow.runtime)), 0) AS INTEGER) AS minutes
+FROM rewatch_session_episode
+INNER JOIN rewatch_session ON rewatch_session.id = rewatch_session_episode.session_id
+INNER JOIN tvshow ON tvshow.id = rewatch_session.show_id
+LEFT JOIN episode ON episode.id = rewatch_session_episode.episode_id;
+
 unsentEpisodes:
 SELECT
     rse.id AS row_id,

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchRepository.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchRepository.kt
@@ -28,6 +28,8 @@ public interface RewatchRepository {
 
     public suspend fun removeEpisodeRewatches(episodeId: Long)
 
+    public fun observeRewatchTotals(): Flow<RewatchTotals>
+
     public suspend fun supportsRewatch(): Boolean
 
     public suspend fun syncPendingRewatches()

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchSessionDao.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchSessionDao.kt
@@ -23,6 +23,8 @@ public interface RewatchSessionDao {
 
     public fun removeEpisodeRewatches(episodeId: Long)
 
+    public fun observeRewatchTotals(): Flow<RewatchTotals>
+
     public fun unsentEpisodes(): List<UnsentRewatchEpisode>
 
     public fun markEpisodeSynced(rowId: Long, syncedAt: Long)

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchTotals.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchTotals.kt
@@ -1,0 +1,6 @@
+package com.thomaskioko.tvmaniac.data.rewatch.api
+
+public data class RewatchTotals(
+    val viewings: Long = 0,
+    val minutes: Long = 0,
+)

--- a/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchRepository.kt
+++ b/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchRepository.kt
@@ -11,6 +11,7 @@ import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchSession
 import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchSessionDao
 import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchStatus
 import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchSyncProviderDataSource
+import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchTotals
 import com.thomaskioko.tvmaniac.shows.api.TvShowsDao
 import com.thomaskioko.tvmaniac.syncstate.api.SyncError
 import com.thomaskioko.tvmaniac.syncstate.api.SyncObserver
@@ -118,6 +119,8 @@ public class DefaultRewatchRepository(
     }
 
     override fun observeEpisodeRewatches(episodeId: Long): Flow<Long> = rewatchSessionDao.observeEpisodeRewatches(episodeId)
+
+    override fun observeRewatchTotals(): Flow<RewatchTotals> = rewatchSessionDao.observeRewatchTotals()
 
     override suspend fun removeEpisodeRewatches(episodeId: Long) {
         rewatchSessionDao.removeEpisodeRewatches(episodeId)

--- a/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchSessionDao.kt
+++ b/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchSessionDao.kt
@@ -10,6 +10,7 @@ import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchCoverage
 import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchSession
 import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchSessionDao
 import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchStatus
+import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchTotals
 import com.thomaskioko.tvmaniac.data.rewatch.api.UnsentRewatchEpisode
 import com.thomaskioko.tvmaniac.db.Id
 import com.thomaskioko.tvmaniac.db.Rewatch_session
@@ -87,6 +88,11 @@ public class DefaultRewatchSessionDao(
 
     override fun observeEpisodeRewatches(episodeId: Long): Flow<Long> =
         queries.observeEpisodeRewatches(Id(episodeId))
+            .asFlow()
+            .mapToOne(dispatchers.databaseRead)
+
+    override fun observeRewatchTotals(): Flow<RewatchTotals> =
+        queries.rewatchTotals { viewings, minutes -> RewatchTotals(viewings = viewings, minutes = minutes) }
             .asFlow()
             .mapToOne(dispatchers.databaseRead)
 

--- a/data/rewatch/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchSessionDaoTest.kt
+++ b/data/rewatch/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchSessionDaoTest.kt
@@ -98,6 +98,26 @@ internal class DefaultRewatchSessionDaoTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun `should report zero totals given no episode was watched again`() = runTest {
+        val totals = dao.observeRewatchTotals().first()
+
+        totals.viewings shouldBe 0L
+        totals.minutes shouldBe 0L
+    }
+
+    @Test
+    fun `should add the episode runtime for each viewing given episodes were watched again`() = runTest {
+        val sessionId = dao.openSession(showId = showId, startedAt = STARTED_AT)
+        dao.addEpisodeToSession(sessionId = sessionId, episodeId = EPISODE_ID, watchedAt = REWATCHED_AT)
+        dao.addEpisodeToSession(sessionId = sessionId, episodeId = EPISODE_ID, watchedAt = SECOND_REWATCHED_AT)
+
+        val totals = dao.observeRewatchTotals().first()
+
+        totals.viewings shouldBe 2L
+        totals.minutes shouldBe 80L
+    }
+
+    @Test
     fun `should return no rewatches given no rewatch session exists for an episode`() = runTest {
         dao.observeEpisodeRewatches(EPISODE_ID).first() shouldBe 0L
     }

--- a/data/rewatch/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/testing/FakeRewatchRepository.kt
+++ b/data/rewatch/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/testing/FakeRewatchRepository.kt
@@ -4,6 +4,7 @@ import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchSession
 import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchRepository
 import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchSession
 import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchStatus
+import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchTotals
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -15,6 +16,7 @@ public class FakeRewatchRepository : RewatchRepository {
     private val sessionsByShow = MutableStateFlow<Map<Long, List<RewatchSession>>>(emptyMap())
     private val rewatchesByEpisode = MutableStateFlow<Map<Long, Long>>(emptyMap())
     private val statusByShow = MutableStateFlow<Map<Long, RewatchStatus>>(emptyMap())
+    private val totals = MutableStateFlow(RewatchTotals())
     private var supportsRewatchValue: Boolean = true
     private var remoteSessionsByShow: Map<Long, List<RemoteRewatchSession>> = emptyMap()
     private var syncException: Throwable? = null
@@ -31,6 +33,10 @@ public class FakeRewatchRepository : RewatchRepository {
 
     public fun setRewatchesForEpisode(episodeId: Long, rewatches: Long) {
         rewatchesByEpisode.value += (episodeId to rewatches)
+    }
+
+    public fun setRewatchTotals(totals: RewatchTotals) {
+        this.totals.value = totals
     }
 
     public fun setRewatchStatusForShow(showId: Long, status: RewatchStatus) {
@@ -91,6 +97,8 @@ public class FakeRewatchRepository : RewatchRepository {
 
     override fun observeEpisodeRewatches(episodeId: Long): Flow<Long> =
         rewatchesByEpisode.asStateFlow().map { it[episodeId] ?: 0L }
+
+    override fun observeRewatchTotals(): Flow<RewatchTotals> = totals.asStateFlow()
 
     override suspend fun removeEpisodeRewatches(episodeId: Long) {
         rewatchesByEpisode.value -= episodeId

--- a/domain/statistics/README.md
+++ b/domain/statistics/README.md
@@ -46,6 +46,10 @@ graph TB
     direction TB
     :data:ratings:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:upnext
     direction TB
     :data:upnext:api[api]:::multiplatform
@@ -73,12 +77,15 @@ graph TB
   :data:ratings:api --> :data:account-manager:api
   :data:ratings:api --> :data:database:sqldelight
   :data:ratings:api --> :data:followedshows:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:watch-status:api --> :data:database:sqldelight
   :domain:statistics --> :core:base
   :domain:statistics --> :core:util:api
   :domain:statistics --> :data:database:sqldelight
   :domain:statistics --> :data:episode:api
   :domain:statistics --> :data:ratings:api
+  :domain:statistics --> :data:rewatch:api
   :domain:statistics --> :data:watch-status:api
 
 classDef application fill:#CAFFBF,stroke:#000,stroke-width:2px,color:#000;

--- a/domain/statistics/build.gradle.kts
+++ b/domain/statistics/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
                 api(projects.data.database.sqldelight)
                 api(projects.data.episode.api)
                 api(projects.data.ratings.api)
+                api(projects.data.rewatch.api)
                 api(projects.data.watchStatus.api)
             }
         }
@@ -30,6 +31,7 @@ kotlin {
                 implementation(projects.data.episode.testing)
                 implementation(projects.data.ratings.implementation)
                 implementation(projects.data.ratings.testing)
+                implementation(projects.data.rewatch.testing)
                 implementation(projects.data.watchStatus.implementation)
             }
         }

--- a/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/ObserveWatchStatisticsInteractor.kt
+++ b/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/ObserveWatchStatisticsInteractor.kt
@@ -1,8 +1,10 @@
 package com.thomaskioko.tvmaniac.domain.statistics
 
+import com.thomaskioko.tvmaniac.core.base.extensions.combine
 import com.thomaskioko.tvmaniac.core.base.interactor.SubjectInteractor
 import com.thomaskioko.tvmaniac.data.ratings.api.HighestRatedShow
 import com.thomaskioko.tvmaniac.data.ratings.api.RatingsRepository
+import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchRepository
 import com.thomaskioko.tvmaniac.domain.statistics.model.WatchStatistics
 import com.thomaskioko.tvmaniac.episodes.api.EpisodeRepository
 import com.thomaskioko.tvmaniac.watchstatus.api.ShowWatchStatusRepository
@@ -15,6 +17,7 @@ public class ObserveWatchStatisticsInteractor(
     private val episodeRepository: EpisodeRepository,
     private val showWatchStatusRepository: ShowWatchStatusRepository,
     private val ratingsRepository: RatingsRepository,
+    private val rewatchRepository: RewatchRepository,
     private val calculator: WatchStatisticsCalculator,
 ) : SubjectInteractor<Unit, WatchStatistics>() {
 
@@ -24,7 +27,8 @@ public class ObserveWatchStatisticsInteractor(
         showWatchStatusRepository.observeShowCountsByStatus(),
         observeRatings(),
         episodeRepository.observeWatchedShowComposition(),
-    ) { watches, mostWatchedShows, showCountsByStatus, ratings, showComposition ->
+        rewatchRepository.observeRewatchTotals(),
+    ) { watches, mostWatchedShows, showCountsByStatus, ratings, showComposition, rewatchTotals ->
         calculator.calculate(
             watches = watches,
             mostWatchedShows = mostWatchedShows,
@@ -32,6 +36,7 @@ public class ObserveWatchStatisticsInteractor(
             ratingCounts = ratings.distribution,
             showComposition = showComposition,
             highestRatedShows = ratings.highestRated,
+            rewatchTotals = rewatchTotals,
         )
     }
 

--- a/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/WatchStatisticsCalculator.kt
+++ b/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/WatchStatisticsCalculator.kt
@@ -1,6 +1,7 @@
 package com.thomaskioko.tvmaniac.domain.statistics
 
 import com.thomaskioko.tvmaniac.data.ratings.api.HighestRatedShow
+import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchTotals
 import com.thomaskioko.tvmaniac.db.WatchStatus
 import com.thomaskioko.tvmaniac.domain.statistics.model.AverageRating
 import com.thomaskioko.tvmaniac.domain.statistics.model.DailyWatchCount
@@ -45,6 +46,7 @@ public class WatchStatisticsCalculator(
         ratingCounts: Map<Int, Long>,
         showComposition: List<WatchedShowComposition>,
         highestRatedShows: List<HighestRatedShow>,
+        rewatchTotals: RewatchTotals,
     ): WatchStatistics {
         val timeZone = dateTimeProvider.getTimeZone()
         val today = dateTimeProvider.now().toLocalDateTime(timeZone).date
@@ -56,8 +58,8 @@ public class WatchStatisticsCalculator(
         }
 
         return WatchStatistics(
-            totalWatchTime = WatchDuration(watchedDays.sumOf { it.minutes }),
-            episodesWatched = watches.size.toLong(),
+            totalWatchTime = WatchDuration(watchedDays.sumOf { it.minutes } + rewatchTotals.minutes),
+            episodesWatched = watches.size.toLong() + rewatchTotals.viewings,
             showsTracked = calculateShowsTracked(showCountsByStatus),
             averageRating = calculateAverageRating(ratingCounts),
             topWeekday = calculateTopWeekday(watchedDays),

--- a/domain/statistics/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/statistics/WatchStatisticsCalculatorTest.kt
+++ b/domain/statistics/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/statistics/WatchStatisticsCalculatorTest.kt
@@ -2,6 +2,7 @@ package com.thomaskioko.tvmaniac.domain.statistics
 
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.data.ratings.implementation.DefaultRatingsDao
+import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchTotals
 import com.thomaskioko.tvmaniac.database.test.BaseDatabaseTest
 import com.thomaskioko.tvmaniac.db.EpisodeId
 import com.thomaskioko.tvmaniac.db.Id
@@ -52,13 +53,16 @@ internal class WatchStatisticsCalculatorTest : BaseDatabaseTest() {
     private val ratingsDao = DefaultRatingsDao(database, dispatchers)
     private val calculator = WatchStatisticsCalculator(dateTimeProvider)
 
-    private suspend fun calculate(): WatchStatistics = calculator.calculate(
+    private suspend fun calculate(
+        rewatchTotals: RewatchTotals = RewatchTotals(),
+    ): WatchStatistics = calculator.calculate(
         watches = watchedEpisodeDao.observeWatchedAtWithRuntime().first(),
         mostWatchedShows = watchedEpisodeDao.observeMostWatchedShows(10).first(),
         showCountsByStatus = showWatchStatusDao.observeStatusCounts().first(),
         ratingCounts = ratingsDao.observeUserRatingDistribution().first(),
         showComposition = watchedEpisodeDao.observeWatchedShowComposition().first(),
         highestRatedShows = ratingsDao.observeHighestRatedShows(10).first(),
+        rewatchTotals = rewatchTotals,
     )
 
     @AfterTest
@@ -170,6 +174,43 @@ internal class WatchStatisticsCalculatorTest : BaseDatabaseTest() {
 
         statistics.totalWatchTime.totalMinutes shouldBe 90L
         statistics.hasRuntimeData shouldBe true
+    }
+
+    @Test
+    fun `should keep the totals unchanged given the account has no rewatches`() = runTest(testDispatcher) {
+        insertShow(tmdbId = BREAKING_BAD)
+        setShowRuntime(BREAKING_BAD, runtime = 45)
+        markWatched(BREAKING_BAD, episodeNumber = 1, watchedAt = epochMillis(2026, 8, 3))
+        markWatched(BREAKING_BAD, episodeNumber = 2, watchedAt = epochMillis(2026, 8, 3))
+
+        val statistics = calculate(rewatchTotals = RewatchTotals())
+
+        statistics.episodesWatched shouldBe 2L
+        statistics.totalWatchTime.totalMinutes shouldBe 90L
+    }
+
+    @Test
+    fun `should count every viewing given an episode was seen three times`() = runTest(testDispatcher) {
+        insertShow(tmdbId = BREAKING_BAD)
+        setShowRuntime(BREAKING_BAD, runtime = 45)
+        markWatched(BREAKING_BAD, episodeNumber = 1, watchedAt = epochMillis(2026, 8, 3))
+
+        val statistics = calculate(rewatchTotals = RewatchTotals(viewings = 2, minutes = 90))
+
+        statistics.episodesWatched shouldBe 3L
+        statistics.totalWatchTime.totalMinutes shouldBe 135L
+    }
+
+    @Test
+    fun `should leave the daily counts on first viewings given an episode was seen again`() = runTest(testDispatcher) {
+        insertShow(tmdbId = BREAKING_BAD)
+        setShowRuntime(BREAKING_BAD, runtime = 45)
+        markWatched(BREAKING_BAD, episodeNumber = 1, watchedAt = epochMillis(2026, 8, 3))
+
+        val statistics = calculate(rewatchTotals = RewatchTotals(viewings = 2, minutes = 90))
+
+        statistics.dailyCounts.sumOf { it.episodeCount } shouldBe 1
+        statistics.streak.currentDays shouldBe calculate().streak.currentDays
     }
 
     @Test

--- a/features/statistics/presenter/README.md
+++ b/features/statistics/presenter/README.md
@@ -46,6 +46,10 @@ graph TB
     direction TB
     :data:ratings:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:subscription
     direction TB
     :data:subscription:api[api]:::multiplatform
@@ -95,12 +99,15 @@ graph TB
   :data:ratings:api --> :data:account-manager:api
   :data:ratings:api --> :data:database:sqldelight
   :data:ratings:api --> :data:followedshows:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:watch-status:api --> :data:database:sqldelight
   :domain:statistics --> :core:base
   :domain:statistics --> :core:util:api
   :domain:statistics --> :data:database:sqldelight
   :domain:statistics --> :data:episode:api
   :domain:statistics --> :data:ratings:api
+  :domain:statistics --> :data:rewatch:api
   :domain:statistics --> :data:watch-status:api
   :features:show-details:nav --> :navigation:api
   :features:statistics:nav --> :navigation:api

--- a/features/statistics/presenter/build.gradle.kts
+++ b/features/statistics/presenter/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin {
                 implementation(projects.data.accountManager.testing)
                 implementation(projects.data.episode.testing)
                 implementation(projects.data.ratings.testing)
+                implementation(projects.data.rewatch.testing)
                 implementation(projects.data.subscription.testing)
                 implementation(projects.data.watchStatus.testing)
                 implementation(projects.i18n.testing)

--- a/features/statistics/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/statistics/presenter/StatisticsPresenterTest.kt
+++ b/features/statistics/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/statistics/presenter/StatisticsPresenterTest.kt
@@ -10,6 +10,7 @@ import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.logger.fixture.FakeLogger
 import com.thomaskioko.tvmaniac.core.view.ErrorToStringMapper
 import com.thomaskioko.tvmaniac.data.ratings.testing.FakeRatingsRepository
+import com.thomaskioko.tvmaniac.data.rewatch.testing.FakeRewatchRepository
 import com.thomaskioko.tvmaniac.db.WatchStatus
 import com.thomaskioko.tvmaniac.domain.statistics.ObserveWatchStatisticsInteractor
 import com.thomaskioko.tvmaniac.domain.statistics.SyncStatisticsInteractor
@@ -53,6 +54,7 @@ internal class StatisticsPresenterTest {
     private val episodeRepository = FakeEpisodeRepository()
     private val showWatchStatusRepository = FakeShowWatchStatusRepository()
     private val ratingsRepository = FakeRatingsRepository()
+    private val rewatchRepository = FakeRewatchRepository()
     private val watchedEpisodeSyncRepository = FakeWatchedEpisodeSyncRepository()
     private val dispatchers = AppCoroutineDispatchers(
         main = testDispatcher,
@@ -381,6 +383,7 @@ internal class StatisticsPresenterTest {
             episodeRepository = episodeRepository,
             showWatchStatusRepository = showWatchStatusRepository,
             ratingsRepository = ratingsRepository,
+            rewatchRepository = rewatchRepository,
             calculator = WatchStatisticsCalculator(dateTimeProvider),
         ),
         accountManager = accountManager,

--- a/features/statistics/ui/README.md
+++ b/features/statistics/ui/README.md
@@ -48,6 +48,10 @@ graph TB
     direction TB
     :data:ratings:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:subscription
     direction TB
     :data:subscription:api[api]:::multiplatform
@@ -103,12 +107,15 @@ graph TB
   :data:ratings:api --> :data:account-manager:api
   :data:ratings:api --> :data:database:sqldelight
   :data:ratings:api --> :data:followedshows:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:watch-status:api --> :data:database:sqldelight
   :domain:statistics --> :core:base
   :domain:statistics --> :core:util:api
   :domain:statistics --> :data:database:sqldelight
   :domain:statistics --> :data:episode:api
   :domain:statistics --> :data:ratings:api
+  :domain:statistics --> :data:rewatch:api
   :domain:statistics --> :data:watch-status:api
   :domain:theme --> :i18n:generator
   :features:show-details:nav --> :navigation:api

--- a/ios-framework/README.md
+++ b/ios-framework/README.md
@@ -991,6 +991,7 @@ graph TB
   :domain:statistics --> :data:database:sqldelight
   :domain:statistics --> :data:episode:api
   :domain:statistics --> :data:ratings:api
+  :domain:statistics --> :data:rewatch:api
   :domain:statistics --> :data:watch-status:api
   :domain:sync-activity --> :core:base
   :domain:sync-activity --> :data:sync-activity:api


### PR DESCRIPTION
## Description
This PR counts every viewing in the statistics totals, so an episode watched three times adds three to episodes watched and three times its runtime to total time watched.

## Changes
- Count every viewing in episodes watched and total time watched on the statistics screen.
- Read the runtime for each repeat viewing from the episode, falling back to the show when the episode has none.
- Leave the heat map, streaks and the day and month charts counting first viewings, so the shape of a year does not change.
