### PR TITLE
feat: Save a watched date and send it to Trakt and Simkl

### DIFF
--- a/api/simkl/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/api/model/SimklSyncRequest.kt
+++ b/api/simkl/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/api/model/SimklSyncRequest.kt
@@ -24,4 +24,5 @@ public data class SimklHistorySeason(
 @Serializable
 public data class SimklHistoryEpisode(
     @SerialName("number") val number: Int,
+    @SerialName("watched_at") val watchedAt: String? = null,
 )

--- a/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklEpisodeWatchesDataSource.kt
+++ b/api/simkl/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklEpisodeWatchesDataSource.kt
@@ -3,6 +3,7 @@ package com.thomaskioko.tvmaniac.simkl.implementation
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.episodes.api.EpisodeWatchesDataSource
+import com.thomaskioko.tvmaniac.episodes.api.WatchedDate
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeEntry
 import com.thomaskioko.tvmaniac.episodes.api.WatchedShowBatch
 import com.thomaskioko.tvmaniac.followedshows.api.PendingAction
@@ -69,12 +70,23 @@ public class SimklEpisodeWatchesDataSource(
                     SimklHistorySeason(
                         number = seasonNumber.toInt(),
                         episodes = seasonWatches.map { watch ->
-                            SimklHistoryEpisode(number = watch.episodeNumber.toInt())
+                            SimklHistoryEpisode(
+                                number = watch.episodeNumber.toInt(),
+                                watchedAt = when {
+                                    WatchedDate.isUnknown(watch.watchedAt) -> UNKNOWN_WATCHED_AT
+                                    else -> watch.watchedAt.toString()
+                                },
+                            )
                         },
                     )
                 },
             )
         }
+
+    internal companion object {
+        internal const val UNKNOWN_WATCHED_AT: String = "1970-01-01T00:00:01Z"
+        internal const val PLACEHOLDER_BEFORE_MILLIS: Long = 946_684_800_000L
+    }
 }
 
 internal class BulkSimklWatchedShowsFetchException(message: String) : Exception(message)
@@ -104,8 +116,11 @@ private fun SimklWatchedEpisode.toEntry(seasonNumber: Int, tmdbId: Long?): Watch
         episodeId = null,
         seasonNumber = seasonNumber.toLong(),
         episodeNumber = number.toLong(),
-        watchedAt = parsedAt,
+        watchedAt = parsedAt.normalizeSimklPlaceholder(),
         traktId = null,
         pendingAction = PendingAction.NOTHING,
     )
 }
+
+private fun Instant.normalizeSimklPlaceholder(): Instant =
+    if (toEpochMilliseconds() < SimklEpisodeWatchesDataSource.PLACEHOLDER_BEFORE_MILLIS) WatchedDate.UNKNOWN else this

--- a/api/simkl/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklEpisodeWatchesDataSourceTest.kt
+++ b/api/simkl/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/simkl/implementation/SimklEpisodeWatchesDataSourceTest.kt
@@ -1,6 +1,7 @@
 package com.thomaskioko.tvmaniac.simkl.implementation
 
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.episodes.api.WatchedDate
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeEntry
 import com.thomaskioko.tvmaniac.followedshows.api.PendingAction
 import com.thomaskioko.tvmaniac.simkl.api.model.SimklAddHistoryResponse
@@ -11,7 +12,9 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.time.Instant
 
@@ -99,6 +102,62 @@ internal class SimklEpisodeWatchesDataSourceTest {
     }
 
     @Test
