### PR TITLE
feat: Add backup and restore strings

### DIFF
--- a/i18n/generator/src/commonMain/moko-resources/base/plurals.xml
+++ b/i18n/generator/src/commonMain/moko-resources/base/plurals.xml
@@ -60,4 +60,12 @@
         <item quantity="one">This will mark %d episode as watched.</item>
         <item quantity="other">This will mark %d episodes as watched.</item>
     </plurals>
+    <plurals name="backup_shows_restored">
+        <item quantity="one">%d show restored</item>
+        <item quantity="other">%d shows restored</item>
+    </plurals>
+    <plurals name="backup_shows_skipped">
+        <item quantity="one">%d show skipped</item>
+        <item quantity="other">%d shows skipped</item>
+    </plurals>
 </resources>

--- a/i18n/generator/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/base/strings.xml
@@ -589,4 +589,23 @@
     <string name="label_watched_date_unknown_display">A long time ago</string>
     <string name="label_mark_show_watched">Mark show as watched</string>
     <string name="label_mark_show_watched_confirm_title">Mark show as watched?</string>
+
+    <string name="settings_backup_title">Backup &amp; restore</string>
+    <string name="settings_backup_description">Save your shows to a file and load them back</string>
+    <string name="settings_backup_export_title">Save a backup</string>
+    <string name="settings_backup_export_description">Write your shows, watch history, ratings and settings to a file</string>
+    <string name="settings_backup_import_title">Restore a backup</string>
+    <string name="settings_backup_import_description">Replace what is on this device with a backup file</string>
+    <string name="settings_backup_restore_confirm_title">Restore this backup?</string>
+    <string name="settings_backup_restore_confirm_message">This replaces the shows and watch history on this device. A copy of your current data is saved first.</string>
+    <string name="settings_backup_restore_confirm_message_connected">This replaces the shows and watch history on this device. %1$s remains the source of truth and the next sync will reconcile. A copy of your current data is saved first.</string>
+    <string name="settings_backup_restore_confirm_button">Restore</string>
+    <string name="settings_backup_restore_summary_title">Restore finished</string>
+    <string name="settings_backup_restore_summary_rewatch">Repeat viewings were not included in this backup</string>
+    <string name="error_backup_save_failed">Could not save the backup. Try another location.</string>
+    <string name="error_backup_read_failed">Could not read that file. It may be damaged or from another app.</string>
+    <string name="error_backup_version_too_new">This backup was made by a newer version of TvManiac. Update the app to restore it.</string>
+    <string name="error_backup_sync_in_progress">A sync is running. Wait for it to finish, then try again.</string>
+    <string name="label_backup_locked_title">Backup is a Premium feature</string>
+    <string name="label_backup_locked_message">Upgrade to Premium to save and restore your shows.</string>
 </resources>

--- a/i18n/generator/src/commonMain/moko-resources/de/plurals.xml
+++ b/i18n/generator/src/commonMain/moko-resources/de/plurals.xml
@@ -60,4 +60,12 @@
         <item quantity="one">Dadurch wird %d Folge als gesehen markiert.</item>
         <item quantity="other">Dadurch werden %d Folgen als gesehen markiert.</item>
     </plurals>
+    <plurals name="backup_shows_restored">
+        <item quantity="one">%d Serie wiederhergestellt</item>
+        <item quantity="other">%d Serien wiederhergestellt</item>
+    </plurals>
+    <plurals name="backup_shows_skipped">
+        <item quantity="one">%d Serie übersprungen</item>
+        <item quantity="other">%d Serien übersprungen</item>
+    </plurals>
 </resources>

--- a/i18n/generator/src/commonMain/moko-resources/de/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/de/strings.xml
@@ -581,4 +581,23 @@
     <string name="label_watched_date_unknown_display">Vor langer Zeit</string>
     <string name="label_mark_show_watched">Serie als gesehen markieren</string>
     <string name="label_mark_show_watched_confirm_title">Serie als gesehen markieren?</string>
