### PR TITLE
feat: Add Watch date selection long press on iOS

### DIFF
--- a/ios/Packages/Home/Sources/Home/UpNextPageContent.swift
+++ b/ios/Packages/Home/Sources/Home/UpNextPageContent.swift
@@ -64,6 +64,14 @@ struct UpNextPageContent: View {
                                 onLongPress: {
                                     presenter.dispatch(action: UpNextEpisodeLongPressed(episodeId: episode.episodeId))
                                 },
+                                onMarkWatchedLongPress: {
+                                    presenter.dispatch(action: MarkWatchedLongPressed(
+                                        showId: episode.showId,
+                                        episodeId: episode.episodeId,
+                                        seasonNumber: episode.seasonNumber,
+                                        episodeNumber: episode.episodeNumberValue
+                                    ))
+                                },
                                 isUpdating: uiState.updatingEpisodeIds.contains(KotlinLong(value: episode.episodeId))
                             )
                         }

--- a/ios/Packages/MyShows/Sources/MyShows/MyShowsScreen.swift
+++ b/ios/Packages/MyShows/Sources/MyShows/MyShowsScreen.swift
@@ -63,6 +63,7 @@ public struct MyShowsScreen: View {
     private let onEpisodeClicked: (Int64, Int64) -> Void
     private let onShowTitleClicked: (Int64) -> Void
     private let onMarkWatched: (SwiftNextEpisode) -> Void
+    private let onMarkWatchedLongPress: ((SwiftNextEpisode) -> Void)?
     private let onRefresh: () async -> Void
 
     @Namespace private var animation
@@ -73,6 +74,7 @@ public struct MyShowsScreen: View {
         onEpisodeClicked: @escaping (Int64, Int64) -> Void,
         onShowTitleClicked: @escaping (Int64) -> Void,
         onMarkWatched: @escaping (SwiftNextEpisode) -> Void,
+        onMarkWatchedLongPress: ((SwiftNextEpisode) -> Void)? = nil,
         onRefresh: @escaping () async -> Void
     ) {
         self.state = state
@@ -80,6 +82,7 @@ public struct MyShowsScreen: View {
         self.onEpisodeClicked = onEpisodeClicked
         self.onShowTitleClicked = onShowTitleClicked
         self.onMarkWatched = onMarkWatched
+        self.onMarkWatchedLongPress = onMarkWatchedLongPress
         self.onRefresh = onRefresh
     }
 
@@ -178,6 +181,9 @@ public struct MyShowsScreen: View {
                 onItemClicked: onEpisodeClicked,
                 onShowTitleClicked: onShowTitleClicked,
                 onMarkWatched: { onMarkWatched(episode) },
+                onMarkWatchedLongPress: onMarkWatchedLongPress.map { longPress in
+                    { longPress(episode) }
+                },
                 isUpdating: state.updatingEpisodeIds.contains(episode.episodeId)
             )
         }

--- a/ios/Packages/MyShows/Sources/MyShows/MyShowsTab.swift
+++ b/ios/Packages/MyShows/Sources/MyShows/MyShowsTab.swift
@@ -285,6 +285,14 @@ public struct MyShowsTab: View {
                     episodeNumber: episode.episodeNumberValue
                 ))
             },
+            onMarkWatchedLongPress: { episode in
+                continueWatchingPresenter.dispatch(action: MarkUpNextEpisodeWatchedLongPressed(
+                    showId: episode.showId,
+                    episodeId: episode.episodeId,
+                    seasonNumber: episode.seasonNumber,
+                    episodeNumber: episode.episodeNumberValue
+                ))
+            },
             onRefresh: { try? await continueWatchingPresenter.refresh() }
         )
     }

