### PR TITLE
feat: Add mark show as watched to the show header on iOS

### DIFF
--- a/ios/Packages/ShowDetails/Sources/ShowDetails/Sections/ShowDetailsHeaderSection.swift
+++ b/ios/Packages/ShowDetails/Sources/ShowDetails/Sections/ShowDetailsHeaderSection.swift
@@ -26,6 +26,8 @@ struct ShowDetailsHeaderSection: View {
             rateLabel: String(\.label_action_rate),
             watchAgainLabel: String(\.label_action_watch_again),
             canWatchAgain: state.canWatchAgain,
+            markShowWatchedLabel: state.markShowWatchedLabel,
+            canMarkShowWatched: state.canMarkShowWatched,
             userRating: state.userRating as? Int,
             onAddToLibrary: {
                 presenter.dispatch(action: ShowDetailsFollowClicked(isInLibrary: state.isInLibrary))
@@ -38,6 +40,9 @@ struct ShowDetailsHeaderSection: View {
             },
             onWatchAgain: {
                 presenter.dispatch(action: WatchAgainClicked())
+            },
+            onMarkShowWatched: {
+                presenter.dispatch(action: MarkShowWatchedClicked())
             }
         )
         .alert(
@@ -59,6 +64,26 @@ struct ShowDetailsHeaderSection: View {
             }
         } message: {
             Text(String(\.label_watch_again_confirm_message, parameter: state.title))
+        }
+        .alert(
+            state.markShowWatchedTitle,
+            isPresented: Binding(
+                get: { state.showMarkShowWatchedConfirmation },
+                set: { isPresented in
+                    if !isPresented {
+                        presenter.dispatch(action: MarkShowWatchedDismissed())
+                    }
+                }
+            )
+        ) {
+            Button(String(\.dialog_button_yes)) {
+                presenter.dispatch(action: MarkShowWatchedConfirmed())
+            }
+            Button(String(\.dialog_button_no), role: .cancel) {
+                presenter.dispatch(action: MarkShowWatchedDismissed())
+            }
+        } message: {
+            Text(state.markShowWatchedMessage)
         }
     }
 }

--- a/ios/Packages/ShowDetails/Sources/ShowDetails/ShowInfoView.swift
+++ b/ios/Packages/ShowDetails/Sources/ShowDetails/ShowInfoView.swift
@@ -17,11 +17,14 @@ public struct ShowInfoView: View {
     private let rateLabel: String
     private let watchAgainLabel: String
     private let canWatchAgain: Bool
+    private let markShowWatchedLabel: String
+    private let canMarkShowWatched: Bool
     private let userRating: Int?
     private let onAddToLibrary: () -> Void
     private let onAddToCustomList: () -> Void
     private let onRate: () -> Void
     private let onWatchAgain: () -> Void
+    private let onMarkShowWatched: () -> Void
 
     public init(
         isFollowed: Bool,
@@ -35,11 +38,14 @@ public struct ShowInfoView: View {
         rateLabel: String,
         watchAgainLabel: String,
         canWatchAgain: Bool = false,
+        markShowWatchedLabel: String = "",
+        canMarkShowWatched: Bool = false,
         userRating: Int? = nil,
         onAddToLibrary: @escaping () -> Void,
         onAddToCustomList: @escaping () -> Void,
         onRate: @escaping () -> Void,
-        onWatchAgain: @escaping () -> Void = {}
+        onWatchAgain: @escaping () -> Void = {},
+        onMarkShowWatched: @escaping () -> Void = {}
     ) {
         self.isFollowed = isFollowed
         self.canAddToList = canAddToList
@@ -52,11 +58,14 @@ public struct ShowInfoView: View {
         self.rateLabel = rateLabel
         self.watchAgainLabel = watchAgainLabel
         self.canWatchAgain = canWatchAgain
+        self.markShowWatchedLabel = markShowWatchedLabel
+        self.canMarkShowWatched = canMarkShowWatched
         self.userRating = userRating
         self.onAddToLibrary = onAddToLibrary
         self.onAddToCustomList = onAddToCustomList
         self.onRate = onRate
         self.onWatchAgain = onWatchAgain
+        self.onMarkShowWatched = onMarkShowWatched
     }
 
     public var body: some View {
@@ -108,6 +117,12 @@ public struct ShowInfoView: View {
                 Label(rateLabel, systemImage: userRating != nil ? "star.fill" : "star")
             }
 
+            if canMarkShowWatched {
+                Button(action: onMarkShowWatched) {
+                    Label(markShowWatchedLabel, systemImage: "checklist.checked")
+                }
+            }
+
             if canWatchAgain {
                 Button(action: onWatchAgain) {
                     Label(watchAgainLabel, systemImage: "arrow.counterclockwise")
@@ -129,6 +144,30 @@ public struct ShowInfoView: View {
         static let moreWidth: CGFloat = 44
         static let moreHeight: CGFloat = 35
     }
+}
+
+#Preview("Followed — Mark show as watched offered") {
+    ShowInfoView(
+        isFollowed: true,
+        canAddToList: true,
+        isInList: false,
+        genres: [.init(name: "Sci-Fi"), .init(name: "Horror"), .init(name: "Action")],
+        trackLabel: "Track",
+        stopTrackingLabel: "Stop Tracking",
+        listActionLabel: "Add To List",
+        moreLabel: "More",
+        rateLabel: "Rate",
+        watchAgainLabel: "Watch again",
+        markShowWatchedLabel: "Mark show as watched",
+        canMarkShowWatched: true,
+        onAddToLibrary: {},
+        onAddToCustomList: {},
+        onRate: {},
+        onWatchAgain: {},
+        onMarkShowWatched: {}
+    )
+    .padding()
+    .appPreview(LightTheme())
 }
 
 #Preview("Followed — Add to List shown") {


### PR DESCRIPTION
## Description
This PR adds a mark show as watched item to the show header on iOS, which asks how many episodes it will mark before opening the watch date sheet.