+
+    <string name="settings_backup_title">Sichern &amp; Wiederherstellen</string>
+    <string name="settings_backup_description">Ihre Serien in eine Datei sichern und wieder laden</string>
+    <string name="settings_backup_export_title">Sicherung speichern</string>
+    <string name="settings_backup_export_description">Serien, Wiedergabeverlauf, Bewertungen und Einstellungen in eine Datei schreiben</string>
+    <string name="settings_backup_import_title">Sicherung wiederherstellen</string>
+    <string name="settings_backup_import_description">Die Daten auf diesem Gerät durch eine Sicherungsdatei ersetzen</string>
+    <string name="settings_backup_restore_confirm_title">Diese Sicherung wiederherstellen?</string>
+    <string name="settings_backup_restore_confirm_message">Dies ersetzt die Serien und den Wiedergabeverlauf auf diesem Gerät. Eine Kopie Ihrer aktuellen Daten wird vorher gespeichert.</string>
+    <string name="settings_backup_restore_confirm_message_connected">Dies ersetzt die Serien und den Wiedergabeverlauf auf diesem Gerät. %1$s bleibt maßgeblich und die nächste Synchronisierung gleicht die Daten ab. Eine Kopie Ihrer aktuellen Daten wird vorher gespeichert.</string>
+    <string name="settings_backup_restore_confirm_button">Wiederherstellen</string>
+    <string name="settings_backup_restore_summary_title">Wiederherstellung abgeschlossen</string>
+    <string name="settings_backup_restore_summary_rewatch">Wiederholte Ansichten waren in dieser Sicherung nicht enthalten</string>
+    <string name="error_backup_save_failed">Sicherung konnte nicht gespeichert werden. Versuchen Sie einen anderen Speicherort.</string>
+    <string name="error_backup_read_failed">Diese Datei konnte nicht gelesen werden. Sie ist möglicherweise beschädigt oder stammt aus einer anderen App.</string>
+    <string name="error_backup_version_too_new">Diese Sicherung wurde mit einer neueren Version von TvManiac erstellt. Aktualisieren Sie die App, um sie wiederherzustellen.</string>
+    <string name="error_backup_sync_in_progress">Eine Synchronisierung läuft. Warten Sie, bis sie abgeschlossen ist, und versuchen Sie es erneut.</string>
+    <string name="label_backup_locked_title">Sichern ist eine Premium-Funktion</string>
+    <string name="label_backup_locked_message">Upgraden Sie auf Premium, um Ihre Serien zu sichern und wiederherzustellen.</string>
 </resources>

--- a/i18n/generator/src/commonMain/moko-resources/fr/plurals.xml
+++ b/i18n/generator/src/commonMain/moko-resources/fr/plurals.xml
@@ -64,4 +64,12 @@
         <item quantity="one">%d épisode sera marqué comme vu.</item>
         <item quantity="other">%d épisodes seront marqués comme vus.</item>
     </plurals>
+    <plurals name="backup_shows_restored">
+        <item quantity="one">%d série restaurée</item>
+        <item quantity="other">%d séries restaurées</item>
+    </plurals>
+    <plurals name="backup_shows_skipped">
+        <item quantity="one">%d série ignorée</item>
+        <item quantity="other">%d séries ignorées</item>
+    </plurals>
 </resources>

--- a/i18n/generator/src/commonMain/moko-resources/fr/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/fr/strings.xml
@@ -575,4 +575,23 @@
     <string name="label_watched_date_unknown_display">Il y a longtemps</string>
     <string name="label_mark_show_watched">Marquer la série comme vue</string>
     <string name="label_mark_show_watched_confirm_title">Marquer la série comme vue ?</string>
+
+    <string name="settings_backup_title">Sauvegarde et restauration</string>
+    <string name="settings_backup_description">Enregistrez vos séries dans un fichier et rechargez-les</string>
+    <string name="settings_backup_export_title">Enregistrer une sauvegarde</string>
+    <string name="settings_backup_export_description">Écrire vos séries, votre historique, vos notes et vos réglages dans un fichier</string>
+    <string name="settings_backup_import_title">Restaurer une sauvegarde</string>
+    <string name="settings_backup_import_description">Remplacer les données de cet appareil par un fichier de sauvegarde</string>
+    <string name="settings_backup_restore_confirm_title">Restaurer cette sauvegarde ?</string>
+    <string name="settings_backup_restore_confirm_message">Cela remplace les séries et l\'historique de cet appareil. Une copie de vos données actuelles est enregistrée au préalable.</string>
+    <string name="settings_backup_restore_confirm_message_connected">Cela remplace les séries et l\'historique de cet appareil. %1$s reste la référence et la prochaine synchronisation mettra les données à jour. Une copie de vos données actuelles est enregistrée au préalable.</string>
+    <string name="settings_backup_restore_confirm_button">Restaurer</string>
+    <string name="settings_backup_restore_summary_title">Restauration terminée</string>
+    <string name="settings_backup_restore_summary_rewatch">Les visionnages répétés n\'étaient pas inclus dans cette sauvegarde</string>
+    <string name="error_backup_save_failed">Impossible d\'enregistrer la sauvegarde. Essayez un autre emplacement.</string>
+    <string name="error_backup_read_failed">Impossible de lire ce fichier. Il est peut-être endommagé ou provient d\'une autre application.</string>
+    <string name="error_backup_version_too_new">Cette sauvegarde a été créée avec une version plus récente de TvManiac. Mettez l\'application à jour pour la restaurer.</string>
+    <string name="error_backup_sync_in_progress">Une synchronisation est en cours. Attendez qu\'elle se termine, puis réessayez.</string>
+    <string name="label_backup_locked_title">La sauvegarde est une fonctionnalité Premium</string>
+    <string name="label_backup_locked_message">Passez à Premium pour sauvegarder et restaurer vos séries.</string>
 </resources>


### PR DESCRIPTION
## Description
This PR adds the strings the backup and restore page needs, in English, German and French. Nothing renders them yet; the presenter and platform tasks follow.
