### PR TITLE
feat: Add Watch date selection long press

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1249,6 +1249,7 @@ graph TB
   :features:continue-watching:presenter --> :features:rating-sheet:presenter
   :features:continue-watching:presenter -.-> :features:season-details:nav
   :features:continue-watching:presenter -.-> :features:show-details:nav
+  :features:continue-watching:presenter --> :features:watchdate-selection:nav
   :features:continue-watching:presenter --> :i18n:api
   :features:continue-watching:presenter --> :navigation:api
   :features:continue-watching:ui -.-> :android-designsystem
@@ -1565,6 +1566,7 @@ graph TB
   :features:season-details:presenter -.-> :features:episode-sheet:nav
   :features:season-details:presenter --> :features:rating-sheet:nav
   :features:season-details:presenter --> :features:season-details:nav
+  :features:season-details:presenter --> :features:watchdate-selection:nav
   :features:season-details:presenter --> :navigation:api
   :features:season-details:ui -.-> :android-designsystem
   :features:season-details:ui --> :core:base
@@ -1632,6 +1634,7 @@ graph TB
   :features:show-details:presenter --> :features:show-details:nav
   :features:show-details:presenter --> :features:show-list:nav
   :features:show-details:presenter -.-> :features:trailers:nav
+  :features:show-details:presenter --> :features:watchdate-selection:nav
   :features:show-details:presenter --> :i18n:api
   :features:show-details:presenter --> :navigation:api
   :features:show-details:ui -.-> :android-designsystem
@@ -1731,6 +1734,7 @@ graph TB
   :features:upnext:presenter --> :features:rating-sheet:presenter
   :features:upnext:presenter -.-> :features:season-details:nav
   :features:upnext:presenter -.-> :features:show-details:nav
+  :features:upnext:presenter --> :features:watchdate-selection:nav
   :features:upnext:presenter --> :navigation:api
   :features:upnext:ui -.-> :android-designsystem
   :features:upnext:ui -.-> :core:test-tags
@@ -1748,6 +1752,7 @@ graph TB
   :features:watchdate-selection:presenter --> :data:ratings:api
   :features:watchdate-selection:presenter --> :domain:episode
   :features:watchdate-selection:presenter --> :domain:ratings
