### PR TITLE
fix: Restore play counts

### DIFF
--- a/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/DefaultSimklRewatchRemoteDataSource.kt
+++ b/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/DefaultSimklRewatchRemoteDataSource.kt
@@ -32,6 +32,7 @@ public class DefaultSimklRewatchRemoteDataSource(
                 path("sync/all-items/shows")
                 parameter("allow_rewatch", "yes")
                 parameter("extended", "full")
+                parameter("episode_watched_at", "yes")
                 dateFrom?.let { parameter("date_from", it) }
             }
         }

--- a/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklRewatchSyncProviderDataSource.kt
+++ b/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklRewatchSyncProviderDataSource.kt
@@ -4,6 +4,7 @@ import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.map
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchClose
+import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchEpisode
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchSession
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchSessionStatus
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchWrite
@@ -103,17 +104,26 @@ public class SimklRewatchSyncProviderDataSource(
     }
 }
 
-private fun SimklRewatchShow.toRemoteRewatchSession(): RemoteRewatchSession = RemoteRewatchSession(
-    providerSessionId = rewatchId,
-    seasonNumber = null,
-    episodeNumber = null,
-    episodeCount = watchedEpisodesCount?.toLong()?.takeIf { it > 0 },
-    lastWatchedAt = lastWatchedAt?.toEpochMillis(),
-    status = RemoteRewatchSessionStatus.fromRaw(rewatchStatus),
-    startedAt = seasons
-        .flatMap { season -> season.episodes }
-        .mapNotNull { episode -> episode.watchedAt?.toEpochMillis() }
-        .minOrNull(),
-)
+private fun SimklRewatchShow.toRemoteRewatchSession(): RemoteRewatchSession {
+    val episodes = seasons.flatMap { season ->
+        season.episodes.mapNotNull { episode ->
+            val seasonNumber = season.number ?: return@mapNotNull null
+            val episodeNumber = episode.number ?: return@mapNotNull null
+            RemoteRewatchEpisode(
+                seasonNumber = seasonNumber.toLong(),
+                episodeNumber = episodeNumber.toLong(),
+                watchedAt = episode.watchedAt?.toEpochMillis(),
+            )
+        }
+    }
+
+    return RemoteRewatchSession(
+        providerSessionId = rewatchId,
+        lastWatchedAt = lastWatchedAt?.toEpochMillis(),
+        status = RemoteRewatchSessionStatus.fromRaw(rewatchStatus),
+        startedAt = episodes.mapNotNull { it.watchedAt }.minOrNull(),
+        episodes = episodes,
+    )
+}
 
 private fun String.toEpochMillis(): Long? = runCatching { Instant.parse(this).toEpochMilliseconds() }.getOrNull()

--- a/api/simkl/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/DefaultSimklRewatchRemoteDataSourceTest.kt
+++ b/api/simkl/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/DefaultSimklRewatchRemoteDataSourceTest.kt
@@ -48,17 +48,19 @@ internal class DefaultSimklRewatchRemoteDataSourceTest {
     }
 
     @Test
