### PR TITLE
feat: Sync changed watch state

### DIFF
--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeDao.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeDao.kt
@@ -9,7 +9,6 @@ import com.thomaskioko.tvmaniac.episodes.api.model.SeasonWatchProgress
 import com.thomaskioko.tvmaniac.episodes.api.model.ShowWatchProgress
 import com.thomaskioko.tvmaniac.episodes.api.model.WatchedEpisodeRuntime
 import com.thomaskioko.tvmaniac.episodes.api.model.WatchedShowComposition
-import com.thomaskioko.tvmaniac.followedshows.api.PendingAction
 import kotlinx.coroutines.flow.Flow
 
 public interface WatchedEpisodeDao {
@@ -44,6 +43,15 @@ public interface WatchedEpisodeDao {
     public suspend fun markAsWatched(
         showId: Long,
         episodeId: Long,
+        seasonNumber: Long,
+        episodeNumber: Long,
+        includeSpecials: Boolean,
+        watchedAt: Long? = null,
+        useReleaseDate: Boolean = false,
+    )
+
+    public suspend fun updateWatchedDate(
+        showId: Long,
         seasonNumber: Long,
         episodeNumber: Long,
         includeSpecials: Boolean,
@@ -108,11 +116,11 @@ public interface WatchedEpisodeDao {
         includeSpecials: Boolean,
     ): Flow<Long>
 
-    public suspend fun entriesByPendingAction(action: PendingAction): List<GetEntriesByPendingAction>
+    public suspend fun entriesByPendingAction(action: WatchedEpisodeSyncOperation): List<GetEntriesByPendingAction>
 
-    public suspend fun updatePendingAction(id: Long, action: PendingAction)
+    public suspend fun updatePendingAction(id: Long, action: WatchedEpisodeSyncOperation)
 
-    public suspend fun updatePendingActions(ids: List<Long>, action: PendingAction)
+    public suspend fun updatePendingActions(ids: List<Long>, action: WatchedEpisodeSyncOperation)
 
     public fun deleteAll()
 

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeSyncOperation.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/WatchedEpisodeSyncOperation.kt
@@ -1,0 +1,8 @@
+package com.thomaskioko.tvmaniac.episodes.api
+
+public enum class WatchedEpisodeSyncOperation(public val value: String) {
+    NOTHING("NOTHING"),
+    UPLOAD("UPLOAD"),
+    DELETE("DELETE"),
+    UPDATE("UPDATE"),
+}

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepository.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepository.kt
@@ -7,9 +7,9 @@ import com.thomaskioko.tvmaniac.episodes.api.EpisodeWatchesDataSource
 import com.thomaskioko.tvmaniac.episodes.api.EpisodesDao
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeDao
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeEntry
+import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeSyncOperation
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeSyncRepository
 import com.thomaskioko.tvmaniac.episodes.api.WatchedShowBatch
-import com.thomaskioko.tvmaniac.followedshows.api.PendingAction
 import com.thomaskioko.tvmaniac.shows.api.ShowReconciler
 import com.thomaskioko.tvmaniac.shows.api.ShowResolveOutcome
 import com.thomaskioko.tvmaniac.shows.api.traktGenreName
@@ -49,6 +49,7 @@ public class DefaultWatchedEpisodeSyncRepository(
 
         syncMutex.withLock {
             processPendingEpisodesToUploads()
+            processPendingEpisodeUpdates()
             processPendingEpisodesDeletes()
         }
     }
@@ -57,17 +58,22 @@ public class DefaultWatchedEpisodeSyncRepository(
         if (accountManager.getActiveProvider() == null) return
 
         syncMutex.withLock {
-            val pendingUploads = dao.entriesByPendingAction(PendingAction.UPLOAD)
-            val pendingDeletes = dao.entriesByPendingAction(PendingAction.DELETE)
+            val pendingUploads = dao.entriesByPendingAction(WatchedEpisodeSyncOperation.UPLOAD)
+            val pendingUpdates = dao.entriesByPendingAction(WatchedEpisodeSyncOperation.UPDATE)
+            val pendingDeletes = dao.entriesByPendingAction(WatchedEpisodeSyncOperation.DELETE)
             if (pendingUploads.isNotEmpty()) {
                 uploadPending(pendingUploads)
+            }
+            if (pendingUpdates.isNotEmpty()) {
+                updatePending(pendingUpdates)
             }
             if (pendingDeletes.isNotEmpty()) {
                 deletePending(pendingDeletes)
             }
 
-            if (pendingDeletes.isNotEmpty()) {
-                logger.debug(TAG, "Deferring bulk pull this cycle after pushing ${pendingDeletes.size} delete(s)")
+            if (pendingDeletes.isNotEmpty() || pendingUpdates.isNotEmpty()) {
+                val removals = pendingDeletes.size + pendingUpdates.size
+                logger.debug(TAG, "Deferring bulk pull this cycle after pushing $removals removal(s)")
                 return
             }
 
@@ -109,17 +115,40 @@ public class DefaultWatchedEpisodeSyncRepository(
     override suspend fun getWatchedShowsMissingGenres(): List<Long> = dao.getWatchedShowsMissingGenres()
 
     private suspend fun processPendingEpisodesToUploads() {
-        val pending = dao.entriesByPendingAction(PendingAction.UPLOAD)
+        val pending = dao.entriesByPendingAction(WatchedEpisodeSyncOperation.UPLOAD)
         if (pending.isEmpty()) return
 
         uploadPending(pending)
     }
 
+    private suspend fun processPendingEpisodeUpdates() {
+        val pending = dao.entriesByPendingAction(WatchedEpisodeSyncOperation.UPDATE)
+        if (pending.isEmpty()) return
+
+        updatePending(pending)
+    }
+
     private suspend fun processPendingEpisodesDeletes() {
-        val pending = dao.entriesByPendingAction(PendingAction.DELETE)
+        val pending = dao.entriesByPendingAction(WatchedEpisodeSyncOperation.DELETE)
         if (pending.isEmpty()) return
 
         deletePending(pending)
+    }
+
+    private suspend fun updatePending(
+        pending: List<com.thomaskioko.tvmaniac.db.GetEntriesByPendingAction>,
+    ) {
+        val source = activeSource() ?: return
+        logger.debug(TAG, "Processing ${pending.size} pending updates")
+
+        val entries = pending.map(::toEntry)
+
+        source.removeEpisodeEntries(entries)
+        source.addEpisodeEntries(entries)
+
+        dao.updatePendingActions(pending.map { it.watched_id }, WatchedEpisodeSyncOperation.NOTHING)
+
+        logger.debug(TAG, "Successfully updated ${pending.size} episodes")
     }
 
     private suspend fun uploadPending(
@@ -128,22 +157,9 @@ public class DefaultWatchedEpisodeSyncRepository(
         val source = activeSource() ?: return
         logger.debug(TAG, "Processing ${pending.size} pending uploads")
 
-        val entries = pending.map { episode ->
-            WatchedEpisodeEntry(
-                id = episode.watched_id,
-                showId = episode.trakt_id,
-                episodeId = episode.episode_id?.id,
-                seasonNumber = episode.season_number,
-                episodeNumber = episode.episode_number,
-                watchedAt = fromEpochMilliseconds(episode.watched_at),
-                traktId = episode.trakt_id,
-                pendingAction = PendingAction.UPLOAD,
-            )
-        }
+        source.addEpisodeEntries(pending.map(::toEntry))
 
-        source.addEpisodeEntries(entries)
-
-        dao.updatePendingActions(pending.map { it.watched_id }, PendingAction.NOTHING)
+        dao.updatePendingActions(pending.map { it.watched_id }, WatchedEpisodeSyncOperation.NOTHING)
 
         logger.debug(TAG, "Successfully uploaded ${pending.size} episodes")
     }
@@ -154,24 +170,24 @@ public class DefaultWatchedEpisodeSyncRepository(
         val source = activeSource() ?: return
         logger.debug(TAG, "Processing ${pending.size} pending deletes")
 
-        val entries = pending.map { episode ->
-            WatchedEpisodeEntry(
-                id = episode.watched_id,
-                showId = episode.trakt_id,
-                episodeId = episode.episode_id?.id,
-                seasonNumber = episode.season_number,
-                episodeNumber = episode.episode_number,
-                watchedAt = fromEpochMilliseconds(episode.watched_at),
-                traktId = episode.trakt_id,
-                pendingAction = PendingAction.DELETE,
-            )
-        }
-        source.removeEpisodeEntries(entries)
+        source.removeEpisodeEntries(pending.map(::toEntry))
 
         dao.deleteByIds(pending.map { it.watched_id })
 
         logger.debug(TAG, "Successfully deleted ${pending.size} episodes")
     }
+
+    private fun toEntry(
+        episode: com.thomaskioko.tvmaniac.db.GetEntriesByPendingAction,
+    ): WatchedEpisodeEntry = WatchedEpisodeEntry(
+        id = episode.watched_id,
+        showId = episode.trakt_id,
+        episodeId = episode.episode_id?.id,
+        seasonNumber = episode.season_number,
+        episodeNumber = episode.episode_number,
+        watchedAt = fromEpochMilliseconds(episode.watched_at),
+        traktId = episode.trakt_id,
+    )
 
     private suspend fun fetchAllWatchedShows() {
         val source = activeSource() ?: return

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/dao/DefaultWatchedEpisodeDao.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/dao/DefaultWatchedEpisodeDao.kt
@@ -14,6 +14,7 @@ import com.thomaskioko.tvmaniac.db.TvManiacDatabase
 import com.thomaskioko.tvmaniac.episodes.api.WatchedDate
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeDao
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeEntry
+import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeSyncOperation
 import com.thomaskioko.tvmaniac.episodes.api.model.EpisodeWatchParams
 import com.thomaskioko.tvmaniac.episodes.api.model.MostWatchedShow
 import com.thomaskioko.tvmaniac.episodes.api.model.RecentlyWatchedEpisode
@@ -21,7 +22,6 @@ import com.thomaskioko.tvmaniac.episodes.api.model.SeasonWatchProgress
 import com.thomaskioko.tvmaniac.episodes.api.model.ShowWatchProgress
 import com.thomaskioko.tvmaniac.episodes.api.model.WatchedEpisodeRuntime
 import com.thomaskioko.tvmaniac.episodes.api.model.WatchedShowComposition
-import com.thomaskioko.tvmaniac.followedshows.api.PendingAction
 import com.thomaskioko.tvmaniac.util.api.DateTimeProvider
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
@@ -152,6 +152,45 @@ public class DefaultWatchedEpisodeDao(
         watchedAt: Long?,
         useReleaseDate: Boolean,
     ) {
+        writeWatch(
+            showId = showId,
+            seasonNumber = seasonNumber,
+            episodeNumber = episodeNumber,
+            includeSpecials = includeSpecials,
+            watchedAt = watchedAt,
+            useReleaseDate = useReleaseDate,
+            action = WatchedEpisodeSyncOperation.UPLOAD,
+        )
+    }
+
+    override suspend fun updateWatchedDate(
+        showId: Long,
+        seasonNumber: Long,
+        episodeNumber: Long,
+        includeSpecials: Boolean,
+        watchedAt: Long?,
+        useReleaseDate: Boolean,
+    ) {
+        writeWatch(
+            showId = showId,
+            seasonNumber = seasonNumber,
+            episodeNumber = episodeNumber,
+            includeSpecials = includeSpecials,
+            watchedAt = watchedAt,
+            useReleaseDate = useReleaseDate,
+            action = WatchedEpisodeSyncOperation.UPDATE,
+        )
+    }
+
+    private suspend fun writeWatch(
+        showId: Long,
+        seasonNumber: Long,
+        episodeNumber: Long,
+        includeSpecials: Boolean,
+        watchedAt: Long?,
+        useReleaseDate: Boolean,
+        action: WatchedEpisodeSyncOperation,
+    ) {
         withContext(dispatchers.databaseWrite) {
             val internalShowId = showIdResolver.showIdForTmdbId(showId) ?: return@withContext
             database.transaction {
@@ -170,7 +209,7 @@ public class DefaultWatchedEpisodeDao(
                     season_number = seasonNumber,
                     episode_number = episodeNumber,
                     watched_at = timestamp,
-                    pending_action = PendingAction.UPLOAD.value,
+                    pending_action = action.value,
                 )
                 recalculateLastWatched(internalShowId, includeSpecials)
             }
@@ -192,7 +231,7 @@ public class DefaultWatchedEpisodeDao(
                 if (entry != null) {
                     if (entry.trakt_id != null) {
                         val _ = database.watchedEpisodesQueries.updatePendingActionByShowAndEpisode(
-                            pending_action = PendingAction.DELETE.value,
+                            pending_action = WatchedEpisodeSyncOperation.DELETE.value,
                             show_id = internalShowId,
                             episode_id = Id(episodeId),
                         )
@@ -303,7 +342,7 @@ public class DefaultWatchedEpisodeDao(
                         season_number = episode.seasonNumber,
                         episode_number = episode.episodeNumber,
                         watched_at = episodeTimestamp,
-                        pending_action = PendingAction.UPLOAD.value,
+                        pending_action = WatchedEpisodeSyncOperation.UPLOAD.value,
                     )
                 }
                 recalculateLastWatched(internalShowId, includeSpecials)
@@ -326,7 +365,7 @@ public class DefaultWatchedEpisodeDao(
                 seasonRows.forEach { row ->
                     if (row.trakt_id != null) {
                         val _ = database.watchedEpisodesQueries.updatePendingAction(
-                            pending_action = PendingAction.DELETE.value,
+                            pending_action = WatchedEpisodeSyncOperation.DELETE.value,
                             id = row.watched_id,
                         )
                     } else {
@@ -365,7 +404,7 @@ public class DefaultWatchedEpisodeDao(
                         season_number = episode.season_number,
                         episode_number = episode.episode_number,
                         watched_at = releaseDateOrNull(episode.first_aired, episode.runtime, useReleaseDate) ?: timestamp,
-                        pending_action = PendingAction.UPLOAD.value,
+                        pending_action = WatchedEpisodeSyncOperation.UPLOAD.value,
                     )
                 }
 
@@ -386,7 +425,7 @@ public class DefaultWatchedEpisodeDao(
                         season_number = episode.season_number,
                         episode_number = episode.episode_number,
                         watched_at = releaseDateOrNull(episode.first_aired, episode.runtime, useReleaseDate) ?: timestamp,
-                        pending_action = PendingAction.UPLOAD.value,
+                        pending_action = WatchedEpisodeSyncOperation.UPLOAD.value,
                     )
                 }
 
@@ -422,7 +461,7 @@ public class DefaultWatchedEpisodeDao(
                         season_number = episode.season_number,
                         episode_number = episode.episode_number,
                         watched_at = releaseDateOrNull(episode.first_aired, episode.runtime, useReleaseDate) ?: timestamp,
-                        pending_action = PendingAction.UPLOAD.value,
+                        pending_action = WatchedEpisodeSyncOperation.UPLOAD.value,
                     )
                 }
 
@@ -439,7 +478,7 @@ public class DefaultWatchedEpisodeDao(
                     episode_number = episodeNumber,
                     watched_at = releaseDateOrNull(markedEpisode?.first_aired, markedEpisode?.runtime, useReleaseDate)
                         ?: timestamp,
-                    pending_action = PendingAction.UPLOAD.value,
+                    pending_action = WatchedEpisodeSyncOperation.UPLOAD.value,
                 )
                 recalculateLastWatched(internalShowId, includeSpecials)
             }
@@ -556,7 +595,7 @@ public class DefaultWatchedEpisodeDao(
             .catch { emit(0L) }
     }
 
-    override suspend fun entriesByPendingAction(action: PendingAction): List<GetEntriesByPendingAction> {
+    override suspend fun entriesByPendingAction(action: WatchedEpisodeSyncOperation): List<GetEntriesByPendingAction> {
         return withContext(dispatchers.databaseRead) {
             database.watchedEpisodesQueries
                 .getEntriesByPendingAction(action.value)
@@ -564,13 +603,13 @@ public class DefaultWatchedEpisodeDao(
         }
     }
 
-    override suspend fun updatePendingAction(id: Long, action: PendingAction) {
+    override suspend fun updatePendingAction(id: Long, action: WatchedEpisodeSyncOperation) {
         withContext(dispatchers.databaseWrite) {
             database.watchedEpisodesQueries.updatePendingAction(action.value, id)
         }
     }
 
-    override suspend fun updatePendingActions(ids: List<Long>, action: PendingAction) {
+    override suspend fun updatePendingActions(ids: List<Long>, action: WatchedEpisodeSyncOperation) {
         if (ids.isEmpty()) return
         withContext(dispatchers.databaseWrite) {
             database.transaction {
@@ -629,7 +668,7 @@ public class DefaultWatchedEpisodeDao(
                         watched_at = entry.watchedAt.toEpochMilliseconds(),
                         trakt_id = entry.traktId,
                         synced_at = syncedAt,
-                        pending_action = PendingAction.NOTHING.value,
+                        pending_action = WatchedEpisodeSyncOperation.NOTHING.value,
                     )
                 }
 

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeDaoTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeDaoTest.kt
@@ -11,6 +11,7 @@ import com.thomaskioko.tvmaniac.episodes.api.EpisodeRepository
 import com.thomaskioko.tvmaniac.episodes.api.WatchedDate
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeDao
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeEntry
+import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeSyncOperation
 import com.thomaskioko.tvmaniac.episodes.implementation.MockData.SEASON_1_EPISODE_COUNT
 import com.thomaskioko.tvmaniac.episodes.implementation.MockData.SEASON_1_ID
 import com.thomaskioko.tvmaniac.episodes.implementation.MockData.SEASON_1_NUMBER
@@ -454,6 +455,95 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
             val watchedEpisodes = awaitItem()
             watchedEpisodes.shouldBeEmpty()
         }
+    }
+
+    @Test
+    fun `should keep the remote id and queue an update given a watched date is changed`() = runTest {
+        val syncedAt = LocalDate(2024, 6, 1).toEpochMillis()
+        addSyncedWatch(episodeNumber = 1L, watchedAt = syncedAt, syncedAt = syncedAt)
+        val updatedAt = LocalDate(2024, 3, 15).toEpochMillis()
+
+        watchedEpisodeDao.updateWatchedDate(
+            showId = TEST_SHOW_ID,
+            seasonNumber = SEASON_1_NUMBER,
+            episodeNumber = 1L,
+            includeSpecials = false,
+            watchedAt = updatedAt,
+        )
+
+        val row = readWatchedRow(episodeNumber = 1L)
+        row.watched_at shouldBe updatedAt
+        row.pending_action shouldBe WatchedEpisodeSyncOperation.UPDATE.value
+        row.trakt_id shouldBe 9001L
+        row.synced_at shouldBe syncedAt
+    }
+
+    @Test
+    fun `should keep an outstanding update given the provider re-reports the episode`() = runTest {
+        val syncedAt = LocalDate(2024, 6, 1).toEpochMillis()
+        addSyncedWatch(episodeNumber = 1L, watchedAt = syncedAt, syncedAt = syncedAt)
+        val updatedAt = LocalDate(2024, 3, 15).toEpochMillis()
+        watchedEpisodeDao.updateWatchedDate(
+            showId = TEST_SHOW_ID,
+            seasonNumber = SEASON_1_NUMBER,
+            episodeNumber = 1L,
+            includeSpecials = false,
+            watchedAt = updatedAt,
+        )
+
+        watchedEpisodeDao.upsertBatchFromTrakt(
+            showId = TEST_SHOW_ID,
+            entries = listOf(
+                WatchedEpisodeEntry(
+                    id = 0,
+                    showId = TEST_SHOW_ID,
+                    episodeId = 101L,
+                    seasonNumber = SEASON_1_NUMBER,
+                    episodeNumber = 1L,
+                    watchedAt = kotlin.time.Instant.fromEpochMilliseconds(syncedAt),
+                    traktId = 9001L,
+                ),
+            ),
+            includeSpecials = false,
+        )
+
+        val row = readWatchedRow(episodeNumber = 1L)
+        row.watched_at shouldBe updatedAt
+        row.pending_action shouldBe WatchedEpisodeSyncOperation.UPDATE.value
+    }
+
+    @Test
+    fun `should keep an outstanding update given the provider stops reporting the episode`() = runTest {
+        val syncedAt = LocalDate(2024, 6, 1).toEpochMillis()
+        addSyncedWatch(episodeNumber = 1L, watchedAt = syncedAt, syncedAt = syncedAt)
+        val updatedAt = LocalDate(2024, 3, 15).toEpochMillis()
+        watchedEpisodeDao.updateWatchedDate(
+            showId = TEST_SHOW_ID,
+            seasonNumber = SEASON_1_NUMBER,
+            episodeNumber = 1L,
+            includeSpecials = false,
+            watchedAt = updatedAt,
+        )
+
+        watchedEpisodeDao.upsertBatchFromTrakt(
+            showId = TEST_SHOW_ID,
+            entries = listOf(
+                WatchedEpisodeEntry(
+                    id = 0,
+                    showId = TEST_SHOW_ID,
+                    episodeId = 102L,
+                    seasonNumber = SEASON_1_NUMBER,
+                    episodeNumber = 2L,
+                    watchedAt = kotlin.time.Instant.fromEpochMilliseconds(syncedAt),
+                    traktId = 9002L,
+                ),
+            ),
+            includeSpecials = false,
+        )
+
+        val row = readWatchedRow(episodeNumber = 1L)
+        row.watched_at shouldBe updatedAt
+        row.pending_action shouldBe WatchedEpisodeSyncOperation.UPDATE.value
     }
 
     @Test
@@ -977,6 +1067,24 @@ internal class DefaultWatchedEpisodeDaoTest : BaseDatabaseTest() {
 
         watchedAtFor(episodeNumber = 1L) shouldBe CHOSEN_TIME
     }
+
+    private fun addSyncedWatch(episodeNumber: Long, watchedAt: Long, syncedAt: Long) {
+        database.watchedEpisodesQueries.upsertFromTrakt(
+            show_id = testShowId,
+            episode_id = Id(100L + episodeNumber),
+            season_number = SEASON_1_NUMBER,
+            episode_number = episodeNumber,
+            watched_at = watchedAt,
+            trakt_id = 9000L + episodeNumber,
+            synced_at = syncedAt,
+            pending_action = WatchedEpisodeSyncOperation.NOTHING.value,
+        )
+    }
+
+    private fun readWatchedRow(episodeNumber: Long, seasonNumber: Long = SEASON_1_NUMBER) =
+        database.watchedEpisodesQueries.getWatchedEpisodes(testShowId)
+            .executeAsList()
+            .first { it.season_number == seasonNumber && it.episode_number == episodeNumber }
 
     private fun libraryOrder(): List<Long> =
         database.followedShowsQueries.followedShows().executeAsList().map { it.show_id.id }

--- a/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepositoryTest.kt
+++ b/data/episode/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultWatchedEpisodeSyncRepositoryTest.kt
@@ -10,6 +10,7 @@ import com.thomaskioko.tvmaniac.db.Id
 import com.thomaskioko.tvmaniac.db.ShowId
 import com.thomaskioko.tvmaniac.episodes.api.EpisodeWatchesDataSource
 import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeEntry
+import com.thomaskioko.tvmaniac.episodes.api.WatchedEpisodeSyncOperation
 import com.thomaskioko.tvmaniac.episodes.api.WatchedShowBatch
 import com.thomaskioko.tvmaniac.episodes.api.WatchedShowMetadata
 import com.thomaskioko.tvmaniac.episodes.implementation.dao.DefaultEpisodesDao
@@ -117,6 +118,43 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun `should send a removal then an add and settle the row given a pending update`() = runTest {
+        addPendingUpdate(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L)
+
+        defaultWatchedEpisodeSyncRepository.syncPendingEpisodes()
+
+        recordingDataSource.operations shouldContainExactly listOf("remove", "add")
+        readRow(seasonNumber = 1L, episodeNumber = 1L)
+            .shouldNotBeNull()
+            .pending_action shouldBe WatchedEpisodeSyncOperation.NOTHING.value
+    }
+
+    @Test
+    fun `should leave the update outstanding given the add fails after the removal lands`() = runTest {
+        addPendingUpdate(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L)
+        recordingDataSource.addError = IllegalStateException("Simkl: failed to add episode history")
+
+        shouldThrow<IllegalStateException> {
+            defaultWatchedEpisodeSyncRepository.syncPendingEpisodes()
+        }
+
+        recordingDataSource.operations shouldContainExactly listOf("remove", "add")
+        readRow(seasonNumber = 1L, episodeNumber = 1L)
+            .shouldNotBeNull()
+            .pending_action shouldBe WatchedEpisodeSyncOperation.UPDATE.value
+    }
+
+    @Test
+    fun `should defer the bulk pull given an update is outstanding`() = runTest {
+        addPendingUpdate(seasonNumber = 1L, episodeNumber = 1L, traktId = 555L)
+
+        defaultWatchedEpisodeSyncRepository.syncAllWatchedEpisodes(forceRefresh = true)
+
+        recordingDataSource.operations shouldContainExactly listOf("remove", "add")
+        recordingDataSource.getAllWatchedShowsCalls.shouldBeEmpty()
+    }
+
+    @Test
     fun `should upload pending entries exactly once given concurrent pending pushes`() = runTest {
         addPendingUpload(seasonNumber = 1L, episodeNumber = 1L)
 
@@ -125,7 +163,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
         advanceUntilIdle()
 
         recordingDataSource.uploaded.size shouldBe 1
-        readRow(seasonNumber = 1L, episodeNumber = 1L).shouldNotBeNull().pending_action shouldBe PendingAction.NOTHING.value
+        readRow(seasonNumber = 1L, episodeNumber = 1L).shouldNotBeNull().pending_action shouldBe WatchedEpisodeSyncOperation.NOTHING.value
     }
 
     @Test
@@ -390,7 +428,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
             watched_at = fakeDateTimeProvider.nowMillis(),
             trakt_id = null,
             synced_at = null,
-            pending_action = PendingAction.UPLOAD.value,
+            pending_action = WatchedEpisodeSyncOperation.UPLOAD.value,
         )
     }
 
@@ -407,7 +445,24 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
             watched_at = fakeDateTimeProvider.nowMillis(),
             trakt_id = traktId,
             synced_at = traktId?.let { fakeDateTimeProvider.nowMillis() },
-            pending_action = PendingAction.DELETE.value,
+            pending_action = WatchedEpisodeSyncOperation.DELETE.value,
+        )
+    }
+
+    private fun addPendingUpdate(
+        seasonNumber: Long,
+        episodeNumber: Long,
+        traktId: Long?,
+    ) {
+        database.watchedEpisodesQueries.upsertFromTrakt(
+            show_id = showId,
+            episode_id = null,
+            season_number = seasonNumber,
+            episode_number = episodeNumber,
+            watched_at = fakeDateTimeProvider.nowMillis(),
+            trakt_id = traktId,
+            synced_at = traktId?.let { fakeDateTimeProvider.nowMillis() },
+            pending_action = WatchedEpisodeSyncOperation.UPDATE.value,
         )
     }
 
@@ -420,7 +475,7 @@ internal class DefaultWatchedEpisodeSyncRepositoryTest : BaseDatabaseTest() {
             watched_at = PAST_MILLIS,
             trakt_id = traktId,
             synced_at = PAST_MILLIS,
-            pending_action = PendingAction.NOTHING.value,
+            pending_action = WatchedEpisodeSyncOperation.NOTHING.value,
         )
     }
 
@@ -659,6 +714,14 @@ private class RecordingEpisodeWatchesDataSource : EpisodeWatchesDataSource {
 
     private val _getShowEpisodeWatchesCalls = mutableListOf<Long>()
     val getShowEpisodeWatchesCalls: List<Long> get() = _getShowEpisodeWatchesCalls.toList()
+
+    private val _operations = mutableListOf<String>()
+    val operations: List<String> get() = _operations.toList()
+
+    private val _getAllWatchedShowsCalls = mutableListOf<Int>()
+    val getAllWatchedShowsCalls: List<Int> get() = _getAllWatchedShowsCalls.toList()
+
+    var addError: Throwable? = null
     var showWatchesToReturn: List<WatchedEpisodeEntry> = emptyList()
     var batchesToReturn: List<WatchedShowBatch> = emptyList()
     var metadataToReturn: List<WatchedShowMetadata> = emptyList()
@@ -678,15 +741,19 @@ private class RecordingEpisodeWatchesDataSource : EpisodeWatchesDataSource {
     }
 
     override suspend fun getAllWatchedShows(page: Int, limit: Int): List<WatchedShowBatch> {
+        _getAllWatchedShowsCalls += page
         val offset = (page - 1) * limit
         return batchesToReturn.drop(offset).take(limit)
     }
 
     override suspend fun addEpisodeEntries(entries: List<WatchedEpisodeEntry>) {
         yield()
+        _operations += "add"
+        addError?.let { throw it }
         _uploaded += entries
     }
     override suspend fun removeEpisodeEntries(entries: List<WatchedEpisodeEntry>) {
+        _operations += "remove"
         _removed += entries.map { it.seasonNumber to it.episodeNumber }
     }
 }


### PR DESCRIPTION
## Description
This PR sends a changed watched date to Trakt and Simkl as a removal followed by an add.

## Changes
- Record a date change as its own pending operation, so a pull cannot overwrite or delete the row before the change is sent
- Send the removal and the add for the same episodes, and leave the change waiting for the next cycle when either call fails
- Hold the bulk pull for a cycle while a date change is waiting, as it already does for deletes
- Scope the watched episode pending values to their own type, in place of the one shared with followed shows, ratings and Trakt lists
- Merge the two copies of the entry construction in the sync path into one