+  :features:watchdate-selection:presenter --> :domain:rewatch
   :features:watchdate-selection:presenter --> :features:rating-sheet:nav
   :features:watchdate-selection:presenter --> :features:watchdate-selection:nav
   :features:watchdate-selection:presenter --> :i18n:api

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/seasons/SeasonFlowTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/seasons/SeasonFlowTest.kt
@@ -57,6 +57,12 @@ internal class SeasonFlowTest : BaseAppFlowTest() {
             .assertMarkPreviousEpisodesDialogDisplayed()
             .clickMarkPreviousEpisodesDismiss()
             .assertMarkPreviousEpisodesDialogDoesNotExist()
+
+        watchDateSelectionRobot
+            .assertSheetDisplayed()
+            .clickJustNow()
+
+        seasonDetailsRobot
             .assertMarkUnwatchedDisplayed(secondEpisodeTraktId)
             .assertMarkWatchedDisplayed(pilotEpisodeTraktId)
 
@@ -68,6 +74,12 @@ internal class SeasonFlowTest : BaseAppFlowTest() {
             .clickMarkWatched(secondEpisodeTraktId)
             .clickMarkPreviousEpisodesConfirm()
             .assertMarkPreviousEpisodesDialogDoesNotExist()
+
+        watchDateSelectionRobot
+            .assertSheetDisplayed()
+            .clickJustNow()
+
+        seasonDetailsRobot
             .assertMarkUnwatchedDisplayed(pilotEpisodeTraktId)
             .assertMarkUnwatchedDisplayed(secondEpisodeTraktId)
             .clickBackButton()
@@ -87,6 +99,12 @@ internal class SeasonFlowTest : BaseAppFlowTest() {
             .assertMarkPreviousSeasonsDialogDisplayed()
             .clickMarkPreviousSeasonsConfirm()
             .assertMarkPreviousSeasonsDialogDoesNotExist()
+
+        watchDateSelectionRobot
+            .assertSheetDisplayed()
+            .clickJustNow()
+
+        seasonDetailsRobot
             .assertMarkUnwatchedDisplayed(seasonTwoFirstEpisodeTraktId)
             .clickBackButton()
 
@@ -135,6 +153,12 @@ internal class SeasonFlowTest : BaseAppFlowTest() {
             .assertWatchSeasonDialogDisplayed()
             .clickWatchSeasonConfirm()
             .assertWatchSeasonDialogDoesNotExist()
+
+        watchDateSelectionRobot
+            .assertSheetDisplayed()
+            .clickJustNow()
+
+        seasonDetailsRobot
             .scrollToMarkUnwatchedButton(secondEpisodeTraktId)
             .assertMarkUnwatchedDisplayed(secondEpisodeTraktId)
     }

--- a/features/continue-watching/presenter/README.md
+++ b/features/continue-watching/presenter/README.md
@@ -153,6 +153,10 @@ graph TB
     direction TB
     :features:show-details:nav[nav]:::multiplatform
   end
+  subgraph :features:watchdate-selection
+    direction TB
+    :features:watchdate-selection:nav[nav]:::multiplatform
+  end
   subgraph :i18n
     direction TB
     :i18n:api[api]:::multiplatform
@@ -261,6 +265,7 @@ graph TB
   :features:continue-watching:presenter --> :features:rating-sheet:presenter
   :features:continue-watching:presenter -.-> :features:season-details:nav
   :features:continue-watching:presenter -.-> :features:show-details:nav
+  :features:continue-watching:presenter --> :features:watchdate-selection:nav
   :features:continue-watching:presenter --> :i18n:api
   :features:continue-watching:presenter --> :navigation:api
   :features:my-shows:nav --> :navigation:api
@@ -277,6 +282,8 @@ graph TB
   :features:rating-sheet:presenter --> :navigation:api
   :features:season-details:nav --> :navigation:api
   :features:show-details:nav --> :navigation:api
+  :features:watchdate-selection:nav --> :data:episode:api
+  :features:watchdate-selection:nav --> :navigation:api
   :i18n:api --> :i18n:generator
 
 classDef application fill:#CAFFBF,stroke:#000,stroke-width:2px,color:#000;

--- a/features/continue-watching/presenter/build.gradle.kts
+++ b/features/continue-watching/presenter/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
                 api(projects.domain.episode)
                 api(projects.domain.ratings)
                 api(projects.features.ratingSheet.nav)
+                api(projects.features.watchdateSelection.nav)
                 api(projects.features.ratingSheet.presenter)
                 api(projects.domain.followedshows)
                 api(projects.domain.continueWatching)

--- a/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingAction.kt
+++ b/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingAction.kt
@@ -17,6 +17,13 @@ public data class MarkUpNextEpisodeWatched(
     val episodeNumber: Long,
 ) : ContinueWatchingAction
 
+public data class MarkUpNextEpisodeWatchedLongPressed(
+    val showId: Long,
+    val episodeId: Long,
+    val seasonNumber: Long,
+    val episodeNumber: Long,
+) : ContinueWatchingAction
+
 public data class UnfollowShowFromUpNext(val showId: Long) : ContinueWatchingAction
 
 public data class OpenSeasonFromUpNext(

--- a/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingPresenter.kt
+++ b/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingPresenter.kt
@@ -19,6 +19,7 @@ import com.thomaskioko.tvmaniac.domain.episode.MarkEpisodeWatchedInteractor
 import com.thomaskioko.tvmaniac.domain.episode.MarkEpisodeWatchedParams
 import com.thomaskioko.tvmaniac.domain.followedshows.UnfollowShowInteractor
 import com.thomaskioko.tvmaniac.domain.ratings.ShouldPromptForRatingInteractor
+import com.thomaskioko.tvmaniac.episodes.api.WatchedDateTarget
 import com.thomaskioko.tvmaniac.featureflags.FeatureFlag
 import com.thomaskioko.tvmaniac.featureflags.flags.ContinueWatchingNitroFlagQualifier
 import com.thomaskioko.tvmaniac.myshows.nav.MyShowsRoot
@@ -32,6 +33,8 @@ import com.thomaskioko.tvmaniac.showdetails.nav.model.ShowDetailsParam
 import com.thomaskioko.tvmaniac.subscription.api.SubscriptionFeature
 import com.thomaskioko.tvmaniac.subscription.api.SubscriptionManager
 import com.thomaskioko.tvmaniac.syncstate.api.SyncObserver
+import com.thomaskioko.tvmaniac.watchdateselection.nav.WatchDateSelectionParam
+import com.thomaskioko.tvmaniac.watchdateselection.nav.WatchDateSelectionRoute
 import com.thomaskioko.tvmaniac.watchlistprefs.api.WatchlistPrefsRepository
 import dev.zacsweers.metro.Inject
 import io.github.thomaskioko.codegen.annotations.ChildPresenter
@@ -152,6 +155,18 @@ public class ContinueWatchingPresenter internal constructor(
             is UpNextEpisodeClicked -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(showId = action.showId)))
             is ShowTitleClicked -> navigator.navigateTo(ShowDetailsRoute(ShowDetailsParam(showId = action.showId)))
             is MarkUpNextEpisodeWatched -> markEpisodeWatched(action)
+            is MarkUpNextEpisodeWatchedLongPressed -> navigator.navigateTo(
+                WatchDateSelectionRoute(
+                    WatchDateSelectionParam(
+                        target = WatchedDateTarget.EPISODE,
+                        showId = action.showId,
+                        episodeId = action.episodeId,
+                        seasonNumber = action.seasonNumber,
+                        episodeNumber = action.episodeNumber,
+                        isEdit = true,
+                    ),
+                ),
+            )
             is UnfollowShowFromUpNext -> unfollowShow(action.showId)
             is OpenSeasonFromUpNext -> navigator.navigateTo(
                 SeasonDetailsRoute(

--- a/features/continue-watching/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingPresenterTest.kt
+++ b/features/continue-watching/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingPresenterTest.kt
@@ -10,6 +10,7 @@ import com.thomaskioko.tvmaniac.navigation.testing.FakeNavigator
 import com.thomaskioko.tvmaniac.ratingsheet.nav.RatingSheetRoute
 import com.thomaskioko.tvmaniac.subscription.api.SubscriptionFeature
 import com.thomaskioko.tvmaniac.upnext.api.model.NextEpisodeWithShow
+import com.thomaskioko.tvmaniac.watchdateselection.nav.WatchDateSelectionRoute
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -67,6 +68,26 @@ class ContinueWatchingPresenterTest {
 
         val route = navigator.lastActivatedOverlay.shouldBeInstanceOf<RatingSheetRoute>()
         route.param.id shouldBe 2L
+    }
+
+    @Test
+    fun `should open the watch date sheet given the check button is long pressed`() = runTest {
+        val navigator = FakeNavigator()
+        val presenter = factory.create(
+            componentContext = DefaultComponentContext(lifecycle = lifecycle),
+            navigator = navigator,
+        )
+
+        presenter.dispatch(
+            MarkUpNextEpisodeWatchedLongPressed(showId = 1L, episodeId = 2L, seasonNumber = 1L, episodeNumber = 3L),
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val route = navigator.lastActivatedOverlay.shouldBeInstanceOf<WatchDateSelectionRoute>()
+        route.param.showId shouldBe 1L
+        route.param.episodeId shouldBe 2L
+        route.param.seasonNumber shouldBe 1L
+        route.param.episodeNumber shouldBe 3L
     }
 
     @Test

--- a/features/continue-watching/ui/README.md
+++ b/features/continue-watching/ui/README.md
@@ -157,6 +157,10 @@ graph TB
     direction TB
     :features:show-details:nav[nav]:::multiplatform
   end
+  subgraph :features:watchdate-selection
+    direction TB
+    :features:watchdate-selection:nav[nav]:::multiplatform
+  end
   subgraph :i18n
     direction TB
     :i18n:api[api]:::multiplatform
@@ -269,6 +273,7 @@ graph TB
   :features:continue-watching:presenter --> :features:rating-sheet:presenter
   :features:continue-watching:presenter -.-> :features:season-details:nav
   :features:continue-watching:presenter -.-> :features:show-details:nav
+  :features:continue-watching:presenter --> :features:watchdate-selection:nav
   :features:continue-watching:presenter --> :i18n:api
   :features:continue-watching:presenter --> :navigation:api
   :features:continue-watching:ui -.-> :android-designsystem
@@ -291,6 +296,8 @@ graph TB
   :features:rating-sheet:presenter --> :navigation:api
   :features:season-details:nav --> :navigation:api
   :features:show-details:nav --> :navigation:api
+  :features:watchdate-selection:nav --> :data:episode:api
+  :features:watchdate-selection:nav --> :navigation:api
   :i18n:api --> :i18n:generator
 
 classDef application fill:#CAFFBF,stroke:#000,stroke-width:2px,color:#000;

--- a/features/my-shows/presenter/README.md
+++ b/features/my-shows/presenter/README.md
@@ -167,6 +167,10 @@ graph TB
     direction TB
     :features:start-watching:presenter[presenter]:::multiplatform
   end
+  subgraph :features:watchdate-selection
+    direction TB
+    :features:watchdate-selection:nav[nav]:::multiplatform
+  end
   subgraph :i18n
     direction TB
     :i18n:api[api]:::multiplatform
@@ -280,6 +284,7 @@ graph TB
   :features:continue-watching:presenter --> :features:rating-sheet:presenter
   :features:continue-watching:presenter -.-> :features:season-details:nav
   :features:continue-watching:presenter -.-> :features:show-details:nav
+  :features:continue-watching:presenter --> :features:watchdate-selection:nav
   :features:continue-watching:presenter --> :i18n:api
   :features:continue-watching:presenter --> :navigation:api
   :features:home:nav --> :navigation:api
@@ -317,6 +322,8 @@ graph TB
   :features:start-watching:presenter --> :features:my-shows:nav
   :features:start-watching:presenter -.-> :features:show-details:nav
   :features:start-watching:presenter --> :navigation:api
+  :features:watchdate-selection:nav --> :data:episode:api
+  :features:watchdate-selection:nav --> :navigation:api
   :i18n:api --> :i18n:generator
 
 classDef application fill:#CAFFBF,stroke:#000,stroke-width:2px,color:#000;

--- a/features/my-shows/ui/README.md
+++ b/features/my-shows/ui/README.md
@@ -173,6 +173,10 @@ graph TB
     :features:start-watching:presenter[presenter]:::multiplatform
     :features:start-watching:ui[ui]:::android-library
   end
+  subgraph :features:watchdate-selection
+    direction TB
+    :features:watchdate-selection:nav[nav]:::multiplatform
+  end
   subgraph :i18n
     direction TB
     :i18n:api[api]:::multiplatform
@@ -291,6 +295,7 @@ graph TB
   :features:continue-watching:presenter --> :features:rating-sheet:presenter
   :features:continue-watching:presenter -.-> :features:season-details:nav
   :features:continue-watching:presenter -.-> :features:show-details:nav
+  :features:continue-watching:presenter --> :features:watchdate-selection:nav
   :features:continue-watching:presenter --> :i18n:api
   :features:continue-watching:presenter --> :navigation:api
   :features:continue-watching:ui -.-> :android-designsystem
@@ -353,6 +358,8 @@ graph TB
   :features:start-watching:ui -.-> :core:view
   :features:start-watching:ui --> :features:start-watching:presenter
   :features:start-watching:ui -.-> :i18n:generator
+  :features:watchdate-selection:nav --> :data:episode:api
+  :features:watchdate-selection:nav --> :navigation:api
   :i18n:api --> :i18n:generator
   :navigation:ui --> :core:base
   :navigation:ui --> :navigation:api

--- a/features/progress/presenter/README.md
+++ b/features/progress/presenter/README.md
@@ -167,6 +167,10 @@ graph TB
     direction TB
     :features:upnext:presenter[presenter]:::multiplatform
   end
+  subgraph :features:watchdate-selection
+    direction TB
+    :features:watchdate-selection:nav[nav]:::multiplatform
+  end
   subgraph :i18n
     direction TB
     :i18n:api[api]:::multiplatform
@@ -314,7 +318,10 @@ graph TB
   :features:upnext:presenter --> :features:rating-sheet:presenter
   :features:upnext:presenter -.-> :features:season-details:nav
   :features:upnext:presenter -.-> :features:show-details:nav
+  :features:upnext:presenter --> :features:watchdate-selection:nav
   :features:upnext:presenter --> :navigation:api
+  :features:watchdate-selection:nav --> :data:episode:api
+  :features:watchdate-selection:nav --> :navigation:api
   :i18n:api --> :i18n:generator
 
 classDef application fill:#CAFFBF,stroke:#000,stroke-width:2px,color:#000;

--- a/features/progress/ui/README.md
+++ b/features/progress/ui/README.md
@@ -173,6 +173,10 @@ graph TB
     :features:upnext:presenter[presenter]:::multiplatform
     :features:upnext:ui[ui]:::android-library
   end
+  subgraph :features:watchdate-selection
+    direction TB
+    :features:watchdate-selection:nav[nav]:::multiplatform
+  end
   subgraph :i18n
     direction TB
     :i18n:api[api]:::multiplatform
@@ -344,6 +348,7 @@ graph TB
   :features:upnext:presenter --> :features:rating-sheet:presenter
   :features:upnext:presenter -.-> :features:season-details:nav
   :features:upnext:presenter -.-> :features:show-details:nav
+  :features:upnext:presenter --> :features:watchdate-selection:nav
   :features:upnext:presenter --> :navigation:api
   :features:upnext:ui -.-> :android-designsystem
   :features:upnext:ui -.-> :core:test-tags
@@ -351,6 +356,8 @@ graph TB
   :features:upnext:ui -.-> :domain:continue-watching
   :features:upnext:ui --> :features:upnext:presenter
   :features:upnext:ui -.-> :i18n:generator
+  :features:watchdate-selection:nav --> :data:episode:api
+  :features:watchdate-selection:nav --> :navigation:api
   :i18n:api --> :i18n:generator
   :navigation:ui --> :core:base
   :navigation:ui --> :navigation:api

--- a/features/season-details/presenter/README.md
+++ b/features/season-details/presenter/README.md
@@ -102,6 +102,10 @@ graph TB
     :features:season-details:nav[nav]:::multiplatform
     :features:season-details:presenter[presenter]:::multiplatform
   end
+  subgraph :features:watchdate-selection
+    direction TB
+    :features:watchdate-selection:nav[nav]:::multiplatform
+  end
   subgraph :i18n
     direction TB
     :i18n:generator[generator]:::multiplatform
@@ -173,7 +177,10 @@ graph TB
   :features:season-details:presenter -.-> :features:episode-sheet:nav
   :features:season-details:presenter --> :features:rating-sheet:nav
   :features:season-details:presenter --> :features:season-details:nav
+  :features:season-details:presenter --> :features:watchdate-selection:nav
   :features:season-details:presenter --> :navigation:api
+  :features:watchdate-selection:nav --> :data:episode:api
+  :features:watchdate-selection:nav --> :navigation:api
 
 classDef application fill:#CAFFBF,stroke:#000,stroke-width:2px,color:#000;
 classDef multiplatform fill:#FFD6A5,stroke:#000,stroke-width:2px,color:#000;

--- a/features/season-details/presenter/build.gradle.kts
+++ b/features/season-details/presenter/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
                 api(projects.domain.ratings)
                 api(projects.domain.seasondetails)
                 api(projects.features.ratingSheet.nav)
+                api(projects.features.watchdateSelection.nav)
                 api(projects.features.seasonDetails.nav)
                 api(projects.navigation.api)
 

--- a/features/season-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/SeasonDetailsAction.kt
+++ b/features/season-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/SeasonDetailsAction.kt
@@ -35,6 +35,12 @@ public data class MarkEpisodeUnwatched(
     val episodeId: Long,
 ) : SeasonDetailsAction
 
+public data class EpisodeWatchedLongPressed(
+    val episodeId: Long,
+    val seasonNumber: Long,
+    val episodeNumber: Long,
+) : SeasonDetailsAction
+
 public data class ToggleEpisodeWatched(
     val episodeId: Long,
 ) : SeasonDetailsAction

--- a/features/season-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/SeasonDetailsPresenter.kt
+++ b/features/season-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/SeasonDetailsPresenter.kt
@@ -30,6 +30,7 @@ import com.thomaskioko.tvmaniac.domain.seasondetails.ObserveSeasonWatchProgressP
 import com.thomaskioko.tvmaniac.domain.seasondetails.ObserveUnwatchedInPreviousSeasonsInteractor
 import com.thomaskioko.tvmaniac.domain.seasondetails.ObserveUnwatchedInPreviousSeasonsParams
 import com.thomaskioko.tvmaniac.domain.seasondetails.SeasonDetailsInteractor
+import com.thomaskioko.tvmaniac.episodes.api.WatchedDateTarget
 import com.thomaskioko.tvmaniac.espisodedetails.nav.model.EpisodeSheetParam
 import com.thomaskioko.tvmaniac.espisodedetails.nav.model.EpisodeSheetRoute
 import com.thomaskioko.tvmaniac.espisodedetails.nav.model.ScreenSource
@@ -39,6 +40,8 @@ import com.thomaskioko.tvmaniac.ratingsheet.nav.RatingSheetRoute
 import com.thomaskioko.tvmaniac.seasondetails.api.SeasonDetailsParam
 import com.thomaskioko.tvmaniac.seasondetails.nav.SeasonDetailsRoute
 import com.thomaskioko.tvmaniac.seasondetails.nav.SeasonDetailsUiParam
+import com.thomaskioko.tvmaniac.watchdateselection.nav.WatchDateSelectionParam
+import com.thomaskioko.tvmaniac.watchdateselection.nav.WatchDateSelectionRoute
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
@@ -164,6 +167,18 @@ public class SeasonDetailsPresenter internal constructor(
                 is MarkSeasonAsWatched -> handleMarkSeasonAsWatched(action.hasUnwatchedInPreviousSeasons)
                 MarkSeasonAsUnwatched -> handleMarkSeasonAsUnwatched()
                 is MarkEpisodeWatched -> handleMarkEpisodeWatched(action)
+                is EpisodeWatchedLongPressed -> navigator.navigateTo(
+                    WatchDateSelectionRoute(
+                        WatchDateSelectionParam(
+                            target = WatchedDateTarget.EPISODE,
+                            showId = param.showId,
+                            episodeId = action.episodeId,
+                            seasonNumber = action.seasonNumber,
+                            episodeNumber = action.episodeNumber,
+                            isEdit = true,
+                        ),
+                    ),
+                )
                 is MarkEpisodeUnwatched -> updateState {
                     copy(
                         dialogState = SeasonDialogState.UnwatchEpisodeConfirmation(
@@ -278,16 +293,46 @@ public class SeasonDetailsPresenter internal constructor(
     private suspend fun handleConfirmDialogAction() {
         val change = (state.value.dialogState as? SeasonDialogState.Confirmation)?.primaryChange ?: return
         updateState { copy(dialogState = SeasonDialogState.Hidden) }
-        execute(change)
+        execute(change, fromConfirmation = true)
     }
 
     private suspend fun handleSecondaryDialogAction() {
         val change = (state.value.dialogState as? SeasonDialogState.Confirmation)?.secondaryChange ?: return
         updateState { copy(dialogState = SeasonDialogState.Hidden) }
-        execute(change)
+        execute(change, fromConfirmation = true)
     }
 
-    private suspend fun execute(change: WatchChange) {
+    private fun watchDateRouteOrNull(change: WatchChange): WatchDateSelectionRoute? = when (change) {
+        is WatchChange.WatchEpisode -> WatchDateSelectionRoute(
+            WatchDateSelectionParam(
+                target = WatchedDateTarget.EPISODE,
+                showId = change.params.showId,
+                episodeId = change.params.episodeId,
+                seasonNumber = change.params.seasonNumber,
+                episodeNumber = change.params.episodeNumber,
+                markPrevious = change.params.markPreviousEpisodes,
+            ),
+        )
+        is WatchChange.WatchSeason -> WatchDateSelectionRoute(
+            WatchDateSelectionParam(
+                target = WatchedDateTarget.SEASON,
+                showId = change.showId,
+                seasonNumber = change.seasonNumber,
+                markPrevious = change.markPreviousSeasons,
+            ),
+        )
+        is WatchChange.UnwatchEpisode, is WatchChange.UnwatchSeason -> null
+    }
+
+    private suspend fun execute(change: WatchChange, fromConfirmation: Boolean = false) {
+        if (fromConfirmation) {
+            val route = watchDateRouteOrNull(change)
+            if (route != null) {
+                navigator.navigateTo(route)
+                return
+            }
+        }
+
         val trackedEpisodeId = when (change) {
             is WatchChange.WatchEpisode -> change.params.episodeId
             is WatchChange.UnwatchEpisode -> change.episodeId

--- a/features/season-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/SeasonPresenterTest.kt
+++ b/features/season-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/seasondetails/presenter/SeasonPresenterTest.kt
@@ -25,11 +25,11 @@ import com.thomaskioko.tvmaniac.domain.seasondetails.ObservableSeasonDetailsInte
 import com.thomaskioko.tvmaniac.domain.seasondetails.ObserveSeasonWatchProgressInteractor
 import com.thomaskioko.tvmaniac.domain.seasondetails.ObserveUnwatchedInPreviousSeasonsInteractor
 import com.thomaskioko.tvmaniac.domain.seasondetails.SeasonDetailsInteractor
+import com.thomaskioko.tvmaniac.episodes.api.WatchedDateTarget
 import com.thomaskioko.tvmaniac.episodes.api.model.SeasonWatchProgress
 import com.thomaskioko.tvmaniac.episodes.testing.FakeEpisodeRepository
 import com.thomaskioko.tvmaniac.episodes.testing.MarkEpisodeUnwatchedCall
 import com.thomaskioko.tvmaniac.episodes.testing.MarkEpisodeWatchedCall
-import com.thomaskioko.tvmaniac.episodes.testing.MarkSeasonWatchedCall
 import com.thomaskioko.tvmaniac.followedshows.api.PendingAction
 import com.thomaskioko.tvmaniac.navigation.testing.FakeNavigator
 import com.thomaskioko.tvmaniac.ratingsheet.nav.RatingSheetRoute
@@ -40,7 +40,9 @@ import com.thomaskioko.tvmaniac.seasondetails.presenter.data.buildSeasonDetailsW
 import com.thomaskioko.tvmaniac.seasondetails.presenter.model.EpisodeDetailsModel
 import com.thomaskioko.tvmaniac.seasondetails.testing.FakeSeasonDetailsRepository
 import com.thomaskioko.tvmaniac.subscription.testing.FakeSubscriptionManager
+import com.thomaskioko.tvmaniac.watchdateselection.nav.WatchDateSelectionRoute
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -462,6 +464,31 @@ class SeasonPresenterTest {
     }
 
     @Test
+    fun `should open the watch date sheet given the check button is long pressed`() = runTest {
+        seasonDetailsRepository.setSeasonsResult(buildSeasonDetailsWithEpisodes())
+        castRepository.setSeasonCast(emptyList())
+
+        presenter.state.test {
+            awaitItem() shouldBe SeasonDetailsModel.Empty
+
+            presenter.dispatch(
+                EpisodeWatchedLongPressed(episodeId = 12345, seasonNumber = 1, episodeNumber = 1),
+            )
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val route = navigator.lastActivatedOverlay.shouldBeInstanceOf<WatchDateSelectionRoute>()
+            route.param.target shouldBe WatchedDateTarget.EPISODE
+            route.param.showId shouldBe 1
+            route.param.episodeId shouldBe 12345
+            route.param.seasonNumber shouldBe 1
+            route.param.episodeNumber shouldBe 1
+            episodeRepository.lastMarkEpisodeWatchedCall.shouldBeNull()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `should not open the rating sheet given previous episodes are marked watched too`() = runTest {
         datastoreRepository.saveQuickRateEnabled(true)
         seasonDetailsRepository.setSeasonsResult(buildSeasonDetailsWithEpisodes())
@@ -484,8 +511,8 @@ class SeasonPresenterTest {
             presenter.dispatch(ConfirmDialogAction)
             testDispatcher.scheduler.advanceUntilIdle()
 
-            episodeRepository.lastMarkEpisodeWatchedCall?.markPreviousEpisodes shouldBe true
-            navigator.activatedOverlays.shouldBeEmpty()
+            navigator.lastActivatedOverlay.shouldBeInstanceOf<WatchDateSelectionRoute>()
+            navigator.activatedOverlays.none { it is RatingSheetRoute } shouldBe true
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -506,8 +533,8 @@ class SeasonPresenterTest {
             presenter.dispatch(ConfirmDialogAction)
             testDispatcher.scheduler.advanceUntilIdle()
 
-            episodeRepository.lastMarkSeasonWatchedCall.shouldNotBeNull()
-            navigator.activatedOverlays.shouldBeEmpty()
+            navigator.lastActivatedOverlay.shouldBeInstanceOf<WatchDateSelectionRoute>()
+            navigator.activatedOverlays.none { it is RatingSheetRoute } shouldBe true
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -539,121 +566,6 @@ class SeasonPresenterTest {
                 episodeId = 12345,
                 seasonNumber = 1,
                 episodeNumber = 1,
-                markPreviousEpisodes = false,
-            )
-        }
-    }
-
-    @Test
-    fun `should show unwatch confirmation dialog when MarkEpisodeUnwatched is dispatched`() = runTest {
-        val initialDetails = buildSeasonDetailsWithEpisodes()
-        seasonDetailsRepository.setSeasonsResult(initialDetails)
-        castRepository.setSeasonCast(emptyList())
-
-        presenter.state.test {
-            awaitItem() shouldBe SeasonDetailsModel.Empty
-
-            presenter.dispatch(MarkEpisodeUnwatched(episodeId = 12345))
-
-            val state = awaitItem()
-            val dialog = state.dialogState
-            dialog.shouldBeInstanceOf<SeasonDialogState.UnwatchEpisodeConfirmation>()
-            dialog.primaryChange.episodeId shouldBe 12345
-        }
-    }
-
-    @Test
-    fun `should mark season as unwatched when ConfirmDialogAction is dispatched from season watch state dialog`() = runTest {
-        val initialDetails = buildSeasonDetailsWithEpisodes()
-        seasonDetailsRepository.setSeasonsResult(initialDetails)
-        castRepository.setSeasonCast(emptyList())
-        episodeRepository.setSeasonWatchProgress(
-            SeasonWatchProgress(
-                showId = 1L,
-                seasonNumber = 1L,
-                watchedCount = 10,
-                totalCount = 10,
-            ),
-        )
-
-        presenter.state.test {
-            awaitItem() shouldBe SeasonDetailsModel.Empty
-            awaitItem()
-
-            presenter.dispatch(MarkSeasonAsUnwatched)
-            awaitItem()
-
-            presenter.dispatch(ConfirmDialogAction)
-
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            val state = awaitItem()
-            state.dialogState.shouldBeInstanceOf<SeasonDialogState.Hidden>()
-        }
-    }
-
-    @Test
-    fun `should show mark previous episodes dialog when marking episode with unwatched prior episodes`() = runTest {
-        val initialDetails = buildSeasonDetailsWithEpisodes()
-        seasonDetailsRepository.setSeasonsResult(initialDetails)
-        castRepository.setSeasonCast(emptyList())
-
-        presenter.state.test {
-            awaitItem() shouldBe SeasonDetailsModel.Empty
-
-            presenter.dispatch(
-                MarkEpisodeWatched(
-                    episodeId = 12345,
-                    seasonNumber = 1,
-                    episodeNumber = 5,
-                    hasPreviousUnwatched = true,
-                ),
-            )
-
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            val state = awaitItem()
-            state.dialogState.shouldBeInstanceOf<SeasonDialogState.MarkPreviousEpisodesConfirmation>()
-        }
-    }
-
-    @Test
-    fun `should mark episode with previous when ConfirmDialogAction is dispatched from mark previous episodes dialog`() = runTest {
-        val initialDetails = buildSeasonDetailsWithEpisodes()
-        seasonDetailsRepository.setSeasonsResult(initialDetails)
-        castRepository.setSeasonCast(emptyList())
-
-        presenter.state.test {
-            awaitItem() shouldBe SeasonDetailsModel.Empty
-
-            presenter.dispatch(
-                MarkEpisodeWatched(
-                    episodeId = 12345,
-                    seasonNumber = 1,
-                    episodeNumber = 5,
-                    hasPreviousUnwatched = true,
-                ),
-            )
-
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            val dialogState = awaitItem()
-            dialogState.dialogState.shouldBeInstanceOf<SeasonDialogState.MarkPreviousEpisodesConfirmation>()
-
-            presenter.dispatch(ConfirmDialogAction)
-
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            val finalState = expectMostRecentItem()
-            finalState.dialogState.shouldBeInstanceOf<SeasonDialogState.Hidden>()
-            finalState.updatingEpisodeIds.shouldBeEmpty()
-
-            episodeRepository.lastMarkEpisodeWatchedCall shouldBe MarkEpisodeWatchedCall(
-                showId = 1,
-                episodeId = 12345,
-                seasonNumber = 1,
-                episodeNumber = 5,
-                markPreviousEpisodes = true,
             )
         }
     }
@@ -722,13 +634,14 @@ class SeasonPresenterTest {
             finalState.dialogState.shouldBeInstanceOf<SeasonDialogState.Hidden>()
             finalState.updatingEpisodeIds.shouldBeEmpty()
 
-            episodeRepository.lastMarkEpisodeWatchedCall shouldBe MarkEpisodeWatchedCall(
-                showId = 1,
-                episodeId = 12345,
-                seasonNumber = 1,
-                episodeNumber = 5,
-                markPreviousEpisodes = false,
-            )
+            val route = navigator.lastActivatedOverlay.shouldBeInstanceOf<WatchDateSelectionRoute>()
+            route.param.target shouldBe WatchedDateTarget.EPISODE
+            route.param.showId shouldBe 1
+            route.param.episodeId shouldBe 12345
+            route.param.seasonNumber shouldBe 1
+            route.param.episodeNumber shouldBe 5
+            route.param.markPrevious shouldBe false
+            episodeRepository.lastMarkEpisodeWatchedCall.shouldBeNull()
         }
     }
 
@@ -809,11 +722,12 @@ class SeasonPresenterTest {
             val finalState = awaitItem()
             finalState.dialogState.shouldBeInstanceOf<SeasonDialogState.Hidden>()
 
-            episodeRepository.lastMarkSeasonWatchedCall shouldBe MarkSeasonWatchedCall(
-                showId = 1,
-                seasonNumber = 1,
-                markPreviousSeasons = true,
-            )
+            val route = navigator.lastActivatedOverlay.shouldBeInstanceOf<WatchDateSelectionRoute>()
+            route.param.target shouldBe WatchedDateTarget.SEASON
+            route.param.showId shouldBe 1
+            route.param.seasonNumber shouldBe 1
+            route.param.markPrevious shouldBe true
+            episodeRepository.lastMarkSeasonWatchedCall.shouldBeNull()
         }
     }
 
@@ -842,11 +756,12 @@ class SeasonPresenterTest {
             val finalState = awaitItem()
             finalState.dialogState.shouldBeInstanceOf<SeasonDialogState.Hidden>()
 
-            episodeRepository.lastMarkSeasonWatchedCall shouldBe MarkSeasonWatchedCall(
-                showId = 1,
-                seasonNumber = 1,
-                markPreviousSeasons = false,
-            )
+            val route = navigator.lastActivatedOverlay.shouldBeInstanceOf<WatchDateSelectionRoute>()
+            route.param.target shouldBe WatchedDateTarget.SEASON
+            route.param.showId shouldBe 1
+            route.param.seasonNumber shouldBe 1
+            route.param.markPrevious shouldBe false
+            episodeRepository.lastMarkSeasonWatchedCall.shouldBeNull()
         }
     }
 
@@ -940,11 +855,12 @@ class SeasonPresenterTest {
 
             cancelAndIgnoreRemainingEvents()
 
-            episodeRepository.lastMarkSeasonWatchedCall shouldBe MarkSeasonWatchedCall(
-                showId = 1,
-                seasonNumber = 1,
-                markPreviousSeasons = false,
-            )
+            val route = navigator.lastActivatedOverlay.shouldBeInstanceOf<WatchDateSelectionRoute>()
+            route.param.target shouldBe WatchedDateTarget.SEASON
+            route.param.showId shouldBe 1
+            route.param.seasonNumber shouldBe 1
+            route.param.markPrevious shouldBe false
+            episodeRepository.lastMarkSeasonWatchedCall.shouldBeNull()
         }
     }
 
@@ -1236,7 +1152,6 @@ class SeasonPresenterTest {
                 episodeId = 12345,
                 seasonNumber = 1,
                 episodeNumber = 1,
-                markPreviousEpisodes = false,
             )
         }
     }
@@ -1290,11 +1205,12 @@ class SeasonPresenterTest {
 
             cancelAndIgnoreRemainingEvents()
 
-            episodeRepository.lastMarkSeasonWatchedCall shouldBe MarkSeasonWatchedCall(
-                showId = 1,
-                seasonNumber = 1,
-                markPreviousSeasons = false,
-            )
+            val route = navigator.lastActivatedOverlay.shouldBeInstanceOf<WatchDateSelectionRoute>()
+            route.param.target shouldBe WatchedDateTarget.SEASON
+            route.param.showId shouldBe 1
+            route.param.seasonNumber shouldBe 1
+            route.param.markPrevious shouldBe false
+            episodeRepository.lastMarkSeasonWatchedCall.shouldBeNull()
         }
     }
 

--- a/features/season-details/ui/README.md
+++ b/features/season-details/ui/README.md
@@ -106,6 +106,10 @@ graph TB
     :features:season-details:presenter[presenter]:::multiplatform
     :features:season-details:ui[ui]:::android-library
   end
+  subgraph :features:watchdate-selection
+    direction TB
+    :features:watchdate-selection:nav[nav]:::multiplatform
+  end
   subgraph :i18n
     direction TB
     :i18n:generator[generator]:::multiplatform
@@ -182,6 +186,7 @@ graph TB
   :features:season-details:presenter -.-> :features:episode-sheet:nav
   :features:season-details:presenter --> :features:rating-sheet:nav
   :features:season-details:presenter --> :features:season-details:nav
+  :features:season-details:presenter --> :features:watchdate-selection:nav
   :features:season-details:presenter --> :navigation:api
   :features:season-details:ui -.-> :android-designsystem
   :features:season-details:ui --> :core:base
@@ -191,6 +196,8 @@ graph TB
   :features:season-details:ui -.-> :i18n:generator
   :features:season-details:ui --> :navigation:api
   :features:season-details:ui --> :navigation:ui
+  :features:watchdate-selection:nav --> :data:episode:api
+  :features:watchdate-selection:nav --> :navigation:api
   :navigation:ui --> :core:base
   :navigation:ui --> :navigation:api
 

--- a/features/show-details/presenter/README.md
+++ b/features/show-details/presenter/README.md
@@ -151,6 +151,10 @@ graph TB
     direction TB
     :features:trailers:nav[nav]:::multiplatform
   end
+  subgraph :features:watchdate-selection
+    direction TB
+    :features:watchdate-selection:nav[nav]:::multiplatform
+  end
   subgraph :i18n
     direction TB
     :i18n:api[api]:::multiplatform
@@ -282,10 +286,13 @@ graph TB
   :features:show-details:presenter --> :features:show-details:nav
   :features:show-details:presenter --> :features:show-list:nav
   :features:show-details:presenter -.-> :features:trailers:nav
+  :features:show-details:presenter --> :features:watchdate-selection:nav
   :features:show-details:presenter --> :i18n:api
   :features:show-details:presenter --> :navigation:api
   :features:show-list:nav --> :navigation:api
   :features:trailers:nav --> :navigation:api
+  :features:watchdate-selection:nav --> :data:episode:api
+  :features:watchdate-selection:nav --> :navigation:api
   :i18n:api --> :i18n:generator
 
 classDef application fill:#CAFFBF,stroke:#000,stroke-width:2px,color:#000;

--- a/features/show-details/presenter/build.gradle.kts
+++ b/features/show-details/presenter/build.gradle.kts
@@ -38,6 +38,7 @@ kotlin {
                 api(projects.domain.similarshows)
                 api(projects.domain.traktlists)
                 api(projects.features.ratingSheet.nav)
+                api(projects.features.watchdateSelection.nav)
                 api(projects.features.ratingSheet.presenter)
                 api(projects.features.showDetails.nav)
                 api(projects.features.showList.nav)

--- a/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/seasonsepisodes/ShowDetailsSeasonsEpisodesAction.kt
+++ b/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/seasonsepisodes/ShowDetailsSeasonsEpisodesAction.kt
@@ -13,6 +13,13 @@ public data class ShowDetailsMarkEpisodeWatched(
     val episodeNumber: Long,
 ) : ShowDetailsSeasonsEpisodesAction
 
+public data class ShowDetailsEpisodeWatchedLongPressed(
+    val showId: Long,
+    val episodeId: Long,
+    val seasonNumber: Long,
+    val episodeNumber: Long,
+) : ShowDetailsSeasonsEpisodesAction
+
 public data class ShowDetailsMarkEpisodeUnwatched(
     val showId: Long,
     val episodeId: Long,

--- a/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/seasonsepisodes/ShowDetailsSeasonsEpisodesPresenter.kt
+++ b/features/show-details/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/seasonsepisodes/ShowDetailsSeasonsEpisodesPresenter.kt
@@ -24,6 +24,7 @@ import com.thomaskioko.tvmaniac.domain.ratings.ShouldPromptForRatingInteractor
 import com.thomaskioko.tvmaniac.domain.showdetails.FetchSeasonsEpisodesInteractor
 import com.thomaskioko.tvmaniac.domain.showdetails.ObserveContinueTrackingInteractor
 import com.thomaskioko.tvmaniac.domain.showdetails.ObserveSeasonsInteractor
+import com.thomaskioko.tvmaniac.episodes.api.WatchedDateTarget
 import com.thomaskioko.tvmaniac.navigation.Navigator
 import com.thomaskioko.tvmaniac.presenter.showdetails.toContinueTrackingModels
 import com.thomaskioko.tvmaniac.presenter.showdetails.toScrollIndex
@@ -33,6 +34,8 @@ import com.thomaskioko.tvmaniac.seasondetails.nav.SeasonDetailsRoute
 import com.thomaskioko.tvmaniac.seasondetails.nav.SeasonDetailsUiParam
 import com.thomaskioko.tvmaniac.showdetails.nav.ShowDetailsRoute
 import com.thomaskioko.tvmaniac.showdetails.nav.scope.ShowDetailsChildScope
+import com.thomaskioko.tvmaniac.watchdateselection.nav.WatchDateSelectionParam
+import com.thomaskioko.tvmaniac.watchdateselection.nav.WatchDateSelectionRoute
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
@@ -160,6 +163,19 @@ public class ShowDetailsSeasonsEpisodesPresenter internal constructor(
                     )
                 }
             }
+
+            is ShowDetailsEpisodeWatchedLongPressed -> navigator.navigateTo(
+                WatchDateSelectionRoute(
+                    WatchDateSelectionParam(
+                        target = WatchedDateTarget.EPISODE,
+                        showId = action.showId,
+                        episodeId = action.episodeId,
+                        seasonNumber = action.seasonNumber,
+                        episodeNumber = action.episodeNumber,
+                        isEdit = true,
+                    ),
+                ),
+            )
 
             is ShowDetailsMarkEpisodeUnwatched -> coroutineScope.launchUpdating(
                 id = action.episodeId,

--- a/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/seasonsepisodes/ShowDetailsSeasonsEpisodesPresenterTest.kt
+++ b/features/show-details/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/showdetails/seasonsepisodes/ShowDetailsSeasonsEpisodesPresenterTest.kt
@@ -37,6 +37,7 @@ import com.thomaskioko.tvmaniac.seasondetails.testing.FakeSeasonDetailsRepositor
 import com.thomaskioko.tvmaniac.seasons.testing.FakeSeasonsRepository
 import com.thomaskioko.tvmaniac.showdetails.nav.model.ShowSeasonDetailsParam
 import com.thomaskioko.tvmaniac.subscription.testing.FakeSubscriptionManager
+import com.thomaskioko.tvmaniac.watchdateselection.nav.WatchDateSelectionRoute
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -222,6 +223,33 @@ internal class ShowDetailsSeasonsEpisodesPresenterTest {
 
             testDispatcher.scheduler.advanceUntilIdle()
             expectMostRecentItem().updatingEpisodeIds.shouldBeEmpty()
+        }
+    }
+
+    @Test
+    fun `should open the watch date sheet given the check button is long pressed`() = runTest {
+        seasonDetailsRepository.setContinueTrackingResult(testContinueTrackingResult)
+        val presenter = buildPresenter()
+
+        presenter.state.test {
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            presenter.dispatch(
+                ShowDetailsEpisodeWatchedLongPressed(
+                    showId = SHOW_ID,
+                    episodeId = 1001L,
+                    seasonNumber = 1L,
+                    episodeNumber = 1L,
+                ),
+            )
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val route = navigator.lastActivatedOverlay.shouldBeInstanceOf<WatchDateSelectionRoute>()
+            route.param.showId shouldBe SHOW_ID
+            route.param.episodeId shouldBe 1001L
+            route.param.seasonNumber shouldBe 1L
+            route.param.episodeNumber shouldBe 1L
+            cancelAndIgnoreRemainingEvents()
         }
     }
 

--- a/features/show-details/ui/README.md
+++ b/features/show-details/ui/README.md
@@ -154,6 +154,10 @@ graph TB
     direction TB
     :features:trailers:nav[nav]:::multiplatform
   end
+  subgraph :features:watchdate-selection
+    direction TB
+    :features:watchdate-selection:nav[nav]:::multiplatform
+  end
   subgraph :i18n
     direction TB
     :i18n:api[api]:::multiplatform
@@ -289,6 +293,7 @@ graph TB
   :features:show-details:presenter --> :features:show-details:nav
   :features:show-details:presenter --> :features:show-list:nav
   :features:show-details:presenter -.-> :features:trailers:nav
+  :features:show-details:presenter --> :features:watchdate-selection:nav
   :features:show-details:presenter --> :i18n:api
   :features:show-details:presenter --> :navigation:api
   :features:show-details:ui -.-> :android-designsystem
@@ -302,6 +307,8 @@ graph TB
   :features:show-details:ui --> :navigation:ui
   :features:show-list:nav --> :navigation:api
   :features:trailers:nav --> :navigation:api
+  :features:watchdate-selection:nav --> :data:episode:api
+  :features:watchdate-selection:nav --> :navigation:api
   :i18n:api --> :i18n:generator
   :navigation:ui --> :core:base
   :navigation:ui --> :navigation:api

--- a/features/upnext/presenter/README.md
+++ b/features/upnext/presenter/README.md
@@ -153,6 +153,10 @@ graph TB
     direction TB
     :features:upnext:presenter[presenter]:::multiplatform
   end
+  subgraph :features:watchdate-selection
+    direction TB
+    :features:watchdate-selection:nav[nav]:::multiplatform
+  end
   subgraph :i18n
     direction TB
     :i18n:api[api]:::multiplatform
@@ -275,7 +279,10 @@ graph TB
   :features:upnext:presenter --> :features:rating-sheet:presenter
   :features:upnext:presenter -.-> :features:season-details:nav
   :features:upnext:presenter -.-> :features:show-details:nav
+  :features:upnext:presenter --> :features:watchdate-selection:nav
   :features:upnext:presenter --> :navigation:api
+  :features:watchdate-selection:nav --> :data:episode:api
+  :features:watchdate-selection:nav --> :navigation:api
   :i18n:api --> :i18n:generator
 
 classDef application fill:#CAFFBF,stroke:#000,stroke-width:2px,color:#000;

--- a/features/upnext/presenter/build.gradle.kts
+++ b/features/upnext/presenter/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
                 api(projects.domain.episode)
                 api(projects.domain.ratings)
                 api(projects.features.ratingSheet.nav)
+                api(projects.features.watchdateSelection.nav)
                 api(projects.features.ratingSheet.presenter)
                 api(projects.domain.followedshows)
                 api(projects.domain.continueWatching)

--- a/features/upnext/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextAction.kt
+++ b/features/upnext/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextAction.kt
@@ -30,3 +30,10 @@ public data class OpenSeason(
 public data class UnfollowShow(val showId: Long) : UpNextAction
 
 public data class UpNextEpisodeLongPressed(val episodeId: Long) : UpNextAction
+
+public data class MarkWatchedLongPressed(
+    val showId: Long,
+    val episodeId: Long,
+    val seasonNumber: Long,
+    val episodeNumber: Long,
+) : UpNextAction

--- a/features/upnext/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextPresenter.kt
+++ b/features/upnext/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextPresenter.kt
@@ -19,6 +19,7 @@ import com.thomaskioko.tvmaniac.domain.episode.MarkEpisodeWatchedInteractor
 import com.thomaskioko.tvmaniac.domain.episode.MarkEpisodeWatchedParams
 import com.thomaskioko.tvmaniac.domain.followedshows.UnfollowShowInteractor
 import com.thomaskioko.tvmaniac.domain.ratings.ShouldPromptForRatingInteractor
+import com.thomaskioko.tvmaniac.episodes.api.WatchedDateTarget
 import com.thomaskioko.tvmaniac.espisodedetails.nav.model.EpisodeSheetParam
 import com.thomaskioko.tvmaniac.espisodedetails.nav.model.EpisodeSheetRoute
 import com.thomaskioko.tvmaniac.espisodedetails.nav.model.ScreenSource
@@ -34,6 +35,8 @@ import com.thomaskioko.tvmaniac.showdetails.nav.model.ShowDetailsParam
 import com.thomaskioko.tvmaniac.syncstate.api.SyncObserver
 import com.thomaskioko.tvmaniac.upnext.api.UpNextRepository
 import com.thomaskioko.tvmaniac.upnext.api.model.UpNextEpisode
+import com.thomaskioko.tvmaniac.watchdateselection.nav.WatchDateSelectionParam
+import com.thomaskioko.tvmaniac.watchdateselection.nav.WatchDateSelectionRoute
 import dev.zacsweers.metro.Inject
 import io.github.thomaskioko.codegen.annotations.ChildPresenter
 import kotlinx.collections.immutable.persistentSetOf
@@ -108,6 +111,18 @@ public class UpNextPresenter internal constructor(
         when (action) {
             is UpNextShowClicked -> navigateToSeasonFromEpisode(action.showId)
             is MarkWatched -> markEpisodeWatched(action)
+            is MarkWatchedLongPressed -> navigator.navigateTo(
+                WatchDateSelectionRoute(
+                    WatchDateSelectionParam(
+                        target = WatchedDateTarget.EPISODE,
+                        showId = action.showId,
+                        episodeId = action.episodeId,
+                        seasonNumber = action.seasonNumber,
+                        episodeNumber = action.episodeNumber,
+                        isEdit = true,
+                    ),
+                ),
+            )
             is UpNextChangeSortOption -> changeSortOption(action.sortOption)
             is RefreshUpNext -> refreshUpNext(isUserInitiated = true)
             is UpNextMessageShown -> clearMessage(action.id)

--- a/features/upnext/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextPresenterTest.kt
+++ b/features/upnext/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presentation/upnext/UpNextPresenterTest.kt
@@ -42,9 +42,11 @@ import com.thomaskioko.tvmaniac.syncstate.testing.FakeSyncObserver
 import com.thomaskioko.tvmaniac.upnext.api.model.NextEpisodeWithShow
 import com.thomaskioko.tvmaniac.upnext.testing.FakeUpNextRepository
 import com.thomaskioko.tvmaniac.util.testing.FakeDateTimeProvider
+import com.thomaskioko.tvmaniac.watchdateselection.nav.WatchDateSelectionRoute
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -263,6 +265,23 @@ internal class UpNextPresenterTest {
 
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun `should open the watch date sheet given the check button is long pressed`() = runTest {
+        val presenter = createPresenter()
+
+        presenter.dispatch(
+            MarkWatchedLongPressed(showId = 123L, episodeId = 456L, seasonNumber = 1L, episodeNumber = 5L),
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val route = navigator.lastActivatedOverlay.shouldBeInstanceOf<WatchDateSelectionRoute>()
+        route.param.showId shouldBe 123L
+        route.param.episodeId shouldBe 456L
+        route.param.seasonNumber shouldBe 1L
+        route.param.episodeNumber shouldBe 5L
+        episodeRepository.lastMarkEpisodeWatchedCall.shouldBeNull()
     }
 
     @Test

--- a/features/upnext/ui/README.md
+++ b/features/upnext/ui/README.md
@@ -157,6 +157,10 @@ graph TB
     :features:upnext:presenter[presenter]:::multiplatform
     :features:upnext:ui[ui]:::android-library
   end
+  subgraph :features:watchdate-selection
+    direction TB
+    :features:watchdate-selection:nav[nav]:::multiplatform
+  end
   subgraph :i18n
     direction TB
     :i18n:api[api]:::multiplatform
@@ -283,6 +287,7 @@ graph TB
   :features:upnext:presenter --> :features:rating-sheet:presenter
   :features:upnext:presenter -.-> :features:season-details:nav
   :features:upnext:presenter -.-> :features:show-details:nav
+  :features:upnext:presenter --> :features:watchdate-selection:nav
   :features:upnext:presenter --> :navigation:api
   :features:upnext:ui -.-> :android-designsystem
   :features:upnext:ui -.-> :core:test-tags
@@ -290,6 +295,8 @@ graph TB
   :features:upnext:ui -.-> :domain:continue-watching
   :features:upnext:ui --> :features:upnext:presenter
   :features:upnext:ui -.-> :i18n:generator
+  :features:watchdate-selection:nav --> :data:episode:api
+  :features:watchdate-selection:nav --> :navigation:api
   :i18n:api --> :i18n:generator
 
 classDef application fill:#CAFFBF,stroke:#000,stroke-width:2px,color:#000;

--- a/features/watchdate-selection/presenter/README.md
+++ b/features/watchdate-selection/presenter/README.md
@@ -151,6 +151,7 @@ graph TB
   :features:watchdate-selection:presenter --> :data:ratings:api
   :features:watchdate-selection:presenter --> :domain:episode
   :features:watchdate-selection:presenter --> :domain:ratings
+  :features:watchdate-selection:presenter --> :domain:rewatch
   :features:watchdate-selection:presenter --> :features:rating-sheet:nav
   :features:watchdate-selection:presenter --> :features:watchdate-selection:nav
   :features:watchdate-selection:presenter --> :i18n:api

--- a/features/watchdate-selection/presenter/build.gradle.kts
+++ b/features/watchdate-selection/presenter/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
                 api(projects.data.ratings.api)
                 api(projects.domain.episode)
                 api(projects.domain.ratings)
+                api(projects.domain.rewatch)
                 api(projects.features.ratingSheet.nav)
                 api(projects.features.watchdateSelection.nav)
                 api(projects.i18n.api)

--- a/features/watchdate-selection/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/watchdateselection/presenter/WatchDateSelectionPresenter.kt
+++ b/features/watchdate-selection/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/watchdateselection/presenter/WatchDateSelectionPresenter.kt
@@ -17,6 +17,7 @@ import com.thomaskioko.tvmaniac.domain.episode.MarkWatchedAtInteractor
 import com.thomaskioko.tvmaniac.domain.episode.MarkWatchedAtParams
 import com.thomaskioko.tvmaniac.domain.episode.ObserveEpisodeByIdInteractor
 import com.thomaskioko.tvmaniac.domain.ratings.ShouldPromptForRatingInteractor
+import com.thomaskioko.tvmaniac.domain.rewatch.ObserveEpisodeRewatchesInteractor
 import com.thomaskioko.tvmaniac.episodes.api.WatchedDate
 import com.thomaskioko.tvmaniac.episodes.api.WatchedDateTarget
 import com.thomaskioko.tvmaniac.i18n.StringResourceKey
@@ -34,7 +35,7 @@ import io.github.thomaskioko.codegen.annotations.DestinationKind
 import io.github.thomaskioko.codegen.annotations.NavDestination
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
@@ -53,6 +54,7 @@ public class WatchDateSelectionPresenter internal constructor(
     @Assisted private val param: WatchDateSelectionParam,
     componentContext: ComponentContext,
     observeEpisodeByIdInteractor: ObserveEpisodeByIdInteractor,
+    observeEpisodeRewatchesInteractor: ObserveEpisodeRewatchesInteractor,
     private val markWatchedAtInteractor: MarkWatchedAtInteractor,
     private val shouldPromptForRatingInteractor: ShouldPromptForRatingInteractor,
     private val dateTimeProvider: DateTimeProvider,
@@ -70,27 +72,29 @@ public class WatchDateSelectionPresenter internal constructor(
     private val episode: StateFlow<EpisodeById?> = observeEpisodeByIdInteractor.flow
         .stateIn(scope = coroutineScope, started = SharingStarted.Eagerly, initialValue = null)
 
-    private val title = localizer.getString(
-        if (param.isEdit) StringResourceKey.LabelWatchedDateEditTitle else StringResourceKey.LabelWatchedDateTitle,
-    )
+    private val rewatchCount: StateFlow<Long> = observeEpisodeRewatchesInteractor.flow
+        .stateIn(scope = coroutineScope, started = SharingStarted.Eagerly, initialValue = 0L)
+
+    private val sheetTitle = localizer.getString(StringResourceKey.LabelWatchedDateTitle)
+    private val editTitle = localizer.getString(StringResourceKey.LabelWatchedDateEditTitle)
     private val justNowLabel = localizer.getString(StringResourceKey.LabelWatchedDateJustNow)
     private val releaseDateLabel = localizer.getString(StringResourceKey.LabelWatchedDateReleaseDate)
     private val otherDateLabel = localizer.getString(StringResourceKey.LabelWatchedDateOther)
     private val unknownDateLabel = localizer.getString(StringResourceKey.LabelWatchedDateUnknown)
     private val unknownDateDisplayLabel = localizer.getString(StringResourceKey.LabelWatchedDateUnknownDisplay)
 
-    public val state: StateFlow<WatchDateSelectionState> = episode
-        .map { buildState(it) }
+    public val state: StateFlow<WatchDateSelectionState> = combine(episode, rewatchCount, ::buildState)
         .stateIn(
             scope = coroutineScope,
             started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = buildState(episode = null),
+            initialValue = buildState(episode = null, rewatchCount = 0L),
         )
 
     public val stateValue: Value<WatchDateSelectionState> = state.asValue(coroutineScope)
 
     init {
         observeEpisodeByIdInteractor(param.episodeId)
+        observeEpisodeRewatchesInteractor(param.episodeId)
     }
 
     public fun dispatch(action: WatchDateSelectionAction) {
@@ -103,14 +107,14 @@ public class WatchDateSelectionPresenter internal constructor(
         }
     }
 
-    private fun buildState(episode: EpisodeById?): WatchDateSelectionState = WatchDateSelectionState(
-        title = title,
+    private fun buildState(episode: EpisodeById?, rewatchCount: Long): WatchDateSelectionState = WatchDateSelectionState(
+        title = if (isEditing(episode, rewatchCount)) editTitle else sheetTitle,
         justNowLabel = justNowLabel,
         releaseDateLabel = releaseDateLabel,
         otherDateLabel = otherDateLabel,
         unknownDateLabel = unknownDateLabel,
         isReleaseDateEnabled = isReleaseDateEnabled(episode),
-        currentWatchedAtLabel = currentWatchedAtLabel(episode),
+        currentWatchedAtLabel = currentWatchedAtLabel(episode, rewatchCount),
         maxSelectableDate = today(),
     )
 
@@ -119,8 +123,13 @@ public class WatchDateSelectionPresenter internal constructor(
         WatchedDateTarget.SEASON, WatchedDateTarget.SHOW -> true
     }
 
-    private fun currentWatchedAtLabel(episode: EpisodeById?): String? {
-        if (!param.isEdit) return null
+    private fun isEditing(episode: EpisodeById?, rewatchCount: Long): Boolean = when (param.target) {
+        WatchedDateTarget.EPISODE -> param.isEdit && episode != null && episode.is_watched != 0L && rewatchCount == 0L
+        WatchedDateTarget.SEASON, WatchedDateTarget.SHOW -> param.isEdit
+    }
+
+    private fun currentWatchedAtLabel(episode: EpisodeById?, rewatchCount: Long): String? {
+        if (!isEditing(episode, rewatchCount)) return null
         val watchedAt = episode?.watched_at ?: return null
         return if (WatchedDate.isUnknown(watchedAt)) {
             unknownDateDisplayLabel
@@ -159,7 +168,7 @@ public class WatchDateSelectionPresenter internal constructor(
         seasonNumber = param.seasonNumber,
         episodeNumber = param.episodeNumber,
         markPrevious = param.markPrevious,
-        isEdit = param.isEdit,
+        isEdit = isEditing(episode.value, rewatchCount.value),
         watchedAt = watchedAt,
         useReleaseDate = useReleaseDate,
     )

--- a/features/watchdate-selection/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/watchdateselection/presenter/WatchDateSelectionPresenterTest.kt
+++ b/features/watchdate-selection/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/watchdateselection/presenter/WatchDateSelectionPresenterTest.kt
@@ -14,6 +14,7 @@ import com.thomaskioko.tvmaniac.db.Id
 import com.thomaskioko.tvmaniac.domain.episode.MarkWatchedAtInteractor
 import com.thomaskioko.tvmaniac.domain.episode.ObserveEpisodeByIdInteractor
 import com.thomaskioko.tvmaniac.domain.ratings.ShouldPromptForRatingInteractor
+import com.thomaskioko.tvmaniac.domain.rewatch.ObserveEpisodeRewatchesInteractor
 import com.thomaskioko.tvmaniac.domain.rewatch.WatchAgainInteractor
 import com.thomaskioko.tvmaniac.episodes.api.WatchedDate
 import com.thomaskioko.tvmaniac.episodes.api.WatchedDateTarget
@@ -263,6 +264,43 @@ internal class WatchDateSelectionPresenterTest {
     }
 
     @Test
+    fun `should treat a singly watched episode as a correction`() = runTest {
+        dateTimeProvider.setEpochToDisplayDateTimeResult("12 Jan 2026 20:30")
+        episodeRepository.setEpisodeById(testEpisode(isWatched = true, watchedAt = AIR_DATE_MILLIS))
+        rewatchRepository.setRewatchesForEpisode(EPISODE_ID, 0L)
+
+        val presenter = createPresenter(param = episodeParam(isEdit = true))
+        settle(presenter)
+
+        presenter.state.value.title shouldBe localizer.getString(StringResourceKey.LabelWatchedDateEditTitle)
+        presenter.state.value.currentWatchedAtLabel shouldBe "12 Jan 2026 20:30"
+
+        presenter.dispatch(WatchDateSelectionAction.JustNowSelected)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        episodeRepository.lastMarkEpisodeWatchedCall?.watchedAt shouldBe NOW_MILLIS
+        rewatchRepository.lastAddEpisodeWatchedAt.shouldBeNull()
+    }
+
+    @Test
+    fun `should treat a rewatched episode as another viewing rather than a correction`() = runTest {
+        episodeRepository.setEpisodeById(testEpisode(isWatched = true, watchedAt = AIR_DATE_MILLIS))
+        rewatchRepository.setRewatchesForEpisode(EPISODE_ID, 1L)
+
+        val presenter = createPresenter(param = episodeParam(isEdit = true))
+        settle(presenter)
+
+        presenter.state.value.title shouldBe localizer.getString(StringResourceKey.LabelWatchedDateTitle)
+        presenter.state.value.currentWatchedAtLabel.shouldBeNull()
+
+        presenter.dispatch(WatchDateSelectionAction.JustNowSelected)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        rewatchRepository.lastAddEpisodeWatchedAt shouldBe NOW_MILLIS
+        episodeRepository.lastMarkEpisodeWatchedCall.shouldBeNull()
+    }
+
+    @Test
     fun `should still dismiss the sheet given the write fails`() = runTest {
         episodeRepository.setEpisodeById(testEpisode())
         episodeRepository.setMarkEpisodeWatchedBehavior { throw IllegalStateException("Disk is full") }
@@ -300,6 +338,7 @@ internal class WatchDateSelectionPresenterTest {
         param = param,
         componentContext = DefaultComponentContext(lifecycle = lifecycle),
         observeEpisodeByIdInteractor = ObserveEpisodeByIdInteractor(episodeRepository),
+        observeEpisodeRewatchesInteractor = ObserveEpisodeRewatchesInteractor(rewatchRepository),
         markWatchedAtInteractor = MarkWatchedAtInteractor(
             episodeRepository = episodeRepository,
             watchAgainInteractor = WatchAgainInteractor(rewatchRepository),

--- a/features/watchdate-selection/ui/README.md
+++ b/features/watchdate-selection/ui/README.md
@@ -160,6 +160,7 @@ graph TB
   :features:watchdate-selection:presenter --> :data:ratings:api
   :features:watchdate-selection:presenter --> :domain:episode
   :features:watchdate-selection:presenter --> :domain:ratings
+  :features:watchdate-selection:presenter --> :domain:rewatch
   :features:watchdate-selection:presenter --> :features:rating-sheet:nav
   :features:watchdate-selection:presenter --> :features:watchdate-selection:nav
   :features:watchdate-selection:presenter --> :i18n:api

--- a/ios-framework/README.md
+++ b/ios-framework/README.md
@@ -1039,6 +1039,7 @@ graph TB
   :features:continue-watching:presenter --> :features:rating-sheet:presenter
   :features:continue-watching:presenter -.-> :features:season-details:nav
   :features:continue-watching:presenter -.-> :features:show-details:nav
+  :features:continue-watching:presenter --> :features:watchdate-selection:nav
   :features:continue-watching:presenter --> :i18n:api
   :features:continue-watching:presenter --> :navigation:api
   :features:debug:nav --> :navigation:api
@@ -1228,6 +1229,7 @@ graph TB
   :features:season-details:presenter -.-> :features:episode-sheet:nav
   :features:season-details:presenter --> :features:rating-sheet:nav
   :features:season-details:presenter --> :features:season-details:nav
+  :features:season-details:presenter --> :features:watchdate-selection:nav
   :features:season-details:presenter --> :navigation:api
   :features:settings:nav --> :navigation:api
   :features:settings:presenter --> :core:appconfig:api
@@ -1276,6 +1278,7 @@ graph TB
   :features:show-details:presenter --> :features:show-details:nav
   :features:show-details:presenter --> :features:show-list:nav
   :features:show-details:presenter -.-> :features:trailers:nav
+  :features:show-details:presenter --> :features:watchdate-selection:nav
   :features:show-details:presenter --> :i18n:api
   :features:show-details:presenter --> :navigation:api
   :features:show-list:nav --> :navigation:api
@@ -1340,6 +1343,7 @@ graph TB
   :features:upnext:presenter --> :features:rating-sheet:presenter
   :features:upnext:presenter -.-> :features:season-details:nav
   :features:upnext:presenter -.-> :features:show-details:nav
+  :features:upnext:presenter --> :features:watchdate-selection:nav
   :features:upnext:presenter --> :navigation:api
   :features:watchdate-selection:nav --> :data:episode:api
   :features:watchdate-selection:nav --> :navigation:api
@@ -1351,6 +1355,7 @@ graph TB
   :features:watchdate-selection:presenter --> :data:ratings:api
   :features:watchdate-selection:presenter --> :domain:episode
   :features:watchdate-selection:presenter --> :domain:ratings
+  :features:watchdate-selection:presenter --> :domain:rewatch
   :features:watchdate-selection:presenter --> :features:rating-sheet:nav
   :features:watchdate-selection:presenter --> :features:watchdate-selection:nav
   :features:watchdate-selection:presenter --> :i18n:api


### PR DESCRIPTION
## Description
This PR now prompts the user to select a date when marking a season or earlier episodes as watched, rather than using the current time. It also adds a long press action for the four check buttons.

## Changes
- Prompt for a date after the user confirms any of the three season and episode dialogs
- Keep a plain tap on a check button marking with the current time, on all four screens
- Keep both unwatch confirmations marking straight away
- Add a long press action to Up Next, Continue Watching, Season Details and Show Details
- Show the date already saved, and a title that says the date is changing, when the sheet opens on an episode watched once
- Treat an episode watched more than once as a new viewing rather than a change
