### PR TITLE
fix: Clear a season's plays when it is removed from watched

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1165,6 +1165,7 @@ graph TB
   :domain:seasondetails --> :core:base
   :domain:seasondetails --> :data:cast:api
   :domain:seasondetails --> :data:episode:api
+  :domain:seasondetails --> :data:rewatch:api
   :domain:seasondetails --> :data:seasondetails:api
   :domain:settings --> :core:base
   :domain:settings --> :core:util:api

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Rewatch.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Rewatch.sq
@@ -107,6 +107,15 @@ removeEpisodeRewatches:
 DELETE FROM rewatch_session_episode
 WHERE episode_id = :episodeId;
 
+removeSeasonRewatches:
+DELETE FROM rewatch_session_episode
+WHERE episode_id IN (
+    SELECT episode.id
+    FROM episode
+    INNER JOIN season ON season.id = episode.season_id
+    WHERE season.show_id = :showId AND season.season_number = :seasonNumber
+);
+
 rewatchTotals:
 SELECT
     COUNT(*) AS viewings,

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchRepository.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchRepository.kt
@@ -28,6 +28,8 @@ public interface RewatchRepository {
 
     public suspend fun removeEpisodeRewatches(episodeId: Long)
 
+    public suspend fun removeSeasonRewatches(showId: Long, seasonNumber: Long)
+
     public fun observeRewatchTotals(): Flow<RewatchTotals>
 
     public suspend fun supportsRewatch(): Boolean

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchSessionDao.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchSessionDao.kt
@@ -23,6 +23,8 @@ public interface RewatchSessionDao {
 
     public fun removeEpisodeRewatches(episodeId: Long)
 
+    public fun removeSeasonRewatches(showId: Long, seasonNumber: Long)
+
     public fun observeRewatchTotals(): Flow<RewatchTotals>
 
     public fun unsentEpisodes(): List<UnsentRewatchEpisode>

--- a/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchRepository.kt
+++ b/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchRepository.kt
@@ -126,6 +126,11 @@ public class DefaultRewatchRepository(
         rewatchSessionDao.removeEpisodeRewatches(episodeId)
     }
 
+    override suspend fun removeSeasonRewatches(showId: Long, seasonNumber: Long) {
+        val localShowId = tvShowsDao.getLocalShowIdByTmdbId(showId) ?: return
+        rewatchSessionDao.removeSeasonRewatches(showId = localShowId, seasonNumber = seasonNumber)
+    }
+
     override suspend fun supportsRewatch(): Boolean = activeSource()?.supportsRewatch() ?: true
 
     override suspend fun syncPendingRewatches() {

--- a/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchSessionDao.kt
+++ b/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchSessionDao.kt
@@ -100,6 +100,10 @@ public class DefaultRewatchSessionDao(
         queries.removeEpisodeRewatches(Id(episodeId))
     }
 
+    override fun removeSeasonRewatches(showId: Long, seasonNumber: Long) {
+        queries.removeSeasonRewatches(showId = Id(showId), seasonNumber = seasonNumber)
+    }
+
     override fun unsentEpisodes(): List<UnsentRewatchEpisode> =
         queries.unsentEpisodes().executeAsList().map { it.toUnsentRewatchEpisode() }
 

--- a/data/rewatch/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchSessionDaoTest.kt
+++ b/data/rewatch/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchSessionDaoTest.kt
@@ -98,6 +98,26 @@ internal class DefaultRewatchSessionDaoTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun `should clear the plays of a season given the season is removed from watched`() = runTest {
+        val sessionId = dao.openSession(showId = showId, startedAt = STARTED_AT)
+        dao.addEpisodeToSession(sessionId = sessionId, episodeId = EPISODE_ID, watchedAt = REWATCHED_AT)
+
+        dao.removeSeasonRewatches(showId = showId, seasonNumber = 1L)
+
+        dao.observeEpisodeRewatches(EPISODE_ID).first() shouldBe 0L
+    }
+
+    @Test
+    fun `should keep the plays of other seasons given one season is removed from watched`() = runTest {
+        val sessionId = dao.openSession(showId = showId, startedAt = STARTED_AT)
+        dao.addEpisodeToSession(sessionId = sessionId, episodeId = EPISODE_ID, watchedAt = REWATCHED_AT)
+
+        dao.removeSeasonRewatches(showId = showId, seasonNumber = 2L)
+
+        dao.observeEpisodeRewatches(EPISODE_ID).first() shouldBe 1L
+    }
+
+    @Test
     fun `should report zero totals given no episode was watched again`() = runTest {
         val totals = dao.observeRewatchTotals().first()
 

--- a/data/rewatch/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/testing/FakeRewatchRepository.kt
+++ b/data/rewatch/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/testing/FakeRewatchRepository.kt
@@ -17,6 +17,7 @@ public class FakeRewatchRepository : RewatchRepository {
     private val rewatchesByEpisode = MutableStateFlow<Map<Long, Long>>(emptyMap())
     private val statusByShow = MutableStateFlow<Map<Long, RewatchStatus>>(emptyMap())
     private val totals = MutableStateFlow(RewatchTotals())
+    private val removedSeasons = mutableListOf<Pair<Long, Long>>()
     private var supportsRewatchValue: Boolean = true
     private var remoteSessionsByShow: Map<Long, List<RemoteRewatchSession>> = emptyMap()
     private var syncException: Throwable? = null
@@ -103,6 +104,12 @@ public class FakeRewatchRepository : RewatchRepository {
     override suspend fun removeEpisodeRewatches(episodeId: Long) {
         rewatchesByEpisode.value -= episodeId
     }
+
+    override suspend fun removeSeasonRewatches(showId: Long, seasonNumber: Long) {
+        removedSeasons += showId to seasonNumber
+    }
+
+    public fun removedSeasons(): List<Pair<Long, Long>> = removedSeasons.toList()
 
     override suspend fun supportsRewatch(): Boolean = supportsRewatchValue
 

--- a/domain/episode/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/episode/MarkEpisodeUnwatchedInteractorTest.kt
+++ b/domain/episode/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/episode/MarkEpisodeUnwatchedInteractorTest.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
-class MarkEpisodeUnwatchedInteractorTest {
+internal class MarkEpisodeUnwatchedInteractorTest {
     private val episodeRepository = FakeEpisodeRepository()
     private val rewatchRepository = FakeRewatchRepository()
 

--- a/domain/seasondetails/README.md
+++ b/domain/seasondetails/README.md
@@ -10,9 +10,17 @@ graph TB
     :core:base[base]:::multiplatform
     :core:view[view]:::multiplatform
   end
+  subgraph :core:connectivity
+    direction TB
+    :core:connectivity:api[api]:::multiplatform
+  end
   subgraph :core:logger
     direction TB
     :core:logger:api[api]:::multiplatform
+  end
+  subgraph :core:network-util
+    direction TB
+    :core:network-util:api[api]:::multiplatform
   end
   subgraph :data:account-manager
     direction TB
@@ -34,6 +42,10 @@ graph TB
     direction TB
     :data:followedshows:api[api]:::multiplatform
   end
+  subgraph :data:rewatch
+    direction TB
+    :data:rewatch:api[api]:::multiplatform
+  end
   subgraph :data:seasondetails
     direction TB
     :data:seasondetails:api[api]:::multiplatform
@@ -49,6 +61,7 @@ graph TB
 
   :core:base --> :core:logger:api
   :core:base --> :core:view
+  :core:network-util:api --> :core:connectivity:api
   :core:view --> :core:logger:api
   :data:account-manager:api --> :data:database:sqldelight
   :data:cast:api --> :data:database:sqldelight
@@ -57,10 +70,13 @@ graph TB
   :data:episode:api --> :data:database:sqldelight
   :data:episode:api --> :data:followedshows:api
   :data:episode:api --> :data:upnext:api
+  :data:rewatch:api --> :core:network-util:api
+  :data:rewatch:api --> :data:account-manager:api
   :data:seasondetails:api --> :data:database:sqldelight
   :domain:seasondetails --> :core:base
   :domain:seasondetails --> :data:cast:api
   :domain:seasondetails --> :data:episode:api
+  :domain:seasondetails --> :data:rewatch:api
   :domain:seasondetails --> :data:seasondetails:api
 
 classDef application fill:#CAFFBF,stroke:#000,stroke-width:2px,color:#000;

--- a/domain/seasondetails/build.gradle.kts
+++ b/domain/seasondetails/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
                 api(projects.core.base)
                 api(projects.data.cast.api)
                 api(projects.data.episode.api)
+                api(projects.data.rewatch.api)
                 api(projects.data.seasondetails.api)
             }
         }

--- a/domain/seasondetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/seasondetails/MarkSeasonUnwatchedInteractor.kt
+++ b/domain/seasondetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/seasondetails/MarkSeasonUnwatchedInteractor.kt
@@ -1,16 +1,22 @@
 package com.thomaskioko.tvmaniac.domain.seasondetails
 
 import com.thomaskioko.tvmaniac.core.base.interactor.Interactor
+import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchRepository
 import com.thomaskioko.tvmaniac.episodes.api.EpisodeRepository
 import dev.zacsweers.metro.Inject
 
 @Inject
 public class MarkSeasonUnwatchedInteractor(
     private val episodeRepository: EpisodeRepository,
+    private val rewatchRepository: RewatchRepository,
 ) : Interactor<MarkSeasonUnwatchedParams>() {
 
     override suspend fun doWork(params: MarkSeasonUnwatchedParams) {
         episodeRepository.markSeasonUnwatched(
+            showId = params.showId,
+            seasonNumber = params.seasonNumber,
+        )
+        rewatchRepository.removeSeasonRewatches(
             showId = params.showId,
             seasonNumber = params.seasonNumber,
         )

--- a/features/season-details/presenter/README.md
+++ b/features/season-details/presenter/README.md
@@ -146,6 +146,7 @@ graph TB
   :domain:seasondetails --> :core:base
   :domain:seasondetails --> :data:cast:api
   :domain:seasondetails --> :data:episode:api
+  :domain:seasondetails --> :data:rewatch:api
   :domain:seasondetails --> :data:seasondetails:api
   :features:episode-sheet:nav --> :navigation:api
   :features:rating-sheet:nav --> :data:ratings:api

--- a/features/season-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/SeasonPresenterTest.kt
+++ b/features/season-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/SeasonPresenterTest.kt
@@ -1385,6 +1385,7 @@ class SeasonPresenterTest {
             ),
             markSeasonUnwatchedInteractor = MarkSeasonUnwatchedInteractor(
                 episodeRepository = episodeRepository,
+                rewatchRepository = rewatchRepository,
             ),
             fetchPreviousSeasonsInteractor = FetchPreviousSeasonsInteractor(
                 seasonDetailsRepository = seasonDetailsRepository,

--- a/features/season-details/ui/README.md
+++ b/features/season-details/ui/README.md
@@ -154,6 +154,7 @@ graph TB
   :domain:seasondetails --> :core:base
   :domain:seasondetails --> :data:cast:api
   :domain:seasondetails --> :data:episode:api
+  :domain:seasondetails --> :data:rewatch:api
   :domain:seasondetails --> :data:seasondetails:api
   :domain:theme --> :i18n:generator
   :features:episode-sheet:nav --> :navigation:api

--- a/ios-framework/README.md
+++ b/ios-framework/README.md
@@ -964,6 +964,7 @@ graph TB
   :domain:seasondetails --> :core:base
   :domain:seasondetails --> :data:cast:api
   :domain:seasondetails --> :data:episode:api
+  :domain:seasondetails --> :data:rewatch:api
   :domain:seasondetails --> :data:seasondetails:api
   :domain:settings --> :core:base
   :domain:settings --> :core:util:api


### PR DESCRIPTION
## Description
This PR clears the plays an episode recorded when its whole season is removed from watched, matching what removing a single episode already does.

## Bug Fixes
- Clear a season's recorded plays when it is removed from watched, so the statistics totals and the episode play count stop counting viewings for an episode that is no longer watched.