+    fun `should carry a watched time on every serialized episode given entries are added`() = runTest {
+        fakeRemote.setAddHistoryResponse(ApiResponse.Success(SimklAddHistoryResponse()))
+
+        dataSource.addEpisodeEntries(
+            listOf(
+                watchedEntry(episodeNumber = 1L, watchedAt = Instant.parse("2024-09-01T09:10:11Z")),
+                watchedEntry(episodeNumber = 2L, watchedAt = Instant.parse("2024-09-02T10:00:00Z")),
+            ),
+        )
+
+        val episodes = fakeRemote.lastAddedHistory!!.shows.single().seasons.single().episodes
+        episodes.map { it.watchedAt } shouldBe listOf("2024-09-01T09:10:11Z", "2024-09-02T10:00:00Z")
+
+        val payload = Json.encodeToString(fakeRemote.lastAddedHistory!!)
+        payload shouldContain """"number":1,"watched_at":"2024-09-01T09:10:11Z""""
+        payload shouldContain """"number":2,"watched_at":"2024-09-02T10:00:00Z""""
+    }
+
+    @Test
+    fun `should send the placeholder given the watched time is unknown`() = runTest {
+        fakeRemote.setAddHistoryResponse(ApiResponse.Success(SimklAddHistoryResponse()))
+
+        dataSource.addEpisodeEntries(listOf(watchedEntry(episodeNumber = 1L, watchedAt = WatchedDate.UNKNOWN)))
+
+        fakeRemote.lastAddedHistory!!.shows.single().seasons.single().episodes.single().watchedAt shouldBe
+            "1970-01-01T00:00:01Z"
+    }
+
+    @Test
+    fun `should read back as the unknown sentinel given a pulled timestamp is the documented placeholder`() = runTest {
+        fakeRemote.setAllWatchedShows(ApiResponse.Success(SIMKL_RESPONSE_PLACEHOLDER_WATCHED_AT))
+
+        val episode = dataSource.getAllWatchedShows(page = 1, limit = 100).single().episodes.single()
+
+        episode.watchedAt shouldBe WatchedDate.UNKNOWN
+    }
+
+    @Test
+    fun `should read back as the unknown sentinel given a pulled timestamp predates the year 2000`() = runTest {
+        fakeRemote.setAllWatchedShows(ApiResponse.Success(SIMKL_RESPONSE_1999_WATCHED_AT))
+
+        val episode = dataSource.getAllWatchedShows(page = 1, limit = 100).single().episodes.single()
+
+        episode.watchedAt shouldBe WatchedDate.UNKNOWN
+    }
+
+    private fun watchedEntry(episodeNumber: Long, watchedAt: Instant) = WatchedEpisodeEntry(
+        showId = 583436L,
+        episodeId = null,
+        seasonNumber = 1L,
+        episodeNumber = episodeNumber,
+        watchedAt = watchedAt,
+        pendingAction = PendingAction.NOTHING,
+    )
+
+    @Test
     fun `should remove history entries given removeEpisodeEntries receives watched entries`() = runTest {
         fakeRemote.setRemoveHistoryResponse(ApiResponse.Success(SimklRemoveHistoryResponse()))
         val entries = listOf(
@@ -157,6 +216,52 @@ private val SIMKL_RESPONSE_NULL_WATCHED_AT = SimklAllItemsResponse(
                     number = 1,
                     episodes = listOf(
                         com.thomaskioko.tvmaniac.simkl.api.model.SimklWatchedEpisode(number = 1, watchedAt = null),
+                    ),
+                ),
+            ),
+        ),
+    ),
+)
+
+private val SIMKL_RESPONSE_PLACEHOLDER_WATCHED_AT = SimklAllItemsResponse(
+    shows = listOf(
+        com.thomaskioko.tvmaniac.simkl.api.model.SimklWatchedShow(
+            status = "watching",
+            show = com.thomaskioko.tvmaniac.simkl.api.model.SimklShowEntry(
+                title = "Undated Show",
+                ids = com.thomaskioko.tvmaniac.simkl.api.model.SimklShowIds(simkl = 300L, tmdb = "77"),
+            ),
+            seasons = listOf(
+                com.thomaskioko.tvmaniac.simkl.api.model.SimklWatchedSeason(
+                    number = 1,
+                    episodes = listOf(
+                        com.thomaskioko.tvmaniac.simkl.api.model.SimklWatchedEpisode(
+                            number = 1,
+                            watchedAt = "1970-01-01T00:00:01Z",
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ),
+)
+
+private val SIMKL_RESPONSE_1999_WATCHED_AT = SimklAllItemsResponse(
+    shows = listOf(
+        com.thomaskioko.tvmaniac.simkl.api.model.SimklWatchedShow(
+            status = "watching",
+            show = com.thomaskioko.tvmaniac.simkl.api.model.SimklShowEntry(
+                title = "Old Show",
+                ids = com.thomaskioko.tvmaniac.simkl.api.model.SimklShowIds(simkl = 301L, tmdb = "78"),
+            ),
+            seasons = listOf(
+                com.thomaskioko.tvmaniac.simkl.api.model.SimklWatchedSeason(
+                    number = 1,
+                    episodes = listOf(
+                        com.thomaskioko.tvmaniac.simkl.api.model.SimklWatchedEpisode(
+                            number = 1,
+                            watchedAt = "1999-06-15T20:00:00Z",
+                        ),
                     ),
                 ),
             ),

--- a/api/simkl/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/testing/FakeSimklSyncRemoteDataSource.kt
+++ b/api/simkl/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/simkl/testing/FakeSimklSyncRemoteDataSource.kt
@@ -15,6 +15,12 @@ public class FakeSimklSyncRemoteDataSource(
     private var removeHistoryResponse: ApiResponse<SimklRemoveHistoryResponse> = ApiResponse.Unauthenticated,
 ) : SimklSyncRemoteDataSource {
 
+    public var lastAddedHistory: SimklSyncHistoryRequest? = null
+        private set
+
+    public var lastRemovedHistory: SimklSyncHistoryRequest? = null
+        private set
+
     public fun setLastActivities(response: ApiResponse<SimklLastActivitiesResponse>) {
         lastActivitiesResponse = response
     }
@@ -37,9 +43,13 @@ public class FakeSimklSyncRemoteDataSource(
     override suspend fun getAllWatchedShows(dateFrom: String?): ApiResponse<SimklAllItemsResponse> =
         allWatchedShowsResponse
 
-    override suspend fun addWatchedHistory(request: SimklSyncHistoryRequest): ApiResponse<SimklAddHistoryResponse> =
-        addHistoryResponse
+    override suspend fun addWatchedHistory(request: SimklSyncHistoryRequest): ApiResponse<SimklAddHistoryResponse> {
+        lastAddedHistory = request
+        return addHistoryResponse
+    }
 
-    override suspend fun removeWatchedHistory(request: SimklSyncHistoryRequest): ApiResponse<SimklRemoveHistoryResponse> =
-        removeHistoryResponse
+    override suspend fun removeWatchedHistory(request: SimklSyncHistoryRequest): ApiResponse<SimklRemoveHistoryResponse> {
+        lastRemovedHistory = request
+        return removeHistoryResponse
+    }
 }

--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktEpisodeWatchesDataSource.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktEpisodeWatchesDataSource.kt
@@ -3,6 +3,7 @@ package com.thomaskioko.trakt.service.implementation.sync
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.episodes.api.EpisodeWatchesDataSource
+import com.thomaskioko.tvmaniac.episodes.api.WatchedDate
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeEntry
 import com.thomaskioko.tvmaniac.episodes.api.WatchedShowBatch
 import com.thomaskioko.tvmaniac.episodes.api.WatchedShowMetadata
@@ -41,7 +42,7 @@ public class TraktEpisodeWatchesDataSource(
                         episodeId = 0L,
                         seasonNumber = entry.episode.season.toLong(),
                         episodeNumber = entry.episode.number.toLong(),
-                        watchedAt = Instant.parse(entry.watchedAt),
+                        watchedAt = WatchedDate.normalize(Instant.parse(entry.watchedAt)),
                         traktId = entry.id,
                         pendingAction = PendingAction.NOTHING,
                     )
@@ -122,13 +123,20 @@ public class TraktEpisodeWatchesDataSource(
                         episodes = seasonWatches.map { watch ->
                             TraktSyncSeasonEpisode(
                                 number = watch.episodeNumber,
-                                watchedAt = watch.watchedAt.toString(),
+                                watchedAt = when {
+                                    WatchedDate.isUnknown(watch.watchedAt) -> UNKNOWN_WATCHED_AT
+                                    else -> watch.watchedAt.toString()
+                                },
                             )
                         },
                     )
                 },
             )
         }
+
+    internal companion object {
+        internal const val UNKNOWN_WATCHED_AT: String = "unknown"
+    }
 }
 
 internal class BulkWatchedShowsFetchException(message: String) : Exception(message)
@@ -145,7 +153,7 @@ private fun TraktWatchedShowResponse.toBatch(): WatchedShowBatch? {
                 episodeId = null,
                 seasonNumber = season.number,
                 episodeNumber = episode.number,
-                watchedAt = watchedAt,
+                watchedAt = WatchedDate.normalize(watchedAt),
                 traktId = null,
                 pendingAction = PendingAction.NOTHING,
             )

--- a/api/trakt/implementation/src/commonTest/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktEpisodeWatchesDataSourceTest.kt
+++ b/api/trakt/implementation/src/commonTest/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktEpisodeWatchesDataSourceTest.kt
@@ -1,6 +1,8 @@
 package com.thomaskioko.trakt.service.implementation.sync
 
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import com.thomaskioko.tvmaniac.episodes.api.WatchedDate
+import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeEntry
 import com.thomaskioko.tvmaniac.followedshows.api.PendingAction
 import com.thomaskioko.tvmaniac.followedshows.testing.FakeFollowedShowsDao
 import com.thomaskioko.tvmaniac.trakt.api.model.ShowIds
@@ -22,8 +24,9 @@ import kotlin.time.Instant
 internal class TraktEpisodeWatchesDataSourceTest {
 
     private val fakeSync = FakeTraktSyncRemoteDataSource()
+    private val fakeHistory = FakeTraktEpisodeHistoryRemoteDataSource()
     private val dataSource = TraktEpisodeWatchesDataSource(
-        remoteDataSource = FakeTraktEpisodeHistoryRemoteDataSource(),
+        remoteDataSource = fakeHistory,
         syncRemoteDataSource = fakeSync,
         followedShowsDao = FakeFollowedShowsDao(),
     )
@@ -87,6 +90,48 @@ internal class TraktEpisodeWatchesDataSourceTest {
 
         batches.shouldBeEmpty()
     }
+
+    @Test
+    fun `should send the local watched time unchanged given the mark carries a date`() = runTest {
+        dataSource.addEpisodeEntries(listOf(watchedEntry(Instant.parse("2026-04-25T20:00:00Z"))))
+
+        fakeHistory.lastAddedItems!!.shows!!.single().seasons!!.single().episodes.single().watchedAt shouldBe
+            "2026-04-25T20:00:00Z"
+    }
+
+    @Test
+    fun `should send the unknown literal given the watched time is unknown`() = runTest {
+        dataSource.addEpisodeEntries(listOf(watchedEntry(WatchedDate.UNKNOWN)))
+
+        fakeHistory.lastAddedItems!!.shows!!.single().seasons!!.single().episodes.single().watchedAt shouldBe "unknown"
+    }
+
+    @Test
+    fun `should read back as the unknown sentinel given a pulled timestamp sits at the epoch`() = runTest {
+        fakeSync.setWatchedShows(ApiResponse.Success(listOf(SHOW_WITH_EPOCH_WATCHED_AT)))
+
+        val episode = dataSource.getAllWatchedShows(page = 1, limit = 100).single().episodes.single()
+
+        episode.watchedAt shouldBe WatchedDate.UNKNOWN
+    }
+
+    @Test
+    fun `should keep the pulled timestamp given a watch predates the year 2000`() = runTest {
+        fakeSync.setWatchedShows(ApiResponse.Success(listOf(SHOW_WATCHED_IN_1999)))
+
+        val episode = dataSource.getAllWatchedShows(page = 1, limit = 100).single().episodes.single()
+
+        episode.watchedAt shouldBe Instant.parse("1999-06-15T20:00:00.000Z")
+    }
+
+    private fun watchedEntry(watchedAt: Instant) = WatchedEpisodeEntry(
+        showId = 1388L,
+        episodeId = null,
+        seasonNumber = 1L,
+        episodeNumber = 1L,
+        watchedAt = watchedAt,
+        pendingAction = PendingAction.NOTHING,
+    )
 }
 
 private val BREAKING_BAD = TraktWatchedShowResponse(
@@ -119,6 +164,38 @@ private val SHOW_WITH_NULL_WATCHED_AT = TraktWatchedShowResponse(
         TraktWatchedSeasonResponse(
             number = 1,
             episodes = listOf(TraktWatchedEpisodeResponse(number = 1, plays = 1, lastWatchedAt = null)),
+        ),
+    ),
+)
+
+private val SHOW_WITH_EPOCH_WATCHED_AT = TraktWatchedShowResponse(
+    plays = 1,
+    show = TraktShowResponse(
+        title = "Undated Show",
+        ids = ShowIds(trakt = 77, tmdb = 88),
+    ),
+    seasons = listOf(
+        TraktWatchedSeasonResponse(
+            number = 1,
+            episodes = listOf(
+                TraktWatchedEpisodeResponse(number = 1, plays = 1, lastWatchedAt = "1970-01-01T00:00:00.000Z"),
+            ),
+        ),
+    ),
+)
+
+private val SHOW_WATCHED_IN_1999 = TraktWatchedShowResponse(
+    plays = 1,
+    show = TraktShowResponse(
+        title = "Old Show",
+        ids = ShowIds(trakt = 78, tmdb = 89),
+    ),
+    seasons = listOf(
+        TraktWatchedSeasonResponse(
+            number = 1,
+            episodes = listOf(
+                TraktWatchedEpisodeResponse(number = 1, plays = 1, lastWatchedAt = "1999-06-15T20:00:00.000Z"),
+            ),
         ),
     ),
 )

--- a/app/README.md
+++ b/app/README.md
@@ -1305,6 +1305,7 @@ graph TB
   :features:episode-sheet:nav --> :navigation:api
   :features:episode-sheet:presenter --> :core:base
   :features:episode-sheet:presenter --> :core:logger:api
+  :features:episode-sheet:presenter --> :core:util:api
   :features:episode-sheet:presenter --> :core:view
   :features:episode-sheet:presenter --> :data:datastore:api
   :features:episode-sheet:presenter --> :domain:episode

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Episodes.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Episodes.sq
@@ -154,9 +154,12 @@ SELECT
     episode.vote_count,
     episode.ratings,
     episode.image_url,
+    episode.runtime,
+    episode.first_aired,
     season.season_number,
     tvshow.name AS show_name,
-    CASE WHEN watched_episodes.id IS NOT NULL THEN 1 ELSE 0 END AS is_watched
+    CASE WHEN watched_episodes.id IS NOT NULL THEN 1 ELSE 0 END AS is_watched,
+    watched_episodes.watched_at
 FROM episode
 JOIN season ON season.id = episode.season_id
 JOIN tvshow ON tvshow.id = episode.show_id

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/ShowMetadata.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/ShowMetadata.sq
@@ -46,7 +46,9 @@ UPDATE show_metadata SET
     last_watched_episode_id = (SELECT episode_id FROM last_watched_cte),
     last_watched_season_number = (SELECT season_number FROM last_watched_cte),
     last_watched_episode_number = (SELECT episode_number FROM last_watched_cte),
-    last_watched_at = (SELECT watched_at FROM last_watched_cte)
+    last_watched_at = (
+        SELECT CASE WHEN watched_at > :unknown_millis THEN watched_at END FROM last_watched_cte
+    )
 WHERE show_id = :showId;
 
 CREATE VIEW show_watch_progress AS

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/WatchedEpisodes.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/WatchedEpisodes.sq
@@ -99,7 +99,9 @@ SELECT
     e.id AS episode_id,
     s.season_number,
     e.episode_number,
-    e.season_id
+    e.season_id,
+    e.first_aired,
+    e.runtime
 FROM episode e
 INNER JOIN season s ON e.season_id = s.id
 LEFT JOIN watched_episodes we ON e.id = we.episode_id AND we.show_id = :showId AND we.pending_action NOT IN ('DELETE', 'SYNCED_DELETE')
@@ -118,7 +120,9 @@ SELECT
     e.id AS episode_id,
     s.season_number,
     e.episode_number,
-    e.season_id
+    e.season_id,
+    e.first_aired,
+    e.runtime
 FROM episode e
 INNER JOIN season s ON e.season_id = s.id
 WHERE e.show_id = ? AND s.season_number = ?
@@ -141,7 +145,9 @@ SELECT
     e.id AS episode_id,
     s.season_number,
     e.episode_number,
-    e.season_id
+    e.season_id,
+    e.first_aired,
+    e.runtime
 FROM episode e
 INNER JOIN season s ON e.season_id = s.id
 LEFT JOIN watched_episodes we ON e.id = we.episode_id AND we.show_id = :showId AND we.pending_action NOT IN ('DELETE', 'SYNCED_DELETE')

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/EpisodeRepository.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/EpisodeRepository.kt
@@ -30,6 +30,8 @@ public interface EpisodeRepository {
         episodeId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
+        watchedAt: Long? = null,
+        useReleaseDate: Boolean = false,
     )
 
     /**
@@ -41,6 +43,8 @@ public interface EpisodeRepository {
         episodeId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
+        watchedAt: Long? = null,
+        useReleaseDate: Boolean = false,
     )
 
     /**
@@ -68,7 +72,12 @@ public interface EpisodeRepository {
      * Mark all episodes in a season as watched.
      * Automatically adds the show to the library if not already there.
      */
-    public suspend fun markSeasonWatched(showId: Long, seasonNumber: Long)
+    public suspend fun markSeasonWatched(
+        showId: Long,
+        seasonNumber: Long,
+        watchedAt: Long? = null,
+        useReleaseDate: Boolean = false,
+    )
 
     /**
      * Mark all episodes in a season as watched along with all previous seasons.
@@ -77,6 +86,14 @@ public interface EpisodeRepository {
     public suspend fun markSeasonAndPreviousSeasonsWatched(
         showId: Long,
         seasonNumber: Long,
+        watchedAt: Long? = null,
+        useReleaseDate: Boolean = false,
+    )
+
+    public suspend fun markShowWatched(
+        showId: Long,
+        watchedAt: Long? = null,
+        useReleaseDate: Boolean = false,
     )
 
     /**
@@ -109,4 +126,8 @@ public interface EpisodeRepository {
     )
 
     public suspend fun getShowMetadataSyncInfo(showId: Long): ShowMetadataSyncInfo?
+
+    public companion object {
+        public const val ALL_SEASONS: Long = Long.MAX_VALUE
+    }
 }

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedDate.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedDate.kt
@@ -1,0 +1,16 @@
+package com.thomaskioko.tvmaniac.episodes.api
+
+import kotlin.time.Instant
+
+public object WatchedDate {
+
+    public const val UNKNOWN_MILLIS: Long = 0L
+
+    public val UNKNOWN: Instant = Instant.fromEpochMilliseconds(UNKNOWN_MILLIS)
+
+    public fun isUnknown(epochMillis: Long): Boolean = epochMillis <= UNKNOWN_MILLIS
+
+    public fun isUnknown(instant: Instant): Boolean = isUnknown(instant.toEpochMilliseconds())
+
+    public fun normalize(instant: Instant): Instant = if (isUnknown(instant)) UNKNOWN else instant
+}

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeDao.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeDao.kt
@@ -47,6 +47,8 @@ public interface WatchedEpisodeDao {
         seasonNumber: Long,
         episodeNumber: Long,
         includeSpecials: Boolean,
+        watchedAt: Long? = null,
+        useReleaseDate: Boolean = false,
     )
 
     public suspend fun markAsUnwatched(
@@ -60,6 +62,7 @@ public interface WatchedEpisodeDao {
         seasonNumber: Long,
         episodes: List<EpisodeWatchParams>,
         includeSpecials: Boolean,
+        watchedAt: Long? = null,
     )
 
     public suspend fun markSeasonAsUnwatched(
@@ -72,6 +75,8 @@ public interface WatchedEpisodeDao {
         showId: Long,
         seasonNumber: Long,
         includeSpecials: Boolean,
+        watchedAt: Long? = null,
+        useReleaseDate: Boolean = false,
     )
 
     public suspend fun markEpisodeAndPreviousAsWatched(
@@ -80,11 +85,15 @@ public interface WatchedEpisodeDao {
         seasonNumber: Long,
         episodeNumber: Long,
         includeSpecials: Boolean,
+        watchedAt: Long? = null,
+        useReleaseDate: Boolean = false,
     )
 
     public suspend fun getEpisodesForSeason(
         showId: Long,
         seasonNumber: Long,
+        watchedAt: Long? = null,
+        useReleaseDate: Boolean = false,
     ): List<EpisodeWatchParams>
 
     public suspend fun getUnwatchedEpisodeCountInPreviousSeasons(

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/model/RecentlyWatchedEpisode.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/model/RecentlyWatchedEpisode.kt
@@ -7,5 +7,5 @@ public data class RecentlyWatchedEpisode(
     val seasonNumber: Long,
     val episodeNumber: Long,
     val episodeTitle: String?,
-    val watchedAt: Long,
+    val watchedAt: Long?,
 )

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepository.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepository.kt
@@ -70,6 +70,8 @@ public class DefaultEpisodeRepository(
         episodeId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
+        watchedAt: Long?,
+        useReleaseDate: Boolean,
     ) {
         val includeSpecials = getIncludeSpecials()
         watchedEpisodeDao.markAsWatched(
@@ -78,6 +80,8 @@ public class DefaultEpisodeRepository(
             seasonNumber = seasonNumber,
             episodeNumber = episodeNumber,
             includeSpecials = includeSpecials,
+            watchedAt = watchedAt,
+            useReleaseDate = useReleaseDate,
         )
         notificationManager.cancelNotification(episodeId)
 
@@ -89,6 +93,8 @@ public class DefaultEpisodeRepository(
         episodeId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
+        watchedAt: Long?,
+        useReleaseDate: Boolean,
     ) {
         val includeSpecials = getIncludeSpecials()
         watchedEpisodeDao.markEpisodeAndPreviousAsWatched(
@@ -97,6 +103,8 @@ public class DefaultEpisodeRepository(
             seasonNumber = seasonNumber,
             episodeNumber = episodeNumber,
             includeSpecials = includeSpecials,
+            watchedAt = watchedAt,
+            useReleaseDate = useReleaseDate,
         )
         notificationManager.cancelNotification(episodeId)
 
@@ -132,14 +140,22 @@ public class DefaultEpisodeRepository(
     override suspend fun markSeasonWatched(
         showId: Long,
         seasonNumber: Long,
+        watchedAt: Long?,
+        useReleaseDate: Boolean,
     ) {
         val includeSpecials = getIncludeSpecials()
-        val episodes = watchedEpisodeDao.getEpisodesForSeason(showId, seasonNumber)
+        val episodes = watchedEpisodeDao.getEpisodesForSeason(
+            showId = showId,
+            seasonNumber = seasonNumber,
+            watchedAt = watchedAt,
+            useReleaseDate = useReleaseDate,
+        )
         watchedEpisodeDao.markSeasonAsWatched(
             showId = showId,
             seasonNumber = seasonNumber,
             episodes = episodes,
             includeSpecials = includeSpecials,
+            watchedAt = watchedAt,
         )
         cancelPendingSeasonNotifications(showId, seasonNumber, includePreviousSeasons = false)
 
@@ -149,16 +165,33 @@ public class DefaultEpisodeRepository(
     override suspend fun markSeasonAndPreviousSeasonsWatched(
         showId: Long,
         seasonNumber: Long,
+        watchedAt: Long?,
+        useReleaseDate: Boolean,
     ) {
         val includeSpecials = getIncludeSpecials()
         watchedEpisodeDao.markSeasonAndPreviousAsWatched(
             showId = showId,
             seasonNumber = seasonNumber,
             includeSpecials = includeSpecials,
+            watchedAt = watchedAt,
+            useReleaseDate = useReleaseDate,
         )
         cancelPendingSeasonNotifications(showId, seasonNumber, includePreviousSeasons = true)
 
         launchSyncReporting { SyncError.BatchMarkFailed(showId, it) }
+    }
+
+    override suspend fun markShowWatched(
+        showId: Long,
+        watchedAt: Long?,
+        useReleaseDate: Boolean,
+    ) {
+        markSeasonAndPreviousSeasonsWatched(
+            showId = showId,
+            seasonNumber = EpisodeRepository.ALL_SEASONS,
+            watchedAt = watchedAt,
+            useReleaseDate = useReleaseDate,
+        )
     }
 
     override suspend fun markSeasonUnwatched(showId: Long, seasonNumber: Long) {

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/dao/DefaultWatchedEpisodeDao.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/dao/DefaultWatchedEpisodeDao.kt
@@ -4,12 +4,14 @@ import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.db.GetEntriesByPendingAction
+import com.thomaskioko.tvmaniac.db.GetEpisodeByShowSeasonEpisodeNumber
 import com.thomaskioko.tvmaniac.db.GetPreviousUnwatchedEpisodes
 import com.thomaskioko.tvmaniac.db.GetWatchedEpisodes
 import com.thomaskioko.tvmaniac.db.Id
 import com.thomaskioko.tvmaniac.db.ShowId
 import com.thomaskioko.tvmaniac.db.ShowIdResolver
 import com.thomaskioko.tvmaniac.db.TvManiacDatabase
+import com.thomaskioko.tvmaniac.episodes.api.WatchedDate
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeDao
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeEntry
 import com.thomaskioko.tvmaniac.episodes.api.model.EpisodeWatchParams
@@ -64,7 +66,7 @@ public class DefaultWatchedEpisodeDao(
                         seasonNumber = row.season_number,
                         episodeNumber = row.episode_number,
                         episodeTitle = row.episode_title,
-                        watchedAt = row.watched_at,
+                        watchedAt = row.watched_at.takeUnless { WatchedDate.isUnknown(it) },
                     )
                 }
             }
@@ -147,29 +149,30 @@ public class DefaultWatchedEpisodeDao(
         seasonNumber: Long,
         episodeNumber: Long,
         includeSpecials: Boolean,
+        watchedAt: Long?,
+        useReleaseDate: Boolean,
     ) {
-        val timestamp = dateTimeProvider.nowMillis()
         withContext(dispatchers.databaseWrite) {
             val internalShowId = showIdResolver.showIdForTmdbId(showId) ?: return@withContext
             database.transaction {
+                val episode = getEpisodeOrNull(internalShowId, seasonNumber, episodeNumber)
+                val timestamp = releaseDateOrNull(episode?.first_aired, episode?.runtime, useReleaseDate)
+                    ?: watchedAt
+                    ?: dateTimeProvider.nowMillis()
                 val _ = database.continueWatchingQueries.upsertMembershipForLocalMark(
                     showId = internalShowId,
                     tmdbId = null,
                     watchedAt = timestamp,
                 )
-                val localEpisodeId = getEpisodeIdOrNull(internalShowId, seasonNumber, episodeNumber)
                 val _ = database.watchedEpisodesQueries.markAsWatched(
                     show_id = internalShowId,
-                    episode_id = localEpisodeId?.let { Id(it) },
+                    episode_id = episode?.episode_id,
                     season_number = seasonNumber,
                     episode_number = episodeNumber,
                     watched_at = timestamp,
                     pending_action = PendingAction.UPLOAD.value,
                 )
-                val _ = database.showMetadataQueries.recalculateLastWatched(
-                    showId = internalShowId,
-                    include_specials = if (includeSpecials) 1L else 0L,
-                )
+                recalculateLastWatched(internalShowId, includeSpecials)
             }
         }
     }
@@ -200,10 +203,7 @@ public class DefaultWatchedEpisodeDao(
                         )
                     }
                 }
-                val _ = database.showMetadataQueries.recalculateLastWatched(
-                    showId = internalShowId,
-                    include_specials = if (includeSpecials) 1L else 0L,
-                )
+                recalculateLastWatched(internalShowId, includeSpecials)
                 recalculateContinueWatchingLastWatchedAt(internalShowId)
             }
         }
@@ -281,8 +281,9 @@ public class DefaultWatchedEpisodeDao(
         seasonNumber: Long,
         episodes: List<EpisodeWatchParams>,
         includeSpecials: Boolean,
+        watchedAt: Long?,
     ) {
-        val timestamp = dateTimeProvider.nowMillis()
+        val timestamp = watchedAt ?: dateTimeProvider.nowMillis()
         withContext(dispatchers.databaseWrite) {
             val internalShowId = showIdResolver.showIdForTmdbId(showId) ?: return@withContext
             database.transaction {
@@ -305,10 +306,7 @@ public class DefaultWatchedEpisodeDao(
                         pending_action = PendingAction.UPLOAD.value,
                     )
                 }
-                val _ = database.showMetadataQueries.recalculateLastWatched(
-                    showId = internalShowId,
-                    include_specials = if (includeSpecials) 1L else 0L,
-                )
+                recalculateLastWatched(internalShowId, includeSpecials)
             }
         }
     }
@@ -335,10 +333,7 @@ public class DefaultWatchedEpisodeDao(
                         val _ = database.watchedEpisodesQueries.deleteById(row.watched_id)
                     }
                 }
-                val _ = database.showMetadataQueries.recalculateLastWatched(
-                    showId = internalShowId,
-                    include_specials = if (includeSpecials) 1L else 0L,
-                )
+                recalculateLastWatched(internalShowId, includeSpecials)
                 recalculateContinueWatchingLastWatchedAt(internalShowId)
             }
         }
@@ -348,8 +343,10 @@ public class DefaultWatchedEpisodeDao(
         showId: Long,
         seasonNumber: Long,
         includeSpecials: Boolean,
+        watchedAt: Long?,
+        useReleaseDate: Boolean,
     ) {
-        val timestamp = dateTimeProvider.nowMillis()
+        val timestamp = watchedAt ?: dateTimeProvider.nowMillis()
         withContext(dispatchers.databaseWrite) {
             val internalShowId = showIdResolver.showIdForTmdbId(showId) ?: return@withContext
             database.transaction {
@@ -367,7 +364,7 @@ public class DefaultWatchedEpisodeDao(
                         episode_id = episode.episode_id,
                         season_number = episode.season_number,
                         episode_number = episode.episode_number,
-                        watched_at = timestamp,
+                        watched_at = releaseDateOrNull(episode.first_aired, episode.runtime, useReleaseDate) ?: timestamp,
                         pending_action = PendingAction.UPLOAD.value,
                     )
                 }
@@ -388,15 +385,12 @@ public class DefaultWatchedEpisodeDao(
                         episode_id = episode.episode_id,
                         season_number = episode.season_number,
                         episode_number = episode.episode_number,
-                        watched_at = timestamp,
+                        watched_at = releaseDateOrNull(episode.first_aired, episode.runtime, useReleaseDate) ?: timestamp,
                         pending_action = PendingAction.UPLOAD.value,
                     )
                 }
 
-                val _ = database.showMetadataQueries.recalculateLastWatched(
-                    showId = internalShowId,
-                    include_specials = if (includeSpecials) 1L else 0L,
-                )
+                recalculateLastWatched(internalShowId, includeSpecials)
             }
         }
     }
@@ -407,8 +401,10 @@ public class DefaultWatchedEpisodeDao(
         seasonNumber: Long,
         episodeNumber: Long,
         includeSpecials: Boolean,
+        watchedAt: Long?,
+        useReleaseDate: Boolean,
     ) {
-        val timestamp = dateTimeProvider.nowMillis()
+        val timestamp = watchedAt ?: dateTimeProvider.nowMillis()
         withContext(dispatchers.databaseWrite) {
             val internalShowId = showIdResolver.showIdForTmdbId(showId) ?: return@withContext
             database.transaction {
@@ -425,11 +421,12 @@ public class DefaultWatchedEpisodeDao(
                         episode_id = episode.episode_id,
                         season_number = episode.season_number,
                         episode_number = episode.episode_number,
-                        watched_at = timestamp,
+                        watched_at = releaseDateOrNull(episode.first_aired, episode.runtime, useReleaseDate) ?: timestamp,
                         pending_action = PendingAction.UPLOAD.value,
                     )
                 }
 
+                val markedEpisode = getEpisodeOrNull(internalShowId, seasonNumber, episodeNumber)
                 val _ = database.continueWatchingQueries.upsertMembershipForLocalMark(
                     showId = internalShowId,
                     tmdbId = null,
@@ -440,13 +437,11 @@ public class DefaultWatchedEpisodeDao(
                     episode_id = Id(episodeId),
                     season_number = seasonNumber,
                     episode_number = episodeNumber,
-                    watched_at = timestamp,
+                    watched_at = releaseDateOrNull(markedEpisode?.first_aired, markedEpisode?.runtime, useReleaseDate)
+                        ?: timestamp,
                     pending_action = PendingAction.UPLOAD.value,
                 )
-                val _ = database.showMetadataQueries.recalculateLastWatched(
-                    showId = internalShowId,
-                    include_specials = if (includeSpecials) 1L else 0L,
-                )
+                recalculateLastWatched(internalShowId, includeSpecials)
             }
         }
     }
@@ -468,11 +463,11 @@ public class DefaultWatchedEpisodeDao(
         return unwatchedEpisodes
     }
 
-    private fun getEpisodeIdOrNull(
+    private fun getEpisodeOrNull(
         showId: Id<ShowId>,
         seasonNumber: Long,
         episodeNumber: Long,
-    ): Long? {
+    ): GetEpisodeByShowSeasonEpisodeNumber? {
         return database.episodesQueries
             .getEpisodeByShowSeasonEpisodeNumber(
                 showId = showId,
@@ -480,8 +475,19 @@ public class DefaultWatchedEpisodeDao(
                 episodeNumber = episodeNumber,
             )
             .executeAsOneOrNull()
-            ?.episode_id
-            ?.id
+    }
+
+    private fun releaseDateOrNull(firstAired: Long?, runtimeMinutes: Long?, useReleaseDate: Boolean): Long? {
+        if (!useReleaseDate || firstAired == null) return null
+        return firstAired + (runtimeMinutes?.takeIf { it > 0 } ?: 0L) * MILLIS_PER_MINUTE
+    }
+
+    private fun recalculateLastWatched(showId: Id<ShowId>, includeSpecials: Boolean) {
+        database.showMetadataQueries.recalculateLastWatched(
+            showId = showId,
+            include_specials = if (includeSpecials) 1L else 0L,
+            unknown_millis = WatchedDate.UNKNOWN_MILLIS,
+        )
     }
 
     private fun recalculateContinueWatchingLastWatchedAt(showId: Id<ShowId>) {
@@ -499,6 +505,8 @@ public class DefaultWatchedEpisodeDao(
     override suspend fun getEpisodesForSeason(
         showId: Long,
         seasonNumber: Long,
+        watchedAt: Long?,
+        useReleaseDate: Boolean,
     ): List<EpisodeWatchParams> {
         return withContext(dispatchers.databaseRead) {
             val internalShowId = showIdResolver.showIdForTmdbId(showId) ?: return@withContext emptyList()
@@ -510,6 +518,7 @@ public class DefaultWatchedEpisodeDao(
                         episodeId = result.episode_id.id,
                         seasonNumber = result.season_number,
                         episodeNumber = result.episode_number,
+                        watchedAt = releaseDateOrNull(result.first_aired, result.runtime, useReleaseDate) ?: watchedAt,
                     )
                 }
         }
@@ -631,10 +640,7 @@ public class DefaultWatchedEpisodeDao(
                     syncedAt = syncedAt,
                 )
 
-                val _ = database.showMetadataQueries.recalculateLastWatched(
-                    showId = internalShowId,
-                    include_specials = if (includeSpecials) 1L else 0L,
-                )
+                recalculateLastWatched(internalShowId, includeSpecials)
             }
         }
     }
@@ -663,5 +669,9 @@ public class DefaultWatchedEpisodeDao(
         withContext(dispatchers.databaseWrite) {
             database.watchedShowSyncLogQueries.deleteAll()
         }
+    }
+
+    private companion object {
+        private const val MILLIS_PER_MINUTE = 60_000L
     }
 }

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepositoryNotificationTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepositoryNotificationTest.kt
@@ -14,8 +14,10 @@ import com.thomaskioko.tvmaniac.episodes.testing.FakeWatchedEpisodeSyncRepositor
 import com.thomaskioko.tvmaniac.requestmanager.testing.FakeRequestManagerRepository
 import com.thomaskioko.tvmaniac.syncstate.testing.FakeSyncObserver
 import com.thomaskioko.tvmaniac.util.testing.FakeDateTimeProvider
+import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.maps.shouldContainKey
 import io.kotest.matchers.maps.shouldNotContainKey
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -97,6 +99,30 @@ internal class DefaultEpisodeRepositoryNotificationTest : BaseDatabaseTest() {
         scheduled shouldNotContainKey 201L
         scheduled shouldNotContainKey 301L
         scheduled shouldContainKey 401L
+    }
+
+    @Test
+    fun `should cancel every scheduled notification for the show given the whole show is marked watched`() = runTest {
+        val repository = buildRepository()
+        notificationManager.addPendingNotification(pendingNotification(id = 201, seasonNumber = 1))
+        notificationManager.addPendingNotification(pendingNotification(id = 301, seasonNumber = 2))
+        notificationManager.addPendingNotification(pendingNotification(id = 401, seasonNumber = 3))
+
+        repository.markShowWatched(showId = SHOW_ID)
+
+        notificationManager.getScheduledNotifications().shouldBeEmpty()
+    }
+
+    @Test
+    fun `should mark the show episodes watched given the whole show is marked watched`() = runTest {
+        val repository = buildRepository()
+
+        repository.markShowWatched(showId = SHOW_ID)
+
+        database.watchedEpisodesQueries
+            .getWatchedEpisodes(showIdForTraktId(SHOW_ID))
+            .executeAsList()
+            .map { it.episode_id } shouldBe listOf(Id(EPISODE_ID))
     }
 
     private fun TestScope.buildRepository(): DefaultEpisodeRepository {

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultNextEpisodeDaoTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultNextEpisodeDaoTest.kt
@@ -102,6 +102,24 @@ internal class DefaultNextEpisodeDaoTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun `should keep a show in place given an older episode is marked watched afterwards`() = runTest {
+        followShow(showId = 1L, followedAt = watchDate)
+        followShow(showId = 2L, followedAt = watchDate)
+        markEpisodeWatched(showId = 1L, episodeId = 101L, seasonNumber = 1L, episodeNumber = 1L, watchedAt = RECENT_WATCH)
+        markEpisodeWatched(showId = 2L, episodeId = 201L, seasonNumber = 1L, episodeNumber = 1L, watchedAt = EARLIER_WATCH)
+
+        nextEpisodeDao.observeNextEpisodesForWatchlist(includeSpecials = false).test {
+            awaitItem().map { it.showId } shouldBe listOf(1L, 2L)
+        }
+
+        markEpisodeWatched(showId = 1L, episodeId = 102L, seasonNumber = 1L, episodeNumber = 2L, watchedAt = BACKDATED_WATCH)
+
+        nextEpisodeDao.observeNextEpisodesForWatchlist(includeSpecials = false).test {
+            awaitItem().map { it.showId } shouldBe listOf(1L, 2L)
+        }
+    }
+
+    @Test
     fun `should exclude followed-only show given no continue-watching row`() = runTest {
         followShowOnly(showId = 1L, followedAt = watchDate)
 
@@ -981,5 +999,11 @@ internal class DefaultNextEpisodeDaoTest : BaseDatabaseTest() {
 
         insertSeason(seasonId = 41L, showId = 4L, seasonNumber = 1L, episodeCount = 1L)
         insertEpisode(episodeId = 401L, seasonId = 41L, showId = 4L, episodeNumber = 1L, title = "Regular Episode 1")
+    }
+
+    private companion object {
+        private val RECENT_WATCH = LocalDate(2024, 5, 1).toEpochMillis()
+        private val EARLIER_WATCH = LocalDate(2024, 4, 1).toEpochMillis()
+        private val BACKDATED_WATCH = LocalDate(2019, 1, 1).toEpochMillis()
     }
 }

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeDaoTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeDaoTest.kt
@@ -7,6 +7,8 @@ import com.thomaskioko.tvmaniac.db.EpisodeId
 import com.thomaskioko.tvmaniac.db.Id
 import com.thomaskioko.tvmaniac.db.ShowId
 import com.thomaskioko.tvmaniac.db.TmdbId
+import com.thomaskioko.tvmaniac.episodes.api.EpisodeRepository
+import com.thomaskioko.tvmaniac.episodes.api.WatchedDate
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeDao
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeEntry
 import com.thomaskioko.tvmaniac.episodes.implementation.MockData.SEASON_1_EPISODE_COUNT
@@ -91,7 +93,7 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
 
     @Test
     fun `should return one row per show with the furthest watched episode and show metadata`() = runTest {
-        fakeDateTimeProvider.setCurrentTimeMillis(1_000L)
+        fakeDateTimeProvider.setCurrentTimeMillis(EARLIER_FOLLOW)
         watchedEpisodeDao.markAsWatched(
             showId = TEST_SHOW_ID,
             episodeId = 101L,
@@ -99,7 +101,7 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
             episodeNumber = 1L,
             includeSpecials = false,
         )
-        fakeDateTimeProvider.setCurrentTimeMillis(2_000L)
+        fakeDateTimeProvider.setCurrentTimeMillis(NOW)
         watchedEpisodeDao.markAsWatched(
             showId = TEST_SHOW_ID,
             episodeId = 102L,
@@ -115,7 +117,7 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
             items[0].showTitle shouldBe TEST_SHOW_NAME
             items[0].episodeNumber shouldBe 2L
             items[0].episodeTitle shouldBe "Episode 2"
-            items[0].watchedAt shouldBe 2_000L
+            items[0].watchedAt shouldBe NOW
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -823,6 +825,221 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
         watchedEpisodeDao.getWatchedShowsMissingGenres().shouldBeEmpty()
     }
 
+    @Test
+    fun `should stamp the air date plus runtime given the release date is asked for`() = runTest {
+        watchedEpisodeDao.markAsWatched(
+            showId = TEST_SHOW_ID,
+            episodeId = 101L,
+            seasonNumber = SEASON_1_NUMBER,
+            episodeNumber = 1L,
+            includeSpecials = false,
+            useReleaseDate = true,
+        )
+
+        watchedAtFor(episodeNumber = 1L) shouldBe LocalDate(2023, 1, 1).toEpochMillis() + EPISODE_RUNTIME_MILLIS
+    }
+
+    @Test
+    fun `should stamp the current time given the episode has no air date`() = runTest {
+        fakeDateTimeProvider.setCurrentTimeMillis(NOW)
+        clearFirstAired()
+
+        watchedEpisodeDao.markAsWatched(
+            showId = TEST_SHOW_ID,
+            episodeId = 101L,
+            seasonNumber = SEASON_1_NUMBER,
+            episodeNumber = 1L,
+            includeSpecials = false,
+            useReleaseDate = true,
+        )
+
+        watchedAtFor(episodeNumber = 1L) shouldBe NOW
+    }
+
+    @Test
+    fun `should add no minutes to the air date given the episode runtime is zero`() = runTest {
+        setFirstEpisodeRuntime(runtime = 0L)
+
+        watchedEpisodeDao.markAsWatched(
+            showId = TEST_SHOW_ID,
+            episodeId = 101L,
+            seasonNumber = SEASON_1_NUMBER,
+            episodeNumber = 1L,
+            includeSpecials = false,
+            useReleaseDate = true,
+        )
+
+        watchedAtFor(episodeNumber = 1L) shouldBe LocalDate(2023, 1, 1).toEpochMillis()
+    }
+
+    @Test
+    fun `should stamp the chosen time given one is passed`() = runTest {
+        fakeDateTimeProvider.setCurrentTimeMillis(NOW)
+
+        watchedEpisodeDao.markAsWatched(
+            showId = TEST_SHOW_ID,
+            episodeId = 101L,
+            seasonNumber = SEASON_1_NUMBER,
+            episodeNumber = 1L,
+            includeSpecials = false,
+            watchedAt = CHOSEN_TIME,
+        )
+
+        watchedAtFor(episodeNumber = 1L) shouldBe CHOSEN_TIME
+    }
+
+    @Test
+    fun `should report no watched time given the mark has an unknown date`() = runTest {
+        watchedEpisodeDao.markAsWatched(
+            showId = TEST_SHOW_ID,
+            episodeId = 101L,
+            seasonNumber = SEASON_1_NUMBER,
+            episodeNumber = 1L,
+            includeSpecials = false,
+            watchedAt = WatchedDate.UNKNOWN_MILLIS,
+        )
+
+        watchedEpisodeDao.observeRecentlyWatched(limit = 10).test {
+            val items = awaitItem()
+            items shouldHaveSize 1
+            items[0].watchedAt shouldBe null
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `should keep a show above an older one in the library given its only mark has an unknown date`() = runTest {
+        insertShowMetadata()
+        followTestShow(followedAt = LATER_FOLLOW)
+        followOtherShow(followedAt = EARLIER_FOLLOW)
+
+        watchedEpisodeDao.markAsWatched(
+            showId = TEST_SHOW_ID,
+            episodeId = 101L,
+            seasonNumber = SEASON_1_NUMBER,
+            episodeNumber = 1L,
+            includeSpecials = false,
+            watchedAt = WatchedDate.UNKNOWN_MILLIS,
+        )
+
+        libraryOrder() shouldBe listOf(TEST_SHOW_ID, OTHER_SHOW_TMDB_ID)
+    }
+
+    @Test
+    fun `should move a show up the library given its mark carries a date`() = runTest {
+        insertShowMetadata()
+        followTestShow(followedAt = EARLIER_FOLLOW)
+        followOtherShow(followedAt = LATER_FOLLOW)
+
+        watchedEpisodeDao.markAsWatched(
+            showId = TEST_SHOW_ID,
+            episodeId = 101L,
+            seasonNumber = SEASON_1_NUMBER,
+            episodeNumber = 1L,
+            includeSpecials = false,
+            watchedAt = CHOSEN_TIME,
+        )
+
+        libraryOrder() shouldBe listOf(TEST_SHOW_ID, OTHER_SHOW_TMDB_ID)
+    }
+
+    @Test
+    fun `should mark every unwatched episode across all seasons given the whole show is marked`() = runTest {
+        fakeDateTimeProvider.setCurrentTimeMillis(NOW)
+
+        watchedEpisodeDao.markSeasonAndPreviousAsWatched(
+            showId = TEST_SHOW_ID,
+            seasonNumber = EpisodeRepository.ALL_SEASONS,
+            includeSpecials = false,
+        )
+
+        database.watchedEpisodesQueries.getWatchedEpisodes(testShowId).executeAsList() shouldHaveSize
+            SEASON_1_EPISODE_COUNT + SEASON_2_EPISODE_COUNT
+    }
+
+    @Test
+    fun `should keep the original date given an already watched episode is inside a whole show mark`() = runTest {
+        watchedEpisodeDao.markAsWatched(
+            showId = TEST_SHOW_ID,
+            episodeId = 101L,
+            seasonNumber = SEASON_1_NUMBER,
+            episodeNumber = 1L,
+            includeSpecials = false,
+            watchedAt = CHOSEN_TIME,
+        )
+        fakeDateTimeProvider.setCurrentTimeMillis(NOW)
+
+        watchedEpisodeDao.markSeasonAndPreviousAsWatched(
+            showId = TEST_SHOW_ID,
+            seasonNumber = EpisodeRepository.ALL_SEASONS,
+            includeSpecials = false,
+        )
+
+        watchedAtFor(episodeNumber = 1L) shouldBe CHOSEN_TIME
+    }
+
+    private fun libraryOrder(): List<Long> =
+        database.followedShowsQueries.followedShows().executeAsList().map { it.show_id.id }
+
+    private fun watchedAtFor(episodeNumber: Long, seasonNumber: Long = SEASON_1_NUMBER): Long =
+        database.watchedEpisodesQueries.getWatchedEpisodes(testShowId)
+            .executeAsList()
+            .single { it.season_number == seasonNumber && it.episode_number == episodeNumber }
+            .watched_at
+
+    private fun insertShowMetadata() {
+        database.showMetadataQueries.upsert(
+            show_id = testShowId,
+            season_count = 2L,
+            episode_count = (SEASON_1_EPISODE_COUNT + SEASON_2_EPISODE_COUNT).toLong(),
+            status = "Returning Series",
+        )
+    }
+
+    private fun followTestShow(followedAt: Long) {
+        database.followedShowsQueries.upsert(
+            showId = testShowId,
+            tmdbId = Id<TmdbId>(TEST_SHOW_ID),
+            followedAt = followedAt,
+            pendingAction = "NOTHING",
+        )
+    }
+
+    private fun followOtherShow(followedAt: Long) {
+        addShowWithoutGenres(OTHER_SHOW_TMDB_ID)
+        database.followedShowsQueries.upsert(
+            showId = showIdForTraktId(OTHER_SHOW_TMDB_ID),
+            tmdbId = Id<TmdbId>(OTHER_SHOW_TMDB_ID),
+            followedAt = followedAt,
+            pendingAction = "NOTHING",
+        )
+    }
+
+    private fun clearFirstAired() {
+        database.episodesQueries.updateFirstAired(
+            firstAired = null,
+            showId = testShowId,
+            seasonNumber = SEASON_1_NUMBER,
+            episodeNumber = 1L,
+        )
+    }
+
+    private fun setFirstEpisodeRuntime(runtime: Long) {
+        database.episodesQueries.upsert(
+            id = Id(101L),
+            season_id = Id(SEASON_1_ID),
+            show_id = testShowId,
+            title = "Episode 1",
+            overview = "Episode 1 overview",
+            episode_number = 1L,
+            runtime = runtime,
+            image_url = "/episode1.jpg",
+            ratings = 8.5,
+            vote_count = 50L,
+            first_aired = LocalDate(2023, 1, 1).toEpochMillis(),
+        )
+    }
+
     private fun addShowWithoutGenres(tmdbId: Long) {
         database.tvShowQueries.upsert(
             tmdb_id = Id(tmdbId),
@@ -929,5 +1146,13 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
             followedAt = Clock.System.now().toEpochMilliseconds(),
             pendingAction = "NOTHING",
         )
+    }
+
+    private companion object {
+        private const val EARLIER_FOLLOW = 1_500_000_000_000L
+        private const val NOW = 1_700_000_000_000L
+        private const val LATER_FOLLOW = 1_800_000_000_000L
+        private const val CHOSEN_TIME = 1_900_000_000_000L
+        private const val EPISODE_RUNTIME_MILLIS = 45L * 60_000L
     }
 }

--- a/data/episode/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/testing/FakeEpisodeRepository.kt
+++ b/data/episode/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/testing/FakeEpisodeRepository.kt
@@ -22,12 +22,22 @@ public data class MarkEpisodeWatchedCall(
     val seasonNumber: Long,
     val episodeNumber: Long,
     val markPreviousEpisodes: Boolean = false,
+    val watchedAt: Long? = null,
+    val useReleaseDate: Boolean = false,
 )
 
 public data class MarkSeasonWatchedCall(
     val showId: Long,
     val seasonNumber: Long,
     val markPreviousSeasons: Boolean,
+    val watchedAt: Long? = null,
+    val useReleaseDate: Boolean = false,
+)
+
+public data class MarkShowWatchedCall(
+    val showId: Long,
+    val watchedAt: Long? = null,
+    val useReleaseDate: Boolean = false,
 )
 
 public data class MarkEpisodeUnwatchedCall(
@@ -72,6 +82,9 @@ public class FakeEpisodeRepository : EpisodeRepository {
         private set
 
     public var lastMarkSeasonWatchedCall: MarkSeasonWatchedCall? = null
+        private set
+
+    public var lastMarkShowWatchedCall: MarkShowWatchedCall? = null
         private set
 
     public var lastMarkEpisodeUnwatchedCall: MarkEpisodeUnwatchedCall? = null
@@ -138,8 +151,17 @@ public class FakeEpisodeRepository : EpisodeRepository {
         episodeId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
+        watchedAt: Long?,
+        useReleaseDate: Boolean,
     ) {
-        lastMarkEpisodeWatchedCall = MarkEpisodeWatchedCall(showId, episodeId, seasonNumber, episodeNumber)
+        lastMarkEpisodeWatchedCall = MarkEpisodeWatchedCall(
+            showId = showId,
+            episodeId = episodeId,
+            seasonNumber = seasonNumber,
+            episodeNumber = episodeNumber,
+            watchedAt = watchedAt,
+            useReleaseDate = useReleaseDate,
+        )
     }
 
     override suspend fun markEpisodeAsUnwatched(showId: Long, episodeId: Long) {
@@ -155,8 +177,19 @@ public class FakeEpisodeRepository : EpisodeRepository {
     override fun observeAllSeasonsWatchProgress(showId: Long): Flow<List<SeasonWatchProgress>> =
         allSeasonsWatchProgressFlow.asStateFlow()
 
-    override suspend fun markSeasonWatched(showId: Long, seasonNumber: Long) {
-        lastMarkSeasonWatchedCall = MarkSeasonWatchedCall(showId, seasonNumber, markPreviousSeasons = false)
+    override suspend fun markSeasonWatched(
+        showId: Long,
+        seasonNumber: Long,
+        watchedAt: Long?,
+        useReleaseDate: Boolean,
+    ) {
+        lastMarkSeasonWatchedCall = MarkSeasonWatchedCall(
+            showId = showId,
+            seasonNumber = seasonNumber,
+            markPreviousSeasons = false,
+            watchedAt = watchedAt,
+            useReleaseDate = useReleaseDate,
+        )
     }
 
     override suspend fun markEpisodeAndPreviousEpisodesWatched(
@@ -164,21 +197,41 @@ public class FakeEpisodeRepository : EpisodeRepository {
         episodeId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
+        watchedAt: Long?,
+        useReleaseDate: Boolean,
     ) {
         lastMarkEpisodeWatchedCall = MarkEpisodeWatchedCall(
-            showId,
-            episodeId,
-            seasonNumber,
-            episodeNumber,
+            showId = showId,
+            episodeId = episodeId,
+            seasonNumber = seasonNumber,
+            episodeNumber = episodeNumber,
             markPreviousEpisodes = true,
+            watchedAt = watchedAt,
+            useReleaseDate = useReleaseDate,
         )
     }
 
     override suspend fun markSeasonAndPreviousSeasonsWatched(
         showId: Long,
         seasonNumber: Long,
+        watchedAt: Long?,
+        useReleaseDate: Boolean,
     ) {
-        lastMarkSeasonWatchedCall = MarkSeasonWatchedCall(showId, seasonNumber, markPreviousSeasons = true)
+        lastMarkSeasonWatchedCall = MarkSeasonWatchedCall(
+            showId = showId,
+            seasonNumber = seasonNumber,
+            markPreviousSeasons = true,
+            watchedAt = watchedAt,
+            useReleaseDate = useReleaseDate,
+        )
+    }
+
+    override suspend fun markShowWatched(showId: Long, watchedAt: Long?, useReleaseDate: Boolean) {
+        lastMarkShowWatchedCall = MarkShowWatchedCall(
+            showId = showId,
+            watchedAt = watchedAt,
+            useReleaseDate = useReleaseDate,
+        )
     }
 
     override suspend fun markSeasonUnwatched(showId: Long, seasonNumber: Long) {}

--- a/domain/episode/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/episode/MarkEpisodeWatchedInteractor.kt
+++ b/domain/episode/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/episode/MarkEpisodeWatchedInteractor.kt
@@ -16,6 +16,8 @@ public class MarkEpisodeWatchedInteractor(
                 episodeId = params.episodeId,
                 seasonNumber = params.seasonNumber,
                 episodeNumber = params.episodeNumber,
+                watchedAt = params.watchedAt,
+                useReleaseDate = params.useReleaseDate,
             )
         } else {
             episodeRepository.markEpisodeAsWatched(
@@ -23,6 +25,8 @@ public class MarkEpisodeWatchedInteractor(
                 episodeId = params.episodeId,
                 seasonNumber = params.seasonNumber,
                 episodeNumber = params.episodeNumber,
+                watchedAt = params.watchedAt,
+                useReleaseDate = params.useReleaseDate,
             )
         }
     }
@@ -34,4 +38,6 @@ public data class MarkEpisodeWatchedParams(
     val seasonNumber: Long,
     val episodeNumber: Long,
     val markPreviousEpisodes: Boolean = false,
+    val watchedAt: Long? = null,
+    val useReleaseDate: Boolean = false,
 )

--- a/domain/episode/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/episode/MarkShowWatchedInteractor.kt
+++ b/domain/episode/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/episode/MarkShowWatchedInteractor.kt
@@ -1,0 +1,25 @@
+package com.thomaskioko.tvmaniac.domain.episode
+
+import com.thomaskioko.tvmaniac.core.base.interactor.Interactor
+import com.thomaskioko.tvmaniac.episodes.api.EpisodeRepository
+import dev.zacsweers.metro.Inject
+
+@Inject
+public class MarkShowWatchedInteractor(
+    private val episodeRepository: EpisodeRepository,
+) : Interactor<MarkShowWatchedParams>() {
+
+    override suspend fun doWork(params: MarkShowWatchedParams) {
+        episodeRepository.markShowWatched(
+            showId = params.showId,
+            watchedAt = params.watchedAt,
+            useReleaseDate = params.useReleaseDate,
+        )
+    }
+}
+
+public data class MarkShowWatchedParams(
+    val showId: Long,
+    val watchedAt: Long? = null,
+    val useReleaseDate: Boolean = false,
+)

--- a/domain/notifications/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/notifications/interactor/SyncCalendarInteractorTest.kt
+++ b/domain/notifications/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/notifications/interactor/SyncCalendarInteractorTest.kt
@@ -88,16 +88,36 @@ private class CountingCalendarEpisodeRepository : EpisodeRepository {
     override fun observeWatchedEpisodeRuntimes(): Flow<List<WatchedEpisodeRuntime>> = flowOf(emptyList())
     override fun observeWatchedShowComposition(): Flow<List<WatchedShowComposition>> = flowOf(emptyList())
     override fun observeMostWatchedShows(limit: Long): Flow<List<MostWatchedShow>> = flowOf(emptyList())
-    override suspend fun markEpisodeAsWatched(showId: Long, episodeId: Long, seasonNumber: Long, episodeNumber: Long) {}
-    override suspend fun markEpisodeAndPreviousEpisodesWatched(showId: Long, episodeId: Long, seasonNumber: Long, episodeNumber: Long) {}
+    override suspend fun markEpisodeAsWatched(
+        showId: Long,
+        episodeId: Long,
+        seasonNumber: Long,
+        episodeNumber: Long,
+        watchedAt: Long?,
+        useReleaseDate: Boolean,
+    ) {}
+    override suspend fun markEpisodeAndPreviousEpisodesWatched(
+        showId: Long,
+        episodeId: Long,
+        seasonNumber: Long,
+        episodeNumber: Long,
+        watchedAt: Long?,
+        useReleaseDate: Boolean,
+    ) {}
     override suspend fun markEpisodeAsUnwatched(showId: Long, episodeId: Long) {}
     override fun observeSeasonWatchProgress(showId: Long, seasonNumber: Long): Flow<SeasonWatchProgress> =
         flowOf(SeasonWatchProgress(0, 0, 0, 0))
     override fun observeShowWatchProgress(showId: Long): Flow<ShowWatchProgress> =
         flowOf(ShowWatchProgress(0, 0, 0))
     override fun observeAllSeasonsWatchProgress(showId: Long): Flow<List<SeasonWatchProgress>> = flowOf(emptyList())
-    override suspend fun markSeasonWatched(showId: Long, seasonNumber: Long) {}
-    override suspend fun markSeasonAndPreviousSeasonsWatched(showId: Long, seasonNumber: Long) {}
+    override suspend fun markSeasonWatched(showId: Long, seasonNumber: Long, watchedAt: Long?, useReleaseDate: Boolean) {}
+    override suspend fun markSeasonAndPreviousSeasonsWatched(
+        showId: Long,
+        seasonNumber: Long,
+        watchedAt: Long?,
+        useReleaseDate: Boolean,
+    ) {}
+    override suspend fun markShowWatched(showId: Long, watchedAt: Long?, useReleaseDate: Boolean) {}
     override suspend fun markSeasonUnwatched(showId: Long, seasonNumber: Long) {}
     override fun observeUnwatchedCountInPreviousSeasons(showId: Long, seasonNumber: Long): Flow<Long> = flowOf(0L)
     override suspend fun getUpcomingEpisodesFromFollowedShows(limit: Duration): List<UpcomingEpisode> = emptyList()

--- a/domain/rewatch/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/rewatch/WatchAgainInteractor.kt
+++ b/domain/rewatch/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/rewatch/WatchAgainInteractor.kt
@@ -2,19 +2,16 @@ package com.thomaskioko.tvmaniac.domain.rewatch
 
 import com.thomaskioko.tvmaniac.core.base.interactor.Interactor
 import com.thomaskioko.tvmaniac.data.rewatch.api.RewatchRepository
-import com.thomaskioko.tvmaniac.util.api.DateTimeProvider
 import dev.zacsweers.metro.Inject
 
 @Inject
 public class WatchAgainInteractor(
     private val rewatchRepository: RewatchRepository,
-    private val dateTimeProvider: DateTimeProvider,
 ) : Interactor<WatchAgainInteractor.Param>() {
 
     override suspend fun doWork(params: Param) {
-        val watchedAt = dateTimeProvider.nowMillis()
         val sessionId = rewatchRepository.openSessionForShow(params.showId)?.id
-            ?: rewatchRepository.startSession(showId = params.showId, startedAt = watchedAt)
+            ?: rewatchRepository.startSession(showId = params.showId, startedAt = params.watchedAt)
             ?: return
 
         rewatchRepository.addEpisodeToSession(
@@ -23,7 +20,7 @@ public class WatchAgainInteractor(
             episodeId = params.episodeId,
             seasonNumber = params.seasonNumber,
             episodeNumber = params.episodeNumber,
-            watchedAt = watchedAt,
+            watchedAt = params.watchedAt,
         )
     }
 
@@ -32,5 +29,6 @@ public class WatchAgainInteractor(
         val episodeId: Long,
         val seasonNumber: Long,
         val episodeNumber: Long,
+        val watchedAt: Long,
     )
 }

--- a/domain/rewatch/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/rewatch/WatchAgainInteractorTest.kt
+++ b/domain/rewatch/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/rewatch/WatchAgainInteractorTest.kt
@@ -4,7 +4,6 @@ import app.cash.turbine.test
 import com.thomaskioko.tvmaniac.core.view.InvokeStarted
 import com.thomaskioko.tvmaniac.core.view.InvokeSuccess
 import com.thomaskioko.tvmaniac.data.rewatch.testing.FakeRewatchRepository
-import com.thomaskioko.tvmaniac.util.testing.FakeDateTimeProvider
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -12,12 +11,8 @@ import kotlin.test.Test
 internal class WatchAgainInteractorTest {
 
     private val rewatchRepository = FakeRewatchRepository()
-    private val dateTimeProvider = FakeDateTimeProvider()
 
-    private val interactor = WatchAgainInteractor(
-        rewatchRepository = rewatchRepository,
-        dateTimeProvider = dateTimeProvider,
-    )
+    private val interactor = WatchAgainInteractor(rewatchRepository = rewatchRepository)
 
     @Test
     fun `should emit success given an episode is watched again`() = runTest {
@@ -62,15 +57,14 @@ internal class WatchAgainInteractorTest {
         rewatchRepository.lastAddEpisodeSessionId shouldBe firstSessionId
     }
 
-    private fun episodeWatch(watchedAt: Long): WatchAgainInteractor.Param {
-        dateTimeProvider.setCurrentTimeMillis(watchedAt)
-        return WatchAgainInteractor.Param(
+    private fun episodeWatch(watchedAt: Long): WatchAgainInteractor.Param =
+        WatchAgainInteractor.Param(
             showId = SHOW_ID,
             episodeId = EPISODE_ID,
             seasonNumber = 1L,
             episodeNumber = 3L,
+            watchedAt = watchedAt,
         )
-    }
 
     private companion object {
         private const val SHOW_ID = 84958L

--- a/domain/seasondetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/seasondetails/MarkSeasonWatchedInteractor.kt
+++ b/domain/seasondetails/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/seasondetails/MarkSeasonWatchedInteractor.kt
@@ -14,11 +14,15 @@ public class MarkSeasonWatchedInteractor(
             episodeRepository.markSeasonAndPreviousSeasonsWatched(
                 showId = params.showId,
                 seasonNumber = params.seasonNumber,
+                watchedAt = params.watchedAt,
+                useReleaseDate = params.useReleaseDate,
             )
         } else {
             episodeRepository.markSeasonWatched(
                 showId = params.showId,
                 seasonNumber = params.seasonNumber,
+                watchedAt = params.watchedAt,
+                useReleaseDate = params.useReleaseDate,
             )
         }
     }
@@ -28,4 +32,6 @@ public data class MarkSeasonWatchedParams(
     val showId: Long,
     val seasonNumber: Long,
     val markPreviousSeasons: Boolean = false,
+    val watchedAt: Long? = null,
+    val useReleaseDate: Boolean = false,
 )

--- a/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/WatchStatisticsCalculator.kt
+++ b/domain/statistics/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/statistics/WatchStatisticsCalculator.kt
@@ -21,6 +21,7 @@ import com.thomaskioko.tvmaniac.domain.statistics.model.WatchStatusCount
 import com.thomaskioko.tvmaniac.domain.statistics.model.WatchStreak
 import com.thomaskioko.tvmaniac.domain.statistics.model.WeekdayWatchCount
 import com.thomaskioko.tvmaniac.domain.statistics.model.YearlyWatchCount
+import com.thomaskioko.tvmaniac.episodes.api.WatchedDate
 import com.thomaskioko.tvmaniac.episodes.api.model.MostWatchedShow
 import com.thomaskioko.tvmaniac.episodes.api.model.WatchedEpisodeRuntime
 import com.thomaskioko.tvmaniac.episodes.api.model.WatchedShowComposition
@@ -50,31 +51,33 @@ public class WatchStatisticsCalculator(
     ): WatchStatistics {
         val timeZone = dateTimeProvider.getTimeZone()
         val today = dateTimeProvider.now().toLocalDateTime(timeZone).date
-        val watchedDays = watches.map { watch ->
-            WatchedDay(
-                date = Instant.fromEpochMilliseconds(watch.watchedAt).toLocalDateTime(timeZone).date,
-                minutes = watch.runtimeMinutes ?: 0L,
-            )
-        }
+        val datedWatchedDays = watches
+            .filterNot { watch -> WatchedDate.isUnknown(watch.watchedAt) }
+            .map { watch ->
+                WatchedDay(
+                    date = Instant.fromEpochMilliseconds(watch.watchedAt).toLocalDateTime(timeZone).date,
+                    minutes = watch.runtimeMinutes ?: 0L,
+                )
+            }
 
         return WatchStatistics(
-            totalWatchTime = WatchDuration(watchedDays.sumOf { it.minutes } + rewatchTotals.minutes),
+            totalWatchTime = WatchDuration(watches.sumOf { it.runtimeMinutes ?: 0L } + rewatchTotals.minutes),
             episodesWatched = watches.size.toLong() + rewatchTotals.viewings,
             showsTracked = calculateShowsTracked(showCountsByStatus),
             averageRating = calculateAverageRating(ratingCounts),
-            topWeekday = calculateTopWeekday(watchedDays),
-            streak = calculateStreak(watchedDays, today),
-            watchDaysThisYear = calculateWatchDaysThisYear(watchedDays, today),
-            watchDaysThisMonth = calculateWatchDaysThisMonth(watchedDays, today),
+            topWeekday = calculateTopWeekday(datedWatchedDays),
+            streak = calculateStreak(datedWatchedDays, today),
+            watchDaysThisYear = calculateWatchDaysThisYear(datedWatchedDays, today),
+            watchDaysThisMonth = calculateWatchDaysThisMonth(datedWatchedDays, today),
             lastThirtyDays = calculatePeriodSummary(
-                watchedDays = watchedDays,
+                watchedDays = datedWatchedDays,
                 from = today.plus(-LAST_PERIOD_DAYS, DateTimeUnit.DAY),
             ),
-            peakYear = calculatePeakYear(watchedDays),
-            dailyCounts = calculateDailyCounts(watchedDays, today),
-            yearlyCounts = calculateYearlyCounts(watchedDays),
-            monthlyCounts = calculateMonthlyCounts(watchedDays),
-            weekdayCounts = calculateWeekdayCounts(watchedDays),
+            peakYear = calculatePeakYear(datedWatchedDays),
+            dailyCounts = calculateDailyCounts(datedWatchedDays, today),
+            yearlyCounts = calculateYearlyCounts(datedWatchedDays),
+            monthlyCounts = calculateMonthlyCounts(datedWatchedDays),
+            weekdayCounts = calculateWeekdayCounts(datedWatchedDays),
             mostWatchedShows = mostWatchedShows,
             highestRatedShows = highestRatedShows,
             showsByWatchStatus = getShowsByWatchStatus(showCountsByStatus),

--- a/domain/statistics/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/statistics/WatchStatisticsCalculatorTest.kt
+++ b/domain/statistics/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/statistics/WatchStatisticsCalculatorTest.kt
@@ -14,6 +14,7 @@ import com.thomaskioko.tvmaniac.domain.statistics.model.GenreCount
 import com.thomaskioko.tvmaniac.domain.statistics.model.ReleaseYearCount
 import com.thomaskioko.tvmaniac.domain.statistics.model.WatchStatistics
 import com.thomaskioko.tvmaniac.domain.statistics.model.WatchStreak
+import com.thomaskioko.tvmaniac.episodes.api.WatchedDate
 import com.thomaskioko.tvmaniac.episodes.implementation.dao.DefaultWatchedEpisodeDao
 import com.thomaskioko.tvmaniac.util.testing.FakeDateTimeProvider
 import com.thomaskioko.tvmaniac.watchstatus.implementation.DefaultShowWatchStatusDao
@@ -161,6 +162,37 @@ internal class WatchStatisticsCalculatorTest : BaseDatabaseTest() {
         statistics.episodesWatched shouldBe 1L
         statistics.dailyCounts.all { it.episodeCount == 0 } shouldBe true
         statistics.peakYear?.year shouldBe 2024
+    }
+
+    @Test
+    fun `should leave an undated watch out of every date bucketed chart`() = runTest(testDispatcher) {
+        insertShow(tmdbId = BREAKING_BAD)
+        markWatched(BREAKING_BAD, episodeNumber = 1, watchedAt = epochMillis(2026, 8, 3))
+        markWatched(BREAKING_BAD, episodeNumber = 2, watchedAt = WatchedDate.UNKNOWN_MILLIS)
+
+        val statistics = calculate()
+
+        statistics.yearlyCounts.map { it.year } shouldBe listOf(2026)
+        statistics.monthlyCounts.sumOf { it.episodeCount } shouldBe 1
+        statistics.weekdayCounts.sumOf { it.episodeCount } shouldBe 1
+        statistics.topWeekday?.episodeCount shouldBe 1
+        statistics.peakYear?.year shouldBe 2026
+        statistics.peakYear?.episodeCount shouldBe 1
+        statistics.streak.longestStart shouldBe LocalDate(2026, 8, 3)
+        statistics.streak.longestEnd shouldBe LocalDate(2026, 8, 3)
+    }
+
+    @Test
+    fun `should count an undated watch in the totals given it is left out of the charts`() = runTest(testDispatcher) {
+        insertShow(tmdbId = BREAKING_BAD)
+        setShowRuntime(BREAKING_BAD, runtime = 45)
+        markWatched(BREAKING_BAD, episodeNumber = 1, watchedAt = epochMillis(2026, 8, 3))
+        markWatched(BREAKING_BAD, episodeNumber = 2, watchedAt = WatchedDate.UNKNOWN_MILLIS)
+
+        val statistics = calculate()
+
+        statistics.episodesWatched shouldBe 2L
+        statistics.totalWatchTime.totalMinutes shouldBe 90L
     }
 
     @Test

--- a/features/episode-sheet/presenter/README.md
+++ b/features/episode-sheet/presenter/README.md
@@ -152,6 +152,7 @@ graph TB
   :features:episode-sheet:nav --> :navigation:api
   :features:episode-sheet:presenter --> :core:base
   :features:episode-sheet:presenter --> :core:logger:api
+  :features:episode-sheet:presenter --> :core:util:api
   :features:episode-sheet:presenter --> :core:view
   :features:episode-sheet:presenter --> :data:datastore:api
   :features:episode-sheet:presenter --> :domain:episode

--- a/features/episode-sheet/presenter/build.gradle.kts
+++ b/features/episode-sheet/presenter/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
             dependencies {
                 api(projects.core.base)
                 api(projects.core.logger.api)
+                api(projects.core.util.api)
                 api(projects.core.view)
                 api(projects.domain.episode)
                 api(projects.domain.followedshows)

--- a/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenter.kt
+++ b/features/episode-sheet/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenter.kt
@@ -35,6 +35,7 @@ import com.thomaskioko.tvmaniac.seasondetails.nav.SeasonDetailsRoute
 import com.thomaskioko.tvmaniac.seasondetails.nav.SeasonDetailsUiParam
 import com.thomaskioko.tvmaniac.showdetails.nav.ShowDetailsRoute
 import com.thomaskioko.tvmaniac.showdetails.nav.model.ShowDetailsParam
+import com.thomaskioko.tvmaniac.util.api.DateTimeProvider
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
@@ -63,6 +64,7 @@ public class EpisodeSheetPresenter internal constructor(
     private val shouldPromptForRatingInteractor: ShouldPromptForRatingInteractor,
     private val markEpisodeUnwatchedInteractor: MarkEpisodeUnwatchedInteractor,
     private val watchAgainInteractor: WatchAgainInteractor,
+    private val dateTimeProvider: DateTimeProvider,
     private val datastoreRepository: DatastoreRepository,
     private val unfollowShowInteractor: UnfollowShowInteractor,
     private val errorToStringMapper: ErrorToStringMapper,
@@ -156,6 +158,7 @@ public class EpisodeSheetPresenter internal constructor(
                         episodeId = episode.episode_id.id,
                         seasonNumber = episode.season_number,
                         episodeNumber = episode.episode_number,
+                        watchedAt = dateTimeProvider.nowMillis(),
                     ),
                 )
             } else {

--- a/features/episode-sheet/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenterTest.kt
+++ b/features/episode-sheet/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/episodedetail/EpisodeSheetPresenterTest.kt
@@ -539,7 +539,8 @@ internal class EpisodeSheetPresenterTest {
             shouldPromptForRatingInteractor = shouldPromptForRatingInteractor,
             markEpisodeUnwatchedInteractor = MarkEpisodeUnwatchedInteractor(episodeRepository, rewatchRepository),
             observeEpisodeRewatchesInteractor = ObserveEpisodeRewatchesInteractor(rewatchRepository),
-            watchAgainInteractor = WatchAgainInteractor(rewatchRepository, dateTimeProvider),
+            watchAgainInteractor = WatchAgainInteractor(rewatchRepository),
+            dateTimeProvider = dateTimeProvider,
             datastoreRepository = datastoreRepository,
             unfollowShowInteractor = UnfollowShowInteractor(
                 followedShowsRepository = followedShowsRepository,
@@ -685,8 +686,11 @@ internal class EpisodeSheetPresenterTest {
         vote_count = voteCount,
         ratings = rating,
         image_url = "https://image.url/episode.jpg",
+        runtime = 45L,
+        first_aired = null,
         season_number = 1L,
         show_name = "Breaking Bad",
         is_watched = if (isWatched) 1L else 0L,
+        watched_at = null,
     )
 }

--- a/features/episode-sheet/ui/README.md
+++ b/features/episode-sheet/ui/README.md
@@ -161,6 +161,7 @@ graph TB
   :features:episode-sheet:nav --> :navigation:api
   :features:episode-sheet:presenter --> :core:base
   :features:episode-sheet:presenter --> :core:logger:api
+  :features:episode-sheet:presenter --> :core:util:api
   :features:episode-sheet:presenter --> :core:view
   :features:episode-sheet:presenter --> :data:datastore:api
   :features:episode-sheet:presenter --> :domain:episode

--- a/ios-framework/README.md
+++ b/ios-framework/README.md
@@ -1075,6 +1075,7 @@ graph TB
   :features:episode-sheet:nav --> :navigation:api
   :features:episode-sheet:presenter --> :core:base
   :features:episode-sheet:presenter --> :core:logger:api
+  :features:episode-sheet:presenter --> :core:util:api
   :features:episode-sheet:presenter --> :core:view
   :features:episode-sheet:presenter --> :data:datastore:api
   :features:episode-sheet:presenter --> :domain:episode


### PR DESCRIPTION
## Description
This PR lets the app save a watched date other than the current time and send it to Trakt and Simkl. Nothing in the app offers that choice yet, so the only difference today is that Simkl now stores the time the app recorded.

## Changes
- Send the watched time to Simkl, which until now replaced it with its own
- Store a watched date the person does not remember, and convert it to the value Trakt and Simkl each expect
- Work out the release date on the device from an episode's air date and length, so Trakt and Simkl get the same time
- Leave marks with no date out of the yearly, monthly and weekday charts, while still counting them in total time watched and total episodes watched
- Keep a mark with no date off the Recently Watched list and out of the library sort order
- Add a way to mark every unwatched episode of a show at once