-    fun `should use GET method with the rewatch flag and extended full param given rewatch sessions are read`() = runTest {
+    fun `should use GET method with the rewatch flag and the extended episode params given rewatch sessions are read`() = runTest {
         var capturedMethod: HttpMethod? = null
         var capturedPath: String? = null
         var capturedAllowRewatch: String? = null
         var capturedExtended: String? = null
+        var capturedEpisodeWatchedAt: String? = null
 
         val engine = MockEngine { request ->
             capturedMethod = request.method
             capturedPath = request.url.encodedPath
             capturedAllowRewatch = request.url.parameters["allow_rewatch"]
             capturedExtended = request.url.parameters["extended"]
+            capturedEpisodeWatchedAt = request.url.parameters["episode_watched_at"]
             respond(
                 content = SIMKL_REWATCH_ITEMS_RESPONSE,
                 status = HttpStatusCode.OK,
@@ -73,6 +75,7 @@ internal class DefaultSimklRewatchRemoteDataSourceTest {
         capturedPath shouldBe "/sync/all-items/shows"
         capturedAllowRewatch shouldBe "yes"
         capturedExtended shouldBe "full"
+        capturedEpisodeWatchedAt shouldBe "yes"
     }
 
     @Test

--- a/api/simkl/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklRewatchSyncProviderDataSourceTest.kt
+++ b/api/simkl/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklRewatchSyncProviderDataSourceTest.kt
@@ -22,6 +22,7 @@ import com.thomaskioko.tvmaniac.simkl.api.model.SimklUser
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklUserSettingsResponse
 import com.thomaskioko.tvmaniac.simkl.testing.FakeSimklRewatchRemoteDataSource
 import com.thomaskioko.tvmaniac.simkl.testing.FakeSimklUserRemoteDataSource
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -167,25 +168,45 @@ internal class SimklRewatchSyncProviderDataSourceTest {
     }
 
     @Test
-    fun `should treat a zero episode count as unknown given the response carries the sentinel`() = runTest {
+    fun `should carry no episodes given the response omits them`() = runTest {
         rewatchRemoteDataSource.setRewatchSessionsResponse(
             ApiResponse.Success(SimklRewatchItemsResponse(shows = listOf(rewatchShow(tmdbId = "1396", watchedEpisodesCount = 0)))),
         )
 
         val sessions = source.readRewatchSessions(providerShowId = 1396L).getOrThrow()
 
-        sessions.first().episodeCount.shouldBeNull()
+        sessions.first().episodes.shouldBeEmpty()
     }
 
     @Test
-    fun `should treat a positive episode count as real given the extended payload is present`() = runTest {
+    fun `should carry every episode of the session given the extended payload is present`() = runTest {
         rewatchRemoteDataSource.setRewatchSessionsResponse(
-            ApiResponse.Success(SimklRewatchItemsResponse(shows = listOf(rewatchShow(tmdbId = "1396", watchedEpisodesCount = 5)))),
+            ApiResponse.Success(
+                SimklRewatchItemsResponse(
+                    shows = listOf(
+                        rewatchShow(
+                            tmdbId = "1396",
+                            watchedEpisodesCount = 2,
+                            seasons = listOf(
+                                SimklRewatchSeason(
+                                    number = 1,
+                                    episodes = listOf(
+                                        SimklRewatchEpisode(number = 1, watchedAt = "2026-01-15T00:00:00Z"),
+                                        SimklRewatchEpisode(number = 2, watchedAt = "2026-02-01T00:00:00Z"),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
         )
 
-        val sessions = source.readRewatchSessions(providerShowId = 1396L).getOrThrow()
+        val episodes = source.readRewatchSessions(providerShowId = 1396L).getOrThrow().first().episodes
 
-        sessions.first().episodeCount shouldBe 5L
+        episodes.map { it.episodeNumber } shouldBe listOf(1L, 2L)
+        episodes.first().seasonNumber shouldBe 1L
+        episodes.first().watchedAt shouldBe Instant.parse("2026-01-15T00:00:00Z").toEpochMilliseconds()
     }
 
     @Test
@@ -207,8 +228,8 @@ internal class SimklRewatchSyncProviderDataSourceTest {
             ApiResponse.Success(
                 SimklRewatchItemsResponse(
                     shows = listOf(
-                        rewatchShow(tmdbId = "1396", watchedEpisodesCount = 5, isRewatch = false),
-                        rewatchShow(tmdbId = "1396", watchedEpisodesCount = 3, isRewatch = true),
+                        rewatchShow(tmdbId = "1396", watchedEpisodesCount = 5, isRewatch = false, rewatchId = 2002L),
+                        rewatchShow(tmdbId = "1396", watchedEpisodesCount = 3, isRewatch = true, rewatchId = 3003L),
                     ),
                 ),
             ),
@@ -217,7 +238,7 @@ internal class SimklRewatchSyncProviderDataSourceTest {
         val sessions = source.readRewatchSessions(providerShowId = 1396L).getOrThrow()
 
         sessions.size shouldBe 1
-        sessions.first().episodeCount shouldBe 3L
+        sessions.first().providerSessionId shouldBe 3003L
     }
 
     @Test

--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktRewatchSyncProviderDataSource.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktRewatchSyncProviderDataSource.kt
@@ -4,7 +4,9 @@ import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.map
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchClose
+import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchEpisode
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchSession
+import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchSessionStatus
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchWrite
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchWriteResult
 import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchSyncProviderDataSource
@@ -62,17 +64,32 @@ public class TraktRewatchSyncProviderDataSource(
     override suspend fun closeRewatch(close: RemoteRewatchClose): ApiResponse<Unit> = ApiResponse.Success(Unit)
 }
 
-private fun TraktWatchedShowResponse.toRemoteRewatchSessions(): List<RemoteRewatchSession> =
-    seasons.orEmpty().flatMap { season ->
+private fun TraktWatchedShowResponse.toRemoteRewatchSessions(): List<RemoteRewatchSession> {
+    val episodes = seasons.orEmpty().flatMap { season ->
         season.episodes.mapNotNull { episode ->
             val plays = episode.plays ?: return@mapNotNull null
             if (plays <= 1L) return@mapNotNull null
-            RemoteRewatchSession(
-                providerSessionId = null,
+            RemoteRewatchEpisode(
                 seasonNumber = season.number,
                 episodeNumber = episode.number,
-                episodeCount = plays - 1,
-                lastWatchedAt = episode.lastWatchedAt?.let { runCatching { Instant.parse(it).toEpochMilliseconds() }.getOrNull() },
+                watchedAt = episode.lastWatchedAt?.toEpochMillis(),
+                viewings = plays - 1,
             )
         }
     }
+
+    if (episodes.isEmpty()) return emptyList()
+
+    val watchedAt = episodes.mapNotNull { it.watchedAt }
+    return listOf(
+        RemoteRewatchSession(
+            providerSessionId = null,
+            lastWatchedAt = watchedAt.maxOrNull(),
+            status = RemoteRewatchSessionStatus.CLOSED,
+            startedAt = watchedAt.minOrNull(),
+            episodes = episodes,
+        ),
+    )
+}
+
+private fun String.toEpochMillis(): Long? = runCatching { Instant.parse(this).toEpochMilliseconds() }.getOrNull()

--- a/api/trakt/implementation/src/commonTest/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktRewatchSyncProviderDataSourceTest.kt
+++ b/api/trakt/implementation/src/commonTest/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktRewatchSyncProviderDataSourceTest.kt
@@ -50,16 +50,17 @@ internal class TraktRewatchSyncProviderDataSourceTest {
     }
 
     @Test
-    fun `should map an episode with more than one play into extra sessions of one`() = runTest {
+    fun `should carry the extra plays of an episode as viewings of one session`() = runTest {
         syncRemoteDataSource.setWatchedShows(ApiResponse.Success(listOf(showWithPlays(tmdbId = 1396L, plays = 3L))))
 
         val sessions = source.readRewatchSessions(providerShowId = 1396L).getOrThrow()
 
         sessions shouldHaveSize 1
-        sessions.first().seasonNumber shouldBe 1L
-        sessions.first().episodeNumber shouldBe 1L
-        sessions.first().episodeCount shouldBe 2L
         sessions.first().providerSessionId shouldBe null
+        sessions.first().episodes shouldHaveSize 1
+        sessions.first().episodes.first().seasonNumber shouldBe 1L
+        sessions.first().episodes.first().episodeNumber shouldBe 1L
+        sessions.first().episodes.first().viewings shouldBe 2L
     }
 
     @Test

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Rewatch.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Rewatch.sq
@@ -37,6 +37,24 @@ addEpisodeToSession:
 INSERT INTO rewatch_session_episode(session_id, episode_id, watched_at)
 VALUES (:sessionId, :episodeId, :watchedAt);
 
+addSyncedEpisodeToSession:
+INSERT INTO rewatch_session_episode(session_id, episode_id, watched_at, synced_at)
+VALUES (:sessionId, :episodeId, :watchedAt, :syncedAt);
+
+episodeIdForNumber:
+SELECT episode.id
+FROM episode
+INNER JOIN season ON episode.season_id = season.id
+WHERE episode.show_id = :showId
+  AND season.season_number = :seasonNumber
+  AND episode.episode_number = :episodeNumber
+LIMIT 1;
+
+episodeRewatchCount:
+SELECT COUNT(*)
+FROM rewatch_session_episode
+WHERE episode_id = :episodeId;
+
 closeSession:
 UPDATE rewatch_session
 SET closed_at = :closedAt

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RemoteRewatchEpisode.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RemoteRewatchEpisode.kt
@@ -1,0 +1,8 @@
+package com.thomaskioko.tvmaniac.data.rewatch.api
+
+public data class RemoteRewatchEpisode(
+    val seasonNumber: Long,
+    val episodeNumber: Long,
+    val watchedAt: Long?,
+    val viewings: Long = 1,
+)

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RemoteRewatchSession.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RemoteRewatchSession.kt
@@ -1,23 +1,9 @@
 package com.thomaskioko.tvmaniac.data.rewatch.api
 
-/**
- * A single rewatch session as reported by the active provider.
- *
- * The two providers fill this differently. Simkl returns one row per show: a session-level
- * aggregate with [providerSessionId], [episodeCount], [status] and [startedAt] set, and
- * [seasonNumber] and [episodeNumber] null, since Simkl does not say which episodes made up the
- * count. Trakt returns one row per rewatched episode: [seasonNumber] and [episodeNumber] set, and
- * [providerSessionId] and [startedAt] null, since Trakt has no session concept.
- *
- * Only a session carrying a [providerSessionId] can be written to the local table, since that id is
- * what makes a repeated sync land on the row it wrote last time.
- */
 public data class RemoteRewatchSession(
     val providerSessionId: Long?,
-    val seasonNumber: Long?,
-    val episodeNumber: Long?,
-    val episodeCount: Long?,
     val lastWatchedAt: Long?,
     val status: RemoteRewatchSessionStatus = RemoteRewatchSessionStatus.ACTIVE,
     val startedAt: Long? = null,
+    val episodes: List<RemoteRewatchEpisode> = emptyList(),
 )

--- a/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchSessionDao.kt
+++ b/data/rewatch/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/api/RewatchSessionDao.kt
@@ -7,6 +7,12 @@ public interface RewatchSessionDao {
 
     public fun addEpisodeToSession(sessionId: Long, episodeId: Long, watchedAt: Long): Long
 
+    public fun addSyncedEpisodeToSession(sessionId: Long, episodeId: Long, watchedAt: Long, syncedAt: Long)
+
+    public fun episodeIdForNumber(showId: Long, seasonNumber: Long, episodeNumber: Long): Long?
+
+    public fun episodeRewatchCount(episodeId: Long): Long
+
     public fun closeSession(sessionId: Long, closedAt: Long)
 
     public fun observeSessionsForShow(showId: Long): Flow<List<RewatchSession>>
@@ -38,7 +44,7 @@ public interface RewatchSessionDao {
         providerSessionId: Long,
         startedAt: Long,
         closedAt: Long?,
-    )
+    ): Long
 
     public fun clearAll()
 }

--- a/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchRepository.kt
+++ b/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchRepository.kt
@@ -165,21 +165,46 @@ public class DefaultRewatchRepository(
 
     private fun backfillSessions(showId: Long, sessions: List<RemoteRewatchSession>) {
         val localShowId = tvShowsDao.getLocalShowIdByTmdbId(showId) ?: return
+        val restored = mutableMapOf<Long, RestoredEpisode>()
 
         for (session in sessions) {
-            val providerSessionId = session.providerSessionId ?: continue
             val startedAt = session.startedAt ?: session.lastWatchedAt ?: continue
-            rewatchSessionDao.upsertProviderSession(
+            val localSessionId = rewatchSessionDao.upsertProviderSession(
                 showId = localShowId,
-                providerSessionId = providerSessionId,
+                providerSessionId = session.providerSessionId ?: SESSIONLESS_PROVIDER_ID,
                 startedAt = startedAt,
-                closedAt = when (session.status) {
-                    RemoteRewatchSessionStatus.ACTIVE -> null
-                    RemoteRewatchSessionStatus.CLOSED,
-                    RemoteRewatchSessionStatus.COMPLETED,
-                    -> session.lastWatchedAt ?: startedAt
+                closedAt = when {
+                    session.providerSessionId == null -> session.lastWatchedAt ?: startedAt
+                    session.status == RemoteRewatchSessionStatus.ACTIVE -> null
+                    else -> session.lastWatchedAt ?: startedAt
                 },
             )
+
+            for (episode in session.episodes) {
+                val episodeId = rewatchSessionDao.episodeIdForNumber(
+                    showId = localShowId,
+                    seasonNumber = episode.seasonNumber,
+                    episodeNumber = episode.episodeNumber,
+                ) ?: continue
+
+                restored[episodeId] = RestoredEpisode(
+                    sessionId = localSessionId,
+                    watchedAt = episode.watchedAt ?: startedAt,
+                    viewings = (restored[episodeId]?.viewings ?: 0) + episode.viewings,
+                )
+            }
+        }
+
+        for ((episodeId, episode) in restored) {
+            val missing = episode.viewings - rewatchSessionDao.episodeRewatchCount(episodeId)
+            repeat(missing.coerceAtLeast(0).toInt()) {
+                rewatchSessionDao.addSyncedEpisodeToSession(
+                    sessionId = episode.sessionId,
+                    episodeId = episodeId,
+                    watchedAt = episode.watchedAt,
+                    syncedAt = dateTimeProvider.nowMillis(),
+                )
+            }
         }
     }
 
@@ -250,7 +275,14 @@ public class DefaultRewatchRepository(
         is ApiResponse.Error.OfflineError -> Throwable(errorMessage)
     }
 
+    private data class RestoredEpisode(
+        val sessionId: Long,
+        val watchedAt: Long,
+        val viewings: Long,
+    )
+
     private companion object {
         private const val TAG = "rewatch_sync"
+        private const val SESSIONLESS_PROVIDER_ID = -1L
     }
 }

--- a/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchSessionDao.kt
+++ b/data/rewatch/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchSessionDao.kt
@@ -45,6 +45,25 @@ public class DefaultRewatchSessionDao(
         queries.lastInsertRowId().executeAsOne()
     }
 
+    override fun addSyncedEpisodeToSession(sessionId: Long, episodeId: Long, watchedAt: Long, syncedAt: Long) {
+        queries.addSyncedEpisodeToSession(
+            sessionId = sessionId,
+            episodeId = Id(episodeId),
+            watchedAt = watchedAt,
+            syncedAt = syncedAt,
+        )
+    }
+
+    override fun episodeIdForNumber(showId: Long, seasonNumber: Long, episodeNumber: Long): Long? =
+        queries.episodeIdForNumber(
+            showId = Id(showId),
+            seasonNumber = seasonNumber,
+            episodeNumber = episodeNumber,
+        ).executeAsOneOrNull()?.id
+
+    override fun episodeRewatchCount(episodeId: Long): Long =
+        queries.episodeRewatchCount(Id(episodeId)).executeAsOne()
+
     override fun closeSession(sessionId: Long, closedAt: Long) {
         queries.closeSession(sessionId = sessionId, closedAt = closedAt)
     }
@@ -121,27 +140,27 @@ public class DefaultRewatchSessionDao(
         providerSessionId: Long,
         startedAt: Long,
         closedAt: Long?,
-    ) {
-        queries.transaction {
-            val existing = queries.sessionByProviderSessionId(
-                showId = Id(showId),
-                providerSessionId = providerSessionId,
-            ).executeAsOneOrNull()
+    ): Long = queries.transactionWithResult {
+        val existing = queries.sessionByProviderSessionId(
+            showId = Id(showId),
+            providerSessionId = providerSessionId,
+        ).executeAsOneOrNull()
 
-            if (existing == null) {
-                queries.insertProviderSession(
-                    showId = Id(showId),
-                    startedAt = startedAt,
-                    closedAt = closedAt,
-                    providerSessionId = providerSessionId,
-                )
-            } else {
-                queries.mergeProviderSession(
-                    startedAt = startedAt,
-                    closedAt = closedAt,
-                    sessionId = existing.id,
-                )
-            }
+        if (existing == null) {
+            queries.insertProviderSession(
+                showId = Id(showId),
+                startedAt = startedAt,
+                closedAt = closedAt,
+                providerSessionId = providerSessionId,
+            )
+            queries.lastInsertRowId().executeAsOne()
+        } else {
+            queries.mergeProviderSession(
+                startedAt = startedAt,
+                closedAt = closedAt,
+                sessionId = existing.id,
+            )
+            existing.id
         }
     }
 

--- a/data/rewatch/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchRepositoryTest.kt
+++ b/data/rewatch/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/rewatch/implementation/DefaultRewatchRepositoryTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchEpisode
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchSession
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchSessionStatus
 import com.thomaskioko.tvmaniac.data.rewatch.api.RemoteRewatchWriteResult
@@ -506,9 +507,6 @@ internal class DefaultRewatchRepositoryTest : BaseDatabaseTest() {
         val repository = buildRepository()
         val session = RemoteRewatchSession(
             providerSessionId = null,
-            seasonNumber = 1L,
-            episodeNumber = 1L,
-            episodeCount = 2L,
             lastWatchedAt = REWATCHED_AT,
         )
         rewatchSyncProviderDataSource.setReadRewatchSessionsResponse(ApiResponse.Success(listOf(session)))
@@ -692,28 +690,160 @@ internal class DefaultRewatchRepositoryTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun `should write no local session given the provider reports one without a session id`() = runTest {
+    fun `should write one local session given the provider reports one without a session id`() = runTest {
         val repository = buildRepository()
         rewatchSyncProviderDataSource.setReadRewatchSessionsResponse(
-            ApiResponse.Success(listOf(remoteSession(providerSessionId = null))),
+            ApiResponse.Success(listOf(remoteSession(providerSessionId = null, episodes = listOf(remoteEpisode())))),
+        )
+
+        repository.syncRewatchSessions(TMDB_ID)
+        repository.syncRewatchSessions(TMDB_ID)
+
+        rewatchSessionDao.observeSessionsForShow(localShowId).first().size shouldBe 1
+    }
+
+    @Test
+    fun `should close a restored session given the provider reports no session id`() = runTest {
+        val repository = buildRepository()
+        rewatchSyncProviderDataSource.setReadRewatchSessionsResponse(
+            ApiResponse.Success(
+                listOf(
+                    remoteSession(
+                        providerSessionId = null,
+                        status = RemoteRewatchSessionStatus.ACTIVE,
+                        episodes = listOf(remoteEpisode()),
+                    ),
+                ),
+            ),
         )
 
         repository.syncRewatchSessions(TMDB_ID)
 
-        rewatchSessionDao.observeSessionsForShow(localShowId).first().shouldBeEmpty()
+        rewatchSessionDao.openSessionForShow(localShowId).shouldBeNull()
+    }
+
+    @Test
+    fun `should restore the viewings of an episode given the provider reports them`() = runTest {
+        val repository = buildRepository()
+        rewatchSyncProviderDataSource.setReadRewatchSessionsResponse(
+            ApiResponse.Success(listOf(remoteSession(episodes = listOf(remoteEpisode(viewings = 2L))))),
+        )
+
+        repository.syncRewatchSessions(TMDB_ID)
+
+        rewatchSessionDao.observeEpisodeRewatches(EPISODE_ID).first() shouldBe 2L
+    }
+
+    @Test
+    fun `should keep the restored viewings unchanged given the same sync runs twice`() = runTest {
+        val repository = buildRepository()
+        rewatchSyncProviderDataSource.setReadRewatchSessionsResponse(
+            ApiResponse.Success(listOf(remoteSession(episodes = listOf(remoteEpisode(viewings = 2L))))),
+        )
+
+        repository.syncRewatchSessions(TMDB_ID)
+        repository.syncRewatchSessions(TMDB_ID)
+
+        rewatchSessionDao.observeEpisodeRewatches(EPISODE_ID).first() shouldBe 2L
+    }
+
+    @Test
+    fun `should add every reported viewing given two sessions carry the same episode`() = runTest {
+        val repository = buildRepository()
+        rewatchSyncProviderDataSource.setReadRewatchSessionsResponse(
+            ApiResponse.Success(
+                listOf(
+                    remoteSession(providerSessionId = PROVIDER_SESSION_ID, episodes = listOf(remoteEpisode())),
+                    remoteSession(providerSessionId = OTHER_PROVIDER_SESSION_ID, episodes = listOf(remoteEpisode())),
+                ),
+            ),
+        )
+
+        repository.syncRewatchSessions(TMDB_ID)
+
+        rewatchSessionDao.observeEpisodeRewatches(EPISODE_ID).first() shouldBe 2L
+    }
+
+    @Test
+    fun `should keep a locally recorded viewing given the provider reports the same one`() = runTest {
+        val repository = buildRepository()
+        val sessionId = repository.startSession(showId = TMDB_ID, startedAt = STARTED_AT)!!
+        repository.addEpisodeToSession(
+            sessionId = sessionId,
+            showId = TMDB_ID,
+            episodeId = EPISODE_ID,
+            seasonNumber = 1L,
+            episodeNumber = 1L,
+            watchedAt = REWATCHED_AT,
+        )
+        rewatchSyncProviderDataSource.setReadRewatchSessionsResponse(
+            ApiResponse.Success(listOf(remoteSession(episodes = listOf(remoteEpisode())))),
+        )
+
+        repository.syncRewatchSessions(TMDB_ID)
+
+        rewatchSessionDao.observeEpisodeRewatches(EPISODE_ID).first() shouldBe 1L
+    }
+
+    @Test
+    fun `should send no restored viewing back to the provider given pending rewatches are synced`() = runTest {
+        val repository = buildRepository()
+        rewatchSyncProviderDataSource.setReadRewatchSessionsResponse(
+            ApiResponse.Success(listOf(remoteSession(episodes = listOf(remoteEpisode(viewings = 2L))))),
+        )
+        repository.syncRewatchSessions(TMDB_ID)
+
+        repository.syncPendingRewatches()
+
+        rewatchSyncProviderDataSource.lastWrite.shouldBeNull()
+    }
+
+    @Test
+    fun `should skip a viewing given the episode is missing locally`() = runTest {
+        val repository = buildRepository()
+        rewatchSyncProviderDataSource.setReadRewatchSessionsResponse(
+            ApiResponse.Success(listOf(remoteSession(episodes = listOf(remoteEpisode(episodeNumber = 99L))))),
+        )
+
+        repository.syncRewatchSessions(TMDB_ID)
+
+        rewatchSessionDao.observeSessionsForShow(localShowId).first().size shouldBe 1
+    }
+
+    @Test
+    fun `should clear the restored viewings given the episode is removed from watched`() = runTest {
+        val repository = buildRepository()
+        rewatchSyncProviderDataSource.setReadRewatchSessionsResponse(
+            ApiResponse.Success(listOf(remoteSession(episodes = listOf(remoteEpisode(viewings = 2L))))),
+        )
+        repository.syncRewatchSessions(TMDB_ID)
+
+        repository.removeEpisodeRewatches(EPISODE_ID)
+
+        rewatchSessionDao.observeEpisodeRewatches(EPISODE_ID).first() shouldBe 0L
     }
 
     private fun remoteSession(
         providerSessionId: Long? = PROVIDER_SESSION_ID,
         status: RemoteRewatchSessionStatus = RemoteRewatchSessionStatus.CLOSED,
+        episodes: List<RemoteRewatchEpisode> = emptyList(),
     ): RemoteRewatchSession = RemoteRewatchSession(
         providerSessionId = providerSessionId,
-        seasonNumber = null,
-        episodeNumber = null,
-        episodeCount = 2L,
         lastWatchedAt = REWATCHED_AT,
         status = status,
         startedAt = STARTED_AT,
+        episodes = episodes,
+    )
+
+    private fun remoteEpisode(
+        episodeNumber: Long = 1L,
+        viewings: Long = 1L,
+        watchedAt: Long? = REWATCHED_AT,
+    ): RemoteRewatchEpisode = RemoteRewatchEpisode(
+        seasonNumber = 1L,
+        episodeNumber = episodeNumber,
+        watchedAt = watchedAt,
+        viewings = viewings,
     )
 
     private fun buildRepository(
@@ -785,5 +915,6 @@ internal class DefaultRewatchRepositoryTest : BaseDatabaseTest() {
         private const val SECOND_REWATCHED_AT = 1_800_000_000_000L
         private const val CLOSED_AT = 1_760_000_000_000L
         private const val PROVIDER_SESSION_ID = 7482L
+        private const val OTHER_PROVIDER_SESSION_ID = 7483L
     }
 }


### PR DESCRIPTION
## Description
This PR restores how many times an episode was watched when an account is synced onto another device. Play counts on the episode sheet and the totals on the statistics screen now match what was recorded on the first device instead of starting over.

## Changes
- Restore the repeat viewings a Trakt account recorded, so an episode watched more than once keeps its count after a reinstall or a sign in on a second device.
- Restore the episodes inside each Simkl rewatch session, which the response already carried and the app was reading past.
- Ask Simkl for the date each episode was watched, so a restored viewing keeps the day it happened rather than the day it was synced.
- Count a viewing once when the same account syncs again, so repeated syncs leave every play count and every total unchanged.
- Skip a viewing for an episode the device has not stored yet, and leave nothing behind that removing the episode from watched cannot clear.