--- a/ios/Packages/SeasonDetails/Sources/SeasonDetails/EpisodeItemView.swift
+++ b/ios/Packages/SeasonDetails/Sources/SeasonDetails/EpisodeItemView.swift
@@ -30,6 +30,7 @@ public struct EpisodeItemView: View {
     private let cornerRadius: CGFloat
     private let posterRadius: CGFloat
     private let onWatchedToggle: () -> Void
+    private let onWatchedLongPress: (() -> Void)?
 
     public init(
         imageUrl: String?,
@@ -46,7 +47,8 @@ public struct EpisodeItemView: View {
         shadowToken: TvManiacShadowToken? = nil,
         cornerRadius: CGFloat = Constants.defaultCornerRadius,
         posterRadius: CGFloat = Constants.defaultPosterRadius,
-        onWatchedToggle: @escaping () -> Void = {}
+        onWatchedToggle: @escaping () -> Void = {},
+        onWatchedLongPress: (() -> Void)? = nil
     ) {
         self.imageUrl = imageUrl
         self.episodeTitle = episodeTitle
@@ -63,6 +65,7 @@ public struct EpisodeItemView: View {
         self.cornerRadius = cornerRadius
         self.posterRadius = posterRadius
         self.onWatchedToggle = onWatchedToggle
+        self.onWatchedLongPress = onWatchedLongPress
     }
 
     public var body: some View {
@@ -134,6 +137,13 @@ public struct EpisodeItemView: View {
                 }
             }
             .buttonStyle(.plain)
+            .highPriorityGesture(
+                LongPressGesture().onEnded { _ in
+                    guard let onWatchedLongPress else { return }
+                    Haptics.impact(isEnabled: hapticFeedbackEnabled, style: .medium)
+                    onWatchedLongPress()
+                }
+            )
             .padding(.trailing, theme.spacing.medium)
         } else if let daysUntilAir, daysUntilAir > 0 {
             VStack(spacing: 0) {

--- a/ios/Packages/SeasonDetails/Sources/SeasonDetails/EpisodeListView.swift
+++ b/ios/Packages/SeasonDetails/Sources/SeasonDetails/EpisodeListView.swift
@@ -17,6 +17,7 @@ public struct EpisodeListView: View {
     private let onEpisodeHeaderClicked: () -> Void
     private let onWatchedStateClicked: () -> Void
     private let onEpisodeWatchToggle: (SwiftEpisode) -> Void
+    private let onEpisodeWatchLongPress: ((SwiftEpisode) -> Void)?
     private let onEpisodeTapped: (SwiftEpisode) -> Void
 
     public init(
@@ -31,6 +32,7 @@ public struct EpisodeListView: View {
         onEpisodeHeaderClicked: @escaping () -> Void,
         onWatchedStateClicked: @escaping () -> Void,
         onEpisodeWatchToggle: @escaping (SwiftEpisode) -> Void = { _ in },
+        onEpisodeWatchLongPress: ((SwiftEpisode) -> Void)? = nil,
         onEpisodeTapped: @escaping (SwiftEpisode) -> Void = { _ in }
     ) {
         self.title = title
@@ -44,6 +46,7 @@ public struct EpisodeListView: View {
         self.onEpisodeHeaderClicked = onEpisodeHeaderClicked
         self.onWatchedStateClicked = onWatchedStateClicked
         self.onEpisodeWatchToggle = onEpisodeWatchToggle
+        self.onEpisodeWatchLongPress = onEpisodeWatchLongPress
         self.onEpisodeTapped = onEpisodeTapped
     }
 
@@ -79,7 +82,10 @@ public struct EpisodeListView: View {
                             hasAired: item.hasAired,
                             dayLabelFormat: dayLabelFormat,
                             tbdLabel: tbdLabel,
-                            onWatchedToggle: { onEpisodeWatchToggle(item) }
+                            onWatchedToggle: { onEpisodeWatchToggle(item) },
+                            onWatchedLongPress: onEpisodeWatchLongPress.map { longPress in
+                                { longPress(item) }
+                            }
                         )
                         .contentShape(Rectangle())
                         .onTapGesture { onEpisodeTapped(item) }

--- a/ios/Packages/SeasonDetails/Sources/SeasonDetails/SeasonDetailsScreen.swift
+++ b/ios/Packages/SeasonDetails/Sources/SeasonDetails/SeasonDetailsScreen.swift
@@ -85,6 +85,7 @@ public struct SeasonDetailsScreen: View {
     private let onWatchedStateClicked: () -> Void
     private let onRateClicked: () -> Void
     private let onEpisodeWatchToggle: (SwiftEpisode) -> Void
+    private let onEpisodeWatchLongPress: ((SwiftEpisode) -> Void)?
     private let onEpisodeTapped: (SwiftEpisode) -> Void
 
     public init(
@@ -100,6 +101,7 @@ public struct SeasonDetailsScreen: View {
         onWatchedStateClicked: @escaping () -> Void,
         onRateClicked: @escaping () -> Void = {},
         onEpisodeWatchToggle: @escaping (SwiftEpisode) -> Void,
+        onEpisodeWatchLongPress: ((SwiftEpisode) -> Void)? = nil,
         onEpisodeTapped: @escaping (SwiftEpisode) -> Void = { _ in }
     ) {
         self.state = state
@@ -114,6 +116,7 @@ public struct SeasonDetailsScreen: View {
         self.onWatchedStateClicked = onWatchedStateClicked
         self.onRateClicked = onRateClicked
         self.onEpisodeWatchToggle = onEpisodeWatchToggle
+        self.onEpisodeWatchLongPress = onEpisodeWatchLongPress
         self.onEpisodeTapped = onEpisodeTapped
     }
 
@@ -206,6 +209,7 @@ public struct SeasonDetailsScreen: View {
                         onEpisodeHeaderClicked: onEpisodeHeaderClicked,
                         onWatchedStateClicked: onWatchedStateClicked,
                         onEpisodeWatchToggle: onEpisodeWatchToggle,
+                        onEpisodeWatchLongPress: onEpisodeWatchLongPress,
                         onEpisodeTapped: onEpisodeTapped
                     )
                 }

--- a/ios/Packages/SeasonDetails/Sources/SeasonDetails/SeasonDetailsView.swift
+++ b/ios/Packages/SeasonDetails/Sources/SeasonDetails/SeasonDetailsView.swift
@@ -39,6 +39,13 @@ public struct SeasonDetailsView: View {
             onEpisodeWatchToggle: { episode in
                 presenter.dispatch(action: ToggleEpisodeWatched(episodeId: episode.episodeId))
             },
+            onEpisodeWatchLongPress: { episode in
+                presenter.dispatch(action: EpisodeWatchedLongPressed(
+                    episodeId: episode.episodeId,
+                    seasonNumber: episode.seasonNumber,
+                    episodeNumber: episode.episodeNumber
+                ))
+            },
             onEpisodeTapped: { episode in
                 presenter.dispatch(action: EpisodeClicked(id: Int64(episode.episodeId)))
             }

--- a/ios/Packages/ShowDetails/Sources/ShowDetails/Sections/ShowDetailsSeasonEpisodesSection.swift
+++ b/ios/Packages/ShowDetails/Sources/ShowDetails/Sections/ShowDetailsSeasonEpisodesSection.swift
@@ -39,6 +39,14 @@ struct ShowDetailsSeasonEpisodesSection: View {
                     ))
                 }
             },
+            onMarkWatchedLongPress: { episode in
+                presenter.dispatch(action: ShowDetailsEpisodeWatchedLongPressed(
+                    showId: episode.showId,
+                    episodeId: episode.episodeId,
+                    seasonNumber: episode.seasonNumber,
+                    episodeNumber: episode.episodeNumber
+                ))
+            },
             updatingEpisodeIds: Set(Array(state.updatingEpisodeIds).map(\.int64Value))
         )
         SeasonProgressSection(

--- a/ios/Packages/UpNext/Sources/UpNext/ContinueTrackingCard.swift
+++ b/ios/Packages/UpNext/Sources/UpNext/ContinueTrackingCard.swift
@@ -5,11 +5,13 @@ import SwiftUI
 
 public struct ContinueTrackingCard: View {
     @Environment(\.appTheme) private var theme
+    @Environment(\.hapticFeedbackEnabled) private var hapticFeedbackEnabled
 
     private let episode: SwiftContinueTrackingEpisode
     private let dayLabelFormat: (_ count: Int) -> String
     private let tbdLabel: String
     private let onMarkWatched: () -> Void
+    private let onMarkWatchedLongPress: (() -> Void)?
     private let isUpdating: Bool
 
     public init(
@@ -17,12 +19,14 @@ public struct ContinueTrackingCard: View {
         dayLabelFormat: @escaping (_ count: Int) -> String,
         tbdLabel: String,
         onMarkWatched: @escaping () -> Void,
+        onMarkWatchedLongPress: (() -> Void)? = nil,
         isUpdating: Bool = false
     ) {
         self.episode = episode
         self.dayLabelFormat = dayLabelFormat
         self.tbdLabel = tbdLabel
         self.onMarkWatched = onMarkWatched
+        self.onMarkWatchedLongPress = onMarkWatchedLongPress
         self.isUpdating = isUpdating
     }
 
@@ -75,6 +79,13 @@ public struct ContinueTrackingCard: View {
                     }
                     .buttonStyle(.plain)
                     .disabled(isUpdating)
+                    .highPriorityGesture(
+                        LongPressGesture().onEnded { _ in
+                            guard let onMarkWatchedLongPress else { return }
+                            Haptics.impact(isEnabled: hapticFeedbackEnabled, style: .medium)
+                            onMarkWatchedLongPress()
+                        }
+                    )
                 } else if let daysUntilAir = episode.daysUntilAir, daysUntilAir > 0 {
                     VStack(spacing: 0) {
                         Text("\(daysUntilAir)")

--- a/ios/Packages/UpNext/Sources/UpNext/ContinueTrackingSection.swift
+++ b/ios/Packages/UpNext/Sources/UpNext/ContinueTrackingSection.swift
@@ -12,6 +12,7 @@ public struct ContinueTrackingSection: View {
     private let dayLabelFormat: (_ count: Int) -> String
     private let tbdLabel: String
     private let onMarkWatched: (SwiftContinueTrackingEpisode) -> Void
+    private let onMarkWatchedLongPress: ((SwiftContinueTrackingEpisode) -> Void)?
     private let updatingEpisodeIds: Set<Int64>
 
     public init(
@@ -21,6 +22,7 @@ public struct ContinueTrackingSection: View {
         dayLabelFormat: @escaping (_ count: Int) -> String,
         tbdLabel: String,
         onMarkWatched: @escaping (SwiftContinueTrackingEpisode) -> Void,
+        onMarkWatchedLongPress: ((SwiftContinueTrackingEpisode) -> Void)? = nil,
         updatingEpisodeIds: Set<Int64> = []
     ) {
         self.title = title
@@ -29,6 +31,7 @@ public struct ContinueTrackingSection: View {
         self.dayLabelFormat = dayLabelFormat
         self.tbdLabel = tbdLabel
         self.onMarkWatched = onMarkWatched
+        self.onMarkWatchedLongPress = onMarkWatchedLongPress
         self.updatingEpisodeIds = updatingEpisodeIds
     }
 
@@ -49,6 +52,9 @@ public struct ContinueTrackingSection: View {
                                     dayLabelFormat: dayLabelFormat,
                                     tbdLabel: tbdLabel,
                                     onMarkWatched: { onMarkWatched(episode) },
+                                    onMarkWatchedLongPress: onMarkWatchedLongPress.map { longPress in
+                                        { longPress(episode) }
+                                    },
                                     isUpdating: updatingEpisodeIds.contains(episode.episodeId)
                                 )
                                 .id(episode.id)

--- a/ios/Packages/UpNext/Sources/UpNext/UpNextListItemView.swift
+++ b/ios/Packages/UpNext/Sources/UpNext/UpNextListItemView.swift
@@ -12,6 +12,7 @@ public struct UpNextListItemView: View {
     let onShowTitleClicked: (Int64) -> Void
     let onMarkWatched: () -> Void
     let onLongPress: () -> Void
+    let onMarkWatchedLongPress: (() -> Void)?
     let isUpdating: Bool
 
     private let posterImageUrl: String?
@@ -23,6 +24,7 @@ public struct UpNextListItemView: View {
         onShowTitleClicked: @escaping (Int64) -> Void,
         onMarkWatched: @escaping () -> Void,
         onLongPress: @escaping () -> Void = {},
+        onMarkWatchedLongPress: (() -> Void)? = nil,
         isUpdating: Bool = false
     ) {
         self.episode = episode
@@ -30,6 +32,7 @@ public struct UpNextListItemView: View {
         self.onShowTitleClicked = onShowTitleClicked
         self.onMarkWatched = onMarkWatched
         self.onLongPress = onLongPress
+        self.onMarkWatchedLongPress = onMarkWatchedLongPress
         self.isUpdating = isUpdating
 
         posterImageUrl = episode.imageUrl
@@ -152,6 +155,13 @@ public struct UpNextListItemView: View {
         }
         .buttonStyle(.plain)
         .disabled(isUpdating)
+        .highPriorityGesture(
+            LongPressGesture().onEnded { _ in
+                guard let onMarkWatchedLongPress else { return }
+                Haptics.impact(isEnabled: hapticFeedbackEnabled, style: .medium)
+                onMarkWatchedLongPress()
+            }
+        )
         .frame(maxHeight: .infinity)
         .padding(.trailing, theme.spacing.small)
     }

--- a/ios/Packages/UpNext/Sources/UpNext/WatchListItemView.swift
+++ b/ios/Packages/UpNext/Sources/UpNext/WatchListItemView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 
 public struct WatchListItemView: View {
     @Environment(\.appTheme) private var theme
+    @Environment(\.hapticFeedbackEnabled) private var hapticFeedbackEnabled
 
     let episode: SwiftNextEpisode
     let premiereLabel: String
@@ -12,6 +13,7 @@ public struct WatchListItemView: View {
     let onItemClicked: (Int64, Int64) -> Void
     let onShowTitleClicked: (Int64) -> Void
     let onMarkWatched: () -> Void
+    let onMarkWatchedLongPress: (() -> Void)?
     let isUpdating: Bool
 
     public init(
@@ -21,6 +23,7 @@ public struct WatchListItemView: View {
         onItemClicked: @escaping (Int64, Int64) -> Void,
         onShowTitleClicked: @escaping (Int64) -> Void,
         onMarkWatched: @escaping () -> Void,
+        onMarkWatchedLongPress: (() -> Void)? = nil,
         isUpdating: Bool = false
     ) {
         self.episode = episode
@@ -29,6 +32,7 @@ public struct WatchListItemView: View {
         self.onItemClicked = onItemClicked
         self.onShowTitleClicked = onShowTitleClicked
         self.onMarkWatched = onMarkWatched
+        self.onMarkWatchedLongPress = onMarkWatchedLongPress
         self.isUpdating = isUpdating
     }
 
@@ -133,6 +137,13 @@ public struct WatchListItemView: View {
         }
         .buttonStyle(.plain)
         .disabled(isUpdating)
+        .highPriorityGesture(
+            LongPressGesture().onEnded { _ in
+                guard let onMarkWatchedLongPress else { return }
+                Haptics.impact(isEnabled: hapticFeedbackEnabled, style: .medium)
+                onMarkWatchedLongPress()
+            }
+        )
         .frame(maxHeight: .infinity)
         .padding(.trailing, theme.spacing.medium)
     }


### PR DESCRIPTION
## Description
This PR now prompts the user to select a date when they hold a check button on the iOS Up Next, Continue Watching, Season Details and Show Details screens. A plain tap still marks the episode with the current time, and a hold uses a stronger vibration so the two feel different.
