### PR TITLE
fix: Keep tracked shows and watch history when logging out

### DIFF
--- a/data/logout/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/logout/api/LogoutHandler.kt
+++ b/data/logout/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/logout/api/LogoutHandler.kt
@@ -1,5 +1,7 @@
 package com.thomaskioko.tvmaniac.data.logout.api
 
 public interface LogoutHandler {
-    public suspend fun clear()
+    public suspend fun clearAccountData()
+
+    public suspend fun clearAccountAndTrackingData()
 }

--- a/data/logout/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/logout/implementation/DefaultLogoutHandler.kt
+++ b/data/logout/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/logout/implementation/DefaultLogoutHandler.kt
@@ -30,27 +30,47 @@ public class DefaultLogoutHandler(
     private val transactionRunner: DatabaseTransactionRunner,
 ) : LogoutHandler {
 
-    override suspend fun clear() {
+    override suspend fun clearAccountData() {
+        clearAccountState()
+
+        transactionRunner {
+            deleteAccountTables()
+        }
+    }
+
+    override suspend fun clearAccountAndTrackingData() {
+        clearAccountState()
+
+        transactionRunner {
+            deleteAccountTables()
+            deleteTrackingTables()
+        }
+    }
+
+    private suspend fun clearAccountState() {
         syncCoroutineScope.cancelActiveWork()
 
         userRepository.clearUserData()
         traktActivityRepository.clearAllActivities()
         syncRepository.clearAll()
         requestManagerRepository.deleteAll()
+    }
 
-        transactionRunner {
-            database.watchedEpisodesQueries.deleteAll()
-            database.watchedShowSyncLogQueries.deleteAll()
-            database.followedShowsQueries.deleteAll()
-            database.continueWatchingQueries.deleteAll()
-            database.favoritesQueries.deleteAll()
-            database.traktListShowsQueries.deleteAll()
-            database.traktListsQueries.deleteAll()
-            database.showWatchStatusQueries.deleteAll()
-            database.calendarQueries.deleteAll()
-            ratingsDao.clearAll()
-            providerMetaDao.clearAll()
-            rewatchSessionDao.clearAll()
-        }
+    private fun deleteAccountTables() {
+        database.watchedShowSyncLogQueries.deleteAll()
+        database.favoritesQueries.deleteAll()
+        database.traktListShowsQueries.deleteAll()
+        database.traktListsQueries.deleteAll()
+        database.calendarQueries.deleteAll()
+        providerMetaDao.clearAll()
+    }
+
+    private fun deleteTrackingTables() {
+        database.watchedEpisodesQueries.deleteAll()
+        database.followedShowsQueries.deleteAll()
+        database.continueWatchingQueries.deleteAll()
+        database.showWatchStatusQueries.deleteAll()
+        ratingsDao.clearAll()
+        rewatchSessionDao.clearAll()
     }
 }

--- a/data/logout/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/logout/implementation/DefaultLogoutHandlerTest.kt
+++ b/data/logout/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/logout/implementation/DefaultLogoutHandlerTest.kt
@@ -18,7 +18,10 @@ import com.thomaskioko.tvmaniac.requestmanager.testing.FakeRequestManagerReposit
 import com.thomaskioko.tvmaniac.syncactivity.testing.FakeActivitySyncRepository
 import com.thomaskioko.tvmaniac.syncactivity.testing.FakeTraktActivityRepository
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
@@ -85,15 +88,57 @@ internal class DefaultLogoutHandlerTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun `should empty watched_episodes given clear called`() = runTest(testDispatcher) {
-        cleaner.clear()
+    fun `should keep watched episodes given the user logs out`() = runTest(testDispatcher) {
+        cleaner.clearAccountData()
 
-        database.watchedEpisodesQueries.getWatchedEpisodes(showIdForBreakingBad).executeAsList().shouldBeEmpty()
+        database.watchedEpisodesQueries.getWatchedEpisodes(showIdForBreakingBad).executeAsList() shouldHaveSize 2
     }
 
     @Test
-    fun `should empty watched_show_sync_log given clear called`() = runTest(testDispatcher) {
-        cleaner.clear()
+    fun `should keep pending uploads given the user logs out`() = runTest(testDispatcher) {
+        cleaner.clearAccountData()
+
+        database.watchedEpisodesQueries.countPendingActions().executeAsOne() shouldBe 1L
+    }
+
+    @Test
+    fun `should keep followed shows given the user logs out`() = runTest(testDispatcher) {
+        cleaner.clearAccountData()
+
+        database.followedShowsQueries.countEntries().executeAsOne() shouldBe 1L
+    }
+
+    @Test
+    fun `should keep continue watching given the user logs out`() = runTest(testDispatcher) {
+        cleaner.clearAccountData()
+
+        database.continueWatchingQueries.entries().executeAsList().shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `should keep watch status given the user logs out`() = runTest(testDispatcher) {
+        cleaner.clearAccountData()
+
+        database.showWatchStatusQueries.statusForShow(showIdForBreakingBad).executeAsOneOrNull().shouldNotBeNull()
+    }
+
+    @Test
+    fun `should keep user ratings given the user logs out`() = runTest(testDispatcher) {
+        cleaner.clearAccountData()
+
+        database.ratingsQueries.observeShowRating(showIdForBreakingBad).executeAsOneOrNull().shouldNotBeNull()
+    }
+
+    @Test
+    fun `should keep rewatch sessions given the user logs out`() = runTest(testDispatcher) {
+        cleaner.clearAccountData()
+
+        database.rewatchQueries.sessionsForShow(showIdForBreakingBad).executeAsList().shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `should clear watched show sync log given the user logs out`() = runTest(testDispatcher) {
+        cleaner.clearAccountData()
 
         database.watchedShowSyncLogQueries
             .getRemoteUpdatedAt(showIdForBreakingBad, "TRAKT")
@@ -102,128 +147,141 @@ internal class DefaultLogoutHandlerTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun `should empty followed_shows given clear called`() = runTest(testDispatcher) {
-        cleaner.clear()
-
-        database.followedShowsQueries.countEntries().executeAsOne() shouldBe 0L
-    }
-
-    @Test
-    fun `should empty continue_watching given clear called`() = runTest(testDispatcher) {
-        cleaner.clear()
-
-        database.continueWatchingQueries.entries().executeAsList().shouldBeEmpty()
-    }
-
-    @Test
-    fun `should empty favorite_shows given clear called`() = runTest(testDispatcher) {
-        cleaner.clear()
+    fun `should clear favorite shows given the user logs out`() = runTest(testDispatcher) {
+        cleaner.clearAccountData()
 
         database.favoritesQueries.favoriteShows().executeAsList().shouldBeEmpty()
     }
 
     @Test
-    fun `should empty trakt_list_shows given clear called`() = runTest(testDispatcher) {
-        cleaner.clear()
+    fun `should clear trakt lists given the user logs out`() = runTest(testDispatcher) {
+        cleaner.clearAccountData()
 
+        database.traktListsQueries.selectAll().executeAsList().shouldBeEmpty()
         database.traktListShowsQueries.countActiveByListId().executeAsList().shouldBeEmpty()
     }
 
     @Test
-    fun `should empty trakt_lists given clear called`() = runTest(testDispatcher) {
-        cleaner.clear()
-
-        database.traktListsQueries.selectAll().executeAsList().shouldBeEmpty()
-    }
-
-    @Test
-    fun `should empty show_watch_status given clear called`() = runTest(testDispatcher) {
-        cleaner.clear()
-
-        database.showWatchStatusQueries.statusForShow(showIdForBreakingBad).executeAsOneOrNull().shouldBeNull()
-    }
-
-    @Test
-    fun `should empty calendar_entry given clear called`() = runTest(testDispatcher) {
-        cleaner.clear()
+    fun `should clear calendar entries given the user logs out`() = runTest(testDispatcher) {
+        cleaner.clearAccountData()
 
         database.calendarQueries.hasEntriesInRange(0L, Long.MAX_VALUE).executeAsOne() shouldBe false
     }
 
     @Test
-    fun `should empty show_ratings given clear called`() = runTest(testDispatcher) {
-        cleaner.clear()
+    fun `should clear provider metadata given the user logs out`() = runTest(testDispatcher) {
+        cleaner.clearAccountData()
+
+        database.tvshowProviderMetaQueries
+            .providerRating(showIdForBreakingBad, Provider.TRAKT)
+            .executeAsOneOrNull()
+            .shouldBeNull()
+    }
+
+    @Test
+    fun `should clear the current account given the user logs out`() = runTest(testDispatcher) {
+        cleaner.clearAccountData()
+
+        fakeUserRepository.getCurrentUser().shouldBeNull()
+    }
+
+    @Test
+    fun `should clear trakt activity given the user logs out`() = runTest(testDispatcher) {
+        cleaner.clearAccountData()
+
+        fakeTraktActivityRepository.clearAllInvocationCount() shouldBe 1
+    }
+
+    @Test
+    fun `should clear activity sync given the user logs out`() = runTest(testDispatcher) {
+        cleaner.clearAccountData()
+
+        fakeActivitySyncRepository.clearAllCallCount() shouldBe 1
+    }
+
+    @Test
+    fun `should cancel in-flight sync work given the user logs out`() = runTest(testDispatcher) {
+        val job = syncCoroutineScope.scope.launch { awaitCancellation() }
+        job.isActive shouldBe true
+
+        cleaner.clearAccountData()
+
+        job.isCancelled shouldBe true
+    }
+
+    @Test
+    fun `should clear watched episodes given the user switches accounts`() = runTest(testDispatcher) {
+        cleaner.clearAccountAndTrackingData()
+
+        database.watchedEpisodesQueries.getWatchedEpisodes(showIdForBreakingBad).executeAsList().shouldBeEmpty()
+    }
+
+    @Test
+    fun `should clear followed shows given the user switches accounts`() = runTest(testDispatcher) {
+        cleaner.clearAccountAndTrackingData()
+
+        database.followedShowsQueries.countEntries().executeAsOne() shouldBe 0L
+    }
+
+    @Test
+    fun `should clear continue watching given the user switches accounts`() = runTest(testDispatcher) {
+        cleaner.clearAccountAndTrackingData()
+
+        database.continueWatchingQueries.entries().executeAsList().shouldBeEmpty()
+    }
+
+    @Test
+    fun `should clear watch status given the user switches accounts`() = runTest(testDispatcher) {
+        cleaner.clearAccountAndTrackingData()
+
+        database.showWatchStatusQueries.statusForShow(showIdForBreakingBad).executeAsOneOrNull().shouldBeNull()
+    }
+
+    @Test
+    fun `should clear show ratings given the user switches accounts`() = runTest(testDispatcher) {
+        cleaner.clearAccountAndTrackingData()
 
         database.ratingsQueries.showRatingsWithUploadPendingAction().executeAsList().shouldBeEmpty()
         database.ratingsQueries.observeShowRating(showIdForBreakingBad).executeAsOneOrNull().shouldBeNull()
     }
 
     @Test
-    fun `should empty season_ratings and episode_ratings given clear called`() = runTest(testDispatcher) {
-        cleaner.clear()
+    fun `should clear season and episode ratings given the user switches accounts`() = runTest(testDispatcher) {
+        cleaner.clearAccountAndTrackingData()
 
         database.ratingsQueries.seasonRatingsWithUploadPendingAction().executeAsList().shouldBeEmpty()
         database.ratingsQueries.episodeRatingsWithUploadPendingAction().executeAsList().shouldBeEmpty()
     }
 
     @Test
-    fun `should empty rewatch_session given clear called`() = runTest(testDispatcher) {
-        cleaner.clear()
+    fun `should clear rewatch sessions given the user switches accounts`() = runTest(testDispatcher) {
+        cleaner.clearAccountAndTrackingData()
 
         database.rewatchQueries.sessionsForShow(showIdForBreakingBad).executeAsList().shouldBeEmpty()
     }
 
     @Test
-    fun `should reset the rewatch count given clear called`() = runTest(testDispatcher) {
-        cleaner.clear()
+    fun `should reset the rewatch count given the user switches accounts`() = runTest(testDispatcher) {
+        cleaner.clearAccountAndTrackingData()
 
         rewatchSessionDao.observeEpisodeRewatches(REWATCHED_EPISODE_ID).first() shouldBe 0L
     }
 
     @Test
-    fun `should empty tvshow_provider_meta given clear called`() = runTest(testDispatcher) {
-        cleaner.clear()
+    fun `should clear favorites lists and calendar given the user switches accounts`() = runTest(testDispatcher) {
+        cleaner.clearAccountAndTrackingData()
 
-        database.tvshowProviderMetaQueries.providerRating(showIdForBreakingBad, Provider.TRAKT).executeAsOneOrNull().shouldBeNull()
+        database.favoritesQueries.favoriteShows().executeAsList().shouldBeEmpty()
+        database.traktListsQueries.selectAll().executeAsList().shouldBeEmpty()
+        database.calendarQueries.hasEntriesInRange(0L, Long.MAX_VALUE).executeAsOne() shouldBe false
     }
 
     @Test
-    fun `should preserve tvshow catalog rows given clear called`() = runTest(testDispatcher) {
-        cleaner.clear()
+    fun `should keep tvshow catalog rows given the user switches accounts`() = runTest(testDispatcher) {
+        cleaner.clearAccountAndTrackingData()
 
         database.tvShowQueries.getShowIdByTmdbId(Id<TmdbId>(BREAKING_BAD_TMDB_ID)).executeAsOneOrNull() shouldBe showIdForBreakingBad
         database.tvShowQueries.getShowIdByTmdbId(Id<TmdbId>(THE_WIRE_TMDB_ID)).executeAsOneOrNull() shouldBe showIdForTheWire
-    }
-
-    @Test
-    fun `should cancel in-flight sync work given clear called`() = runTest(testDispatcher) {
-        val job = syncCoroutineScope.scope.launch { awaitCancellation() }
-        job.isActive shouldBe true
-
-        cleaner.clear()
-
-        job.isCancelled shouldBe true
-    }
-
-    @Test
-    fun `should clear user data given clear called`() = runTest(testDispatcher) {
-        cleaner.clear()
-
-        fakeUserRepository.getCurrentUser().shouldBeNull()
-    }
-
-    @Test
-    fun `should clear trakt activity given clear called`() = runTest(testDispatcher) {
-        cleaner.clear()
-
-        fakeTraktActivityRepository.clearAllInvocationCount() shouldBe 1
-    }
-
-    @Test
-    fun `should clear activity sync given clear called`() = runTest(testDispatcher) {
-        cleaner.clear()
-
-        fakeActivitySyncRepository.clearAllCallCount() shouldBe 1
     }
 
     private fun addUserState() {
@@ -236,6 +294,15 @@ internal class DefaultLogoutHandlerTest : BaseDatabaseTest() {
             1L,
             now,
             PendingAction.NOTHING.value,
+        )
+
+        database.watchedEpisodesQueries.upsert(
+            showIdForBreakingBad,
+            null,
+            1L,
+            2L,
+            now,
+            PendingAction.UPLOAD.value,
         )
 
         database.watchedShowSyncLogQueries.upsert(

--- a/data/logout/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/logout/testing/FakeLogoutHandler.kt
+++ b/data/logout/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/logout/testing/FakeLogoutHandler.kt
@@ -4,10 +4,17 @@ import com.thomaskioko.tvmaniac.data.logout.api.LogoutHandler
 
 public class FakeLogoutHandler : LogoutHandler {
 
-    public var cleared: Boolean = false
+    public var accountDataCleared: Boolean = false
         private set
 
-    override suspend fun clear() {
-        cleared = true
+    public var accountAndTrackingDataCleared: Boolean = false
+        private set
+
+    override suspend fun clearAccountData() {
+        accountDataCleared = true
+    }
+
+    override suspend fun clearAccountAndTrackingData() {
+        accountAndTrackingDataCleared = true
     }
 }

--- a/domain/account-switcher/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/accountswitcher/SwitchAccountInteractor.kt
+++ b/domain/account-switcher/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/accountswitcher/SwitchAccountInteractor.kt
@@ -22,7 +22,7 @@ public class SwitchAccountInteractor(
         accountManager.accounts.first()
             .filter { it.isConnected && it.provider != params }
             .forEach { accountManager.logout(it.provider) }
-        logoutHandler.clear()
+        logoutHandler.clearAccountAndTrackingData()
         accountManager.setActive(params)
         appScopeLauncher.launch(RESYNC_TAG) {
             resyncProfile()

--- a/domain/account-switcher/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/accountswitcher/SwitchAccountInteractorTest.kt
+++ b/domain/account-switcher/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/accountswitcher/SwitchAccountInteractorTest.kt
@@ -31,17 +31,18 @@ internal class SwitchAccountInteractorTest {
     )
 
     @Test
-    fun `should clear state and set new provider given switch`() = runTest {
+    fun `should clear state and set the new provider given the user switches accounts`() = runTest {
         accountManager.setActiveProvider(SyncProviderSource.TRAKT)
 
         buildInteractor(backgroundScope).executeSync(SyncProviderSource.SIMKL)
 
-        logoutHandler.cleared shouldBe true
+        logoutHandler.accountAndTrackingDataCleared shouldBe true
+        logoutHandler.accountDataCleared shouldBe false
         accountManager.getActiveProvider() shouldBe SyncProviderSource.SIMKL
     }
 
     @Test
-    fun `should run all resync interactors given switch`() = runTest {
+    fun `should run every resync interactor given the user switches accounts`() = runTest {
         accountManager.setActiveProvider(SyncProviderSource.TRAKT)
 
         buildInteractor(backgroundScope).executeSync(SyncProviderSource.SIMKL)
@@ -53,7 +54,7 @@ internal class SwitchAccountInteractorTest {
     }
 
     @Test
-    fun `should logout old provider before clear given active provider exists`() = runTest {
+    fun `should log out of the old provider before clearing given one is connected`() = runTest {
         accountManager.setActiveProvider(SyncProviderSource.TRAKT)
         accountManager.setAccounts(
             listOf(ConnectedAccount(provider = SyncProviderSource.TRAKT, isConnected = true, isActive = true)),
@@ -65,7 +66,7 @@ internal class SwitchAccountInteractorTest {
     }
 
     @Test
-    fun `should not logout given no active provider on first activation`() = runTest {
+    fun `should not log out given no provider is connected on first activation`() = runTest {
         accountManager.setActiveProvider(null)
 
         buildInteractor(backgroundScope).executeSync(SyncProviderSource.SIMKL)
@@ -75,7 +76,7 @@ internal class SwitchAccountInteractorTest {
     }
 
     @Test
-    fun `should execute in order logout then clear then setActive then resync given switch`() = runTest {
+    fun `should log out then clear then activate then resync given the user switches accounts`() = runTest {
         accountManager.setActiveProvider(SyncProviderSource.TRAKT)
         accountManager.setAccounts(
             listOf(ConnectedAccount(provider = SyncProviderSource.TRAKT, isConnected = true, isActive = true)),
@@ -84,8 +85,12 @@ internal class SwitchAccountInteractorTest {
 
         val interactor = SwitchAccountInteractor(
             logoutHandler = object : LogoutHandler {
-                override suspend fun clear() {
-                    events.add("clear")
+                override suspend fun clearAccountData() {
+                    events.add("clearAccountData")
+                }
+
+                override suspend fun clearAccountAndTrackingData() {
+                    events.add("clearAccountAndTrackingData")
                 }
             },
             accountManager = object : AccountManager by accountManager {
@@ -110,7 +115,7 @@ internal class SwitchAccountInteractorTest {
 
         events shouldBe listOf(
             "logout:TRAKT",
-            "clear",
+            "clearAccountAndTrackingData",
             "setActive:SIMKL",
             "resyncProfile",
             "resyncLibrary",

--- a/domain/logout/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/logout/LogoutInteractor.kt
+++ b/domain/logout/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/logout/LogoutInteractor.kt
@@ -20,6 +20,6 @@ public class LogoutInteractor(
         datastoreRepository.saveLastTraktUserId(currentUser?.slug)
 
         accountManager.getActiveProvider()?.let { accountManager.logout(it) }
-        logoutHandler.clear()
+        logoutHandler.clearAccountData()
     }
 }

--- a/domain/logout/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/logout/LogoutInteractorTest.kt
+++ b/domain/logout/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/logout/LogoutInteractorTest.kt
@@ -39,7 +39,7 @@ internal class LogoutInteractorTest {
     )
 
     @Test
-    fun `should logout active provider given active provider is set`() = runTest(testDispatcher) {
+    fun `should log out of the active provider given one is connected`() = runTest(testDispatcher) {
         fakeAccountManager.setActiveProvider(SyncProviderSource.TRAKT)
 
         interactor.executeSync(Unit)
@@ -48,14 +48,21 @@ internal class LogoutInteractorTest {
     }
 
     @Test
-    fun `should delegate clearing to provider state cleaner given logout executed`() = runTest(testDispatcher) {
+    fun `should clear account data given the user logs out`() = runTest(testDispatcher) {
         interactor.executeSync(Unit)
 
-        fakeLogoutHandler.cleared shouldBe true
+        fakeLogoutHandler.accountDataCleared shouldBe true
     }
 
     @Test
-    fun `should not logout given no active provider`() = runTest(testDispatcher) {
+    fun `should keep tracking data given the user logs out`() = runTest(testDispatcher) {
+        interactor.executeSync(Unit)
+
+        fakeLogoutHandler.accountAndTrackingDataCleared shouldBe false
+    }
+
+    @Test
+    fun `should do nothing given no provider is connected`() = runTest(testDispatcher) {
         fakeAccountManager.setActiveProvider(null)
 
         interactor.executeSync(Unit)


### PR DESCRIPTION
## Description
This PR keeps the shows you track, your watch history, ratings, and rewatch sessions on the device when you log out of Trakt or Simkl. Switching to a different account still clears everything.