### PR TITLE
chore: Add watch date strings in English, German and French

### DIFF
--- a/i18n/generator/src/commonMain/moko-resources/base/plurals.xml
+++ b/i18n/generator/src/commonMain/moko-resources/base/plurals.xml
@@ -56,4 +56,8 @@
         <item quantity="one">Watched %d time</item>
         <item quantity="other">Watched %d times</item>
     </plurals>
+    <plurals name="dialog_message_mark_show_watched">
+        <item quantity="one">This will mark %d episode as watched.</item>
+        <item quantity="other">This will mark %d episodes as watched.</item>
+    </plurals>
 </resources>

--- a/i18n/generator/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/base/strings.xml
@@ -578,4 +578,14 @@
     <string name="label_watch_status_dropped">Dropped</string>
 
     <string name="label_rewatch_simkl_free_tier">Simkl does not store rewatches without a paid plan, so this count stays on this device.</string>
+
+    <string name="label_watched_date_title">When did you watch this?</string>
+    <string name="label_watched_date_edit_title">Change watched date</string>
+    <string name="label_watched_date_just_now">Just now</string>
+    <string name="label_watched_date_release_date">Release date</string>
+    <string name="label_watched_date_other">Other date…</string>
+    <string name="label_watched_date_unknown">Unknown date</string>
+    <string name="label_watched_date_unknown_display">A long time ago</string>
+    <string name="label_mark_show_watched">Mark show as watched</string>
+    <string name="label_mark_show_watched_confirm_title">Mark whole show as watched?</string>
 </resources>

--- a/i18n/generator/src/commonMain/moko-resources/de/plurals.xml
+++ b/i18n/generator/src/commonMain/moko-resources/de/plurals.xml
@@ -56,4 +56,8 @@
         <item quantity="one">%d Mal gesehen</item>
         <item quantity="other">%d Mal gesehen</item>
     </plurals>
+    <plurals name="dialog_message_mark_show_watched">
+        <item quantity="one">Dadurch wird %d Folge als gesehen markiert.</item>
+        <item quantity="other">Dadurch werden %d Folgen als gesehen markiert.</item>
+    </plurals>
 </resources>

--- a/i18n/generator/src/commonMain/moko-resources/de/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/de/strings.xml
@@ -570,4 +570,14 @@
     <string name="label_watch_status_dropped">Abgebrochen</string>
 
     <string name="label_rewatch_simkl_free_tier">Simkl speichert wiederholtes Ansehen nur mit einem kostenpflichtigen Tarif. Diese Zählung bleibt auf diesem Gerät.</string>
+
+    <string name="label_watched_date_title">Wann haben Sie das gesehen?</string>
+    <string name="label_watched_date_edit_title">Sehdatum ändern</string>
+    <string name="label_watched_date_just_now">Gerade eben</string>
+    <string name="label_watched_date_release_date">Ausstrahlungsdatum</string>
+    <string name="label_watched_date_other">Anderes Datum …</string>
+    <string name="label_watched_date_unknown">Datum unbekannt</string>
+    <string name="label_watched_date_unknown_display">Vor langer Zeit</string>
+    <string name="label_mark_show_watched">Serie als gesehen markieren</string>
+    <string name="label_mark_show_watched_confirm_title">Ganze Serie als gesehen markieren?</string>
 </resources>

--- a/i18n/generator/src/commonMain/moko-resources/fr/plurals.xml
+++ b/i18n/generator/src/commonMain/moko-resources/fr/plurals.xml
@@ -60,4 +60,8 @@
         <item quantity="one">Vu %d fois</item>
         <item quantity="other">Vu %d fois</item>
     </plurals>
+    <plurals name="dialog_message_mark_show_watched">
+        <item quantity="one">%d épisode sera marqué comme vu.</item>
+        <item quantity="other">%d épisodes seront marqués comme vus.</item>
+    </plurals>
 </resources>

--- a/i18n/generator/src/commonMain/moko-resources/fr/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/fr/strings.xml
@@ -564,4 +564,14 @@
     <string name="label_remove_watch_confirm_message">\"%1$s\" ne comptera plus comme vu.</string>
 
     <string name="label_rewatch_simkl_free_tier">Simkl n\'enregistre pas les revisionnages sans forfait payant. Ce décompte reste sur cet appareil.</string>
+
+    <string name="label_watched_date_title">Quand avez-vous regardé ceci ?</string>
+    <string name="label_watched_date_edit_title">Modifier la date de visionnage</string>
+    <string name="label_watched_date_just_now">À l\'instant</string>
+    <string name="label_watched_date_release_date">Date de diffusion</string>
+    <string name="label_watched_date_other">Autre date…</string>
+    <string name="label_watched_date_unknown">Date inconnue</string>
+    <string name="label_watched_date_unknown_display">Il y a longtemps</string>
+    <string name="label_mark_show_watched">Marquer la série comme vue</string>
+    <string name="label_mark_show_watched_confirm_title">Marquer toute la série comme vue ?</string>
 </resources>


### PR DESCRIPTION
## Description
This PR adds the text the watch date screen needs, in English, German and French. Nothing displays it yet, because the screen that reads it comes in the next change.
