### PR TITLE
fix: Translate the missing German and French strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,14 @@ jobs:
                     git diff --cached --quiet --exit-code -- '**/README.md' \
                       || { echo "::error::Module graphs are stale. Run ./gradlew graphUpdate and commit the updated README.md files."; exit 1; }
 
+    locale-parity:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v7
+
+            -   name: Check Locale Parity
+                run: python3 scripts/ci/check-locale-parity.py
+
     dependency-guard:
         runs-on: ubuntu-latest
         permissions:

--- a/i18n/generator/src/commonMain/moko-resources/de/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/de/strings.xml
@@ -600,4 +600,17 @@
     <string name="error_backup_sync_in_progress">Eine Synchronisierung läuft. Warten Sie, bis sie abgeschlossen ist, und versuchen Sie es erneut.</string>
     <string name="label_backup_locked_title">Sichern ist eine Premium-Funktion</string>
     <string name="label_backup_locked_message">Upgraden Sie auf Premium, um Ihre Serien zu sichern und wiederherzustellen.</string>
+
+    <string name="dialog_button_just_this">Nur diese</string>
+    <string name="dialog_button_just_this_season">Nur diese Staffel</string>
+    <string name="dialog_button_mark_all">Alle markieren</string>
+    <string name="dialog_button_mark_all_seasons">Alle Staffeln markieren</string>
+    <string name="dialog_message_episode_unwatched">Möchten Sie diese Episode wirklich als ungesehen markieren?</string>
+    <string name="dialog_title_episode_unwatched">Episode als ungesehen markieren?</string>
+    <string name="dialog_title_mark_previous">Vorherige Episoden markieren?</string>
+    <string name="dialog_title_mark_previous_seasons">Vorherige Staffeln markieren?</string>
+    <string name="menu_mark_watched">Als gesehen markieren</string>
+    <string name="menu_open_season">Staffel öffnen</string>
+    <string name="menu_open_show">Serie öffnen</string>
+    <string name="menu_unfollow_show">Nicht mehr folgen</string>
 </resources>

--- a/i18n/generator/src/commonMain/moko-resources/fr/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/fr/strings.xml
@@ -594,4 +594,21 @@
     <string name="error_backup_sync_in_progress">Une synchronisation est en cours. Attendez qu\'elle se termine, puis réessayez.</string>
     <string name="label_backup_locked_title">La sauvegarde est une fonctionnalité Premium</string>
     <string name="label_backup_locked_message">Passez à Premium pour sauvegarder et restaurer vos séries.</string>
+
+    <string name="dialog_button_just_this">Uniquement celui-ci</string>
+    <string name="dialog_button_just_this_season">Uniquement cette saison</string>
+    <string name="dialog_button_mark_all">Tout marquer</string>
+    <string name="dialog_button_mark_all_seasons">Marquer toutes les saisons</string>
+    <string name="dialog_message_episode_unwatched">Voulez-vous vraiment marquer cet épisode comme non vu ?</string>
+    <string name="dialog_title_episode_unwatched">Marquer l\'épisode comme non vu ?</string>
+    <string name="dialog_title_mark_previous">Marquer les épisodes précédents ?</string>
+    <string name="dialog_title_mark_previous_seasons">Marquer les saisons précédentes ?</string>
+    <string name="label_action_more">Plus</string>
+    <string name="label_action_watch_again">Revoir</string>
+    <string name="label_watch_again_confirm_message">Les épisodes que vous marquez à partir de maintenant comptent pour un nouveau visionnage de « %1$s ».</string>
+    <string name="label_watch_again_confirm_title">Revoir ?</string>
+    <string name="menu_mark_watched">Marquer comme vu</string>
+    <string name="menu_open_season">Ouvrir la saison</string>
+    <string name="menu_open_show">Ouvrir la série</string>
+    <string name="menu_unfollow_show">Ne plus suivre</string>
 </resources>

--- a/scripts/ci/check-locale-parity.py
+++ b/scripts/ci/check-locale-parity.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Fail when a localized resource exists in the base locale but not in every translation.
+
+moko-resources silently falls back to the base value for a missing key, so an untranslated
+string reads as English to a German or French user and nothing in the build notices. This
+compares the key sets and fails the run instead.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+RESOURCES = Path("i18n/generator/src/commonMain/moko-resources")
+BASE = "base"
+FILES = ("strings.xml", "plurals.xml")
+KEY_PATTERN = re.compile(r"<(string|plurals)\s+name=\"([^\"]+)\"")
+
+
+def keys_in(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    return [name for _, name in KEY_PATTERN.findall(path.read_text(encoding="utf-8"))]
+
+
+def locales() -> list[str]:
+    return sorted(d.name for d in RESOURCES.iterdir() if d.is_dir() and d.name != BASE)
+
+
+def main() -> int:
+    if not RESOURCES.is_dir():
+        print(f"::error::Resource directory not found: {RESOURCES}")
+        return 1
+
+    translations = locales()
+    if not translations:
+        print(f"::error::No translation locales found beside {BASE} in {RESOURCES}")
+        return 1
+
+    failed = False
+
+    for filename in FILES:
+        base_keys = keys_in(RESOURCES / BASE / filename)
+        if not base_keys:
+            print(f"::error::{BASE}/{filename} has no keys, or is missing")
+            failed = True
+            continue
+
+        duplicates = sorted({k for k in base_keys if base_keys.count(k) > 1})
+        if duplicates:
+            failed = True
+            for key in duplicates:
+                print(f"::error file={RESOURCES / BASE / filename}::Duplicate key: {key}")
+
+        for locale in translations:
+            path = RESOURCES / locale / filename
+            found = keys_in(path)
+
+            for key in sorted({k for k in found if found.count(k) > 1}):
+                failed = True
+                print(f"::error file={path}::Duplicate key: {key}")
+
+            missing = sorted(set(base_keys) - set(found))
+            for key in missing:
+                failed = True
+                print(f"::error file={path}::Missing translation for {key}")
+
+            unknown = sorted(set(found) - set(base_keys))
+            for key in unknown:
+                failed = True
+                print(f"::error file={path}::{key} is not in {BASE}/{filename}")
+
+            status = "ok" if not missing and not unknown else f"{len(missing)} missing, {len(unknown)} unknown"
+            print(f"{filename} {locale}: {status}")
+
+    if failed:
+        print("::error::Locale parity check failed. Every key in base must exist in every translation.")
+        return 1
+
+    print("Locale parity ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description
This PR translates the 12 German and 16 French strings that were still falling back to English, and adds a CI check so the next one fails the build instead of shipping.

## Changes
- Translate the remaining mark as watched, watch again and season menu strings into German and French
- Add a `locale-parity` job that fails when a key exists in the base locale but not in every translation, and that also catches duplicate and unknown keys