### PR TITLE
feat: Refill show metadata after restoring

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1103,8 +1103,12 @@ graph TB
   :domain:account-switcher --> :domain:library
   :domain:account-switcher --> :domain:user
   :domain:backup --> :core:base
+  :domain:backup --> :core:logger:api
+  :domain:backup --> :core:network-util:api
+  :domain:backup --> :core:tasks:api
   :domain:backup --> :core:view
   :domain:backup --> :data:backup:api
+  :domain:backup --> :domain:showdetails
   :domain:calendar --> :core:base
   :domain:calendar --> :core:util:api
   :domain:calendar --> :data:calendar:api

--- a/core/integration/infra/README.md
+++ b/core/integration/infra/README.md
@@ -678,8 +678,12 @@ graph TB
   :domain:account-switcher --> :domain:library
   :domain:account-switcher --> :domain:user
   :domain:backup --> :core:base
+  :domain:backup --> :core:logger:api
+  :domain:backup --> :core:network-util:api
+  :domain:backup --> :core:tasks:api
   :domain:backup --> :core:view
   :domain:backup --> :data:backup:api
+  :domain:backup --> :domain:showdetails
   :domain:continue-watching --> :core:base
   :domain:continue-watching --> :core:feature-flags:api
   :domain:continue-watching --> :core:logger:api

--- a/data/backup/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/api/BackupRepository.kt
+++ b/data/backup/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/api/BackupRepository.kt
@@ -6,4 +6,6 @@ public interface BackupRepository {
     public suspend fun writeBackup(location: String): BackupResult
 
     public suspend fun restoreBackup(location: String): RestoreResult
+
+    public suspend fun showsNeedingMetadata(): List<Long>
 }

--- a/data/backup/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/api/ShowRefillProgress.kt
+++ b/data/backup/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/api/ShowRefillProgress.kt
@@ -1,0 +1,18 @@
+package com.thomaskioko.tvmaniac.data.backup.api
+
+import kotlinx.coroutines.flow.StateFlow
+
+public data class ShowRefillProgress(
+    val completed: Int = 0,
+    val total: Int = 0,
+)
+
+public interface ShowRefillReporter {
+    public val progress: StateFlow<ShowRefillProgress>
+
+    public fun begin(total: Int)
+
+    public fun advance()
+
+    public fun clear()
+}

--- a/data/backup/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultBackupRepository.kt
+++ b/data/backup/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultBackupRepository.kt
@@ -114,6 +114,10 @@ public class DefaultBackupRepository(
         }
     }
 
+    override suspend fun showsNeedingMetadata(): List<Long> = withContext(dispatchers.databaseRead) {
+        database.restoreQueries.showsNeedingMetadata().executeAsList().map { it.id }
+    }
+
     private suspend fun readShows(): List<BackupShow> = withContext(dispatchers.databaseRead) {
         val followedAt = queries.backupFollowedShows().executeAsList()
             .associate { it.tmdb_id.id to it.followed_at }

--- a/data/backup/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultShowRefillReporter.kt
+++ b/data/backup/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultShowRefillReporter.kt
@@ -1,0 +1,32 @@
+package com.thomaskioko.tvmaniac.data.backup.implementation
+
+import com.thomaskioko.tvmaniac.data.backup.api.ShowRefillProgress
+import com.thomaskioko.tvmaniac.data.backup.api.ShowRefillReporter
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+public class DefaultShowRefillReporter : ShowRefillReporter {
+
+    private val mutableProgress = MutableStateFlow(ShowRefillProgress())
+
+    override val progress: StateFlow<ShowRefillProgress> = mutableProgress.asStateFlow()
+
+    override fun begin(total: Int) {
+        mutableProgress.value = ShowRefillProgress(completed = 0, total = total)
+    }
+
+    override fun advance() {
+        mutableProgress.update { it.copy(completed = it.completed + 1) }
+    }
+
+    override fun clear() {
+        mutableProgress.value = ShowRefillProgress()
+    }
+}

--- a/data/backup/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/testing/FakeBackupRepository.kt
+++ b/data/backup/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/testing/FakeBackupRepository.kt
@@ -25,6 +25,12 @@ public class FakeBackupRepository : BackupRepository {
     public var lastRestoreLocation: String? = null
         private set
 
+    private var showsNeedingMetadata: List<Long> = emptyList()
+
+    public fun setShowsNeedingMetadata(ids: List<Long>) {
+        showsNeedingMetadata = ids
+    }
+
     public fun setBackup(file: BackupFile) {
         backup = file
     }
@@ -56,6 +62,8 @@ public class FakeBackupRepository : BackupRepository {
         lastRestoreLocation = location
         return restoreResult
     }
+
+    override suspend fun showsNeedingMetadata(): List<Long> = showsNeedingMetadata
 }
 
 public class FakeBackupDestination : BackupDestination {

--- a/data/backup/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/testing/FakeShowRefillReporter.kt
+++ b/data/backup/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/testing/FakeShowRefillReporter.kt
@@ -1,0 +1,39 @@
+package com.thomaskioko.tvmaniac.data.backup.testing
+
+import com.thomaskioko.tvmaniac.data.backup.api.ShowRefillProgress
+import com.thomaskioko.tvmaniac.data.backup.api.ShowRefillReporter
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+public class FakeShowRefillReporter : ShowRefillReporter {
+
+    private val mutableProgress = MutableStateFlow(ShowRefillProgress())
+
+    public var beganWith: Int? = null
+        private set
+
+    public var advanceCount: Int = 0
+        private set
+
+    public var cleared: Boolean = false
+        private set
+
+    override val progress: StateFlow<ShowRefillProgress> = mutableProgress.asStateFlow()
+
+    override fun begin(total: Int) {
+        beganWith = total
+        mutableProgress.value = ShowRefillProgress(completed = 0, total = total)
+    }
+
+    override fun advance() {
+        advanceCount++
+        mutableProgress.update { it.copy(completed = it.completed + 1) }
+    }
+
+    override fun clear() {
+        cleared = true
+        mutableProgress.value = ShowRefillProgress()
+    }
+}

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Restore.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Restore.sq
@@ -88,3 +88,17 @@ LIMIT 1;
 
 rewatchSessionCount:
 SELECT COUNT(*) FROM rewatch_session;
+
+-- A restore inserts stub shows carrying only a tmdb id and a title, because the backup file holds no
+-- cached metadata. This finds the ones worth refilling: a stub the user either follows or has watch
+-- history for. A stub reached only by a rating is left alone.
+showsNeedingMetadata:
+SELECT tvshow.id
+FROM tvshow
+WHERE tvshow.overview = ''
+  AND tvshow.id IN (
+    SELECT show_id FROM followed_shows WHERE pending_action != 'DELETE'
+    UNION
+    SELECT show_id FROM watched_episodes WHERE pending_action NOT IN ('DELETE', 'SYNCED_DELETE')
+  );
+

--- a/domain/backup/README.md
+++ b/domain/backup/README.md
@@ -10,25 +10,137 @@ graph TB
     :core:base[base]:::multiplatform
     :core:view[view]:::multiplatform
   end
+  subgraph :core:connectivity
+    direction TB
+    :core:connectivity:api[api]:::multiplatform
+  end
   subgraph :core:logger
     direction TB
     :core:logger:api[api]:::multiplatform
+  end
+  subgraph :core:network-util
+    direction TB
+    :core:network-util:api[api]:::multiplatform
+  end
+  subgraph :core:tasks
+    direction TB
+    :core:tasks:api[api]:::multiplatform
+  end
+  subgraph :core:util
+    direction TB
+    :core:util:api[api]:::multiplatform
+  end
+  subgraph :data:account-manager
+    direction TB
+    :data:account-manager:api[api]:::multiplatform
   end
   subgraph :data:backup
     direction TB
     :data:backup:api[api]:::multiplatform
   end
+  subgraph :data:cast
+    direction TB
+    :data:cast:api[api]:::multiplatform
+  end
+  subgraph :data:database
+    direction TB
+    :data:database:sqldelight[sqldelight]:::multiplatform
+  end
+  subgraph :data:datastore
+    direction TB
+    :data:datastore:api[api]:::multiplatform
+  end
+  subgraph :data:episode
+    direction TB
+    :data:episode:api[api]:::multiplatform
+  end
+  subgraph :data:followedshows
+    direction TB
+    :data:followedshows:api[api]:::multiplatform
+  end
+  subgraph :data:library
+    direction TB
+    :data:library:api[api]:::multiplatform
+  end
+  subgraph :data:seasondetails
+    direction TB
+    :data:seasondetails:api[api]:::multiplatform
+  end
+  subgraph :data:seasons
+    direction TB
+    :data:seasons:api[api]:::multiplatform
+  end
+  subgraph :data:showdetails
+    direction TB
+    :data:showdetails:api[api]:::multiplatform
+  end
+  subgraph :data:similar
+    direction TB
+    :data:similar:api[api]:::multiplatform
+  end
+  subgraph :data:trailers
+    direction TB
+    :data:trailers:api[api]:::multiplatform
+  end
+  subgraph :data:upnext
+    direction TB
+    :data:upnext:api[api]:::multiplatform
+  end
+  subgraph :data:watchproviders
+    direction TB
+    :data:watchproviders:api[api]:::multiplatform
+  end
   subgraph :domain
     direction TB
     :domain:backup[backup]:::multiplatform
+    :domain:showdetails[showdetails]:::multiplatform
+  end
+  subgraph :i18n
+    direction TB
+    :i18n:generator[generator]:::multiplatform
   end
 
   :core:base --> :core:logger:api
   :core:base --> :core:view
+  :core:network-util:api --> :core:connectivity:api
   :core:view --> :core:logger:api
+  :data:account-manager:api --> :data:database:sqldelight
+  :data:cast:api --> :data:database:sqldelight
+  :data:database:sqldelight --> :core:logger:api
+  :data:datastore:api --> :i18n:generator
+  :data:episode:api --> :data:account-manager:api
+  :data:episode:api --> :data:database:sqldelight
+  :data:episode:api --> :data:followedshows:api
+  :data:episode:api --> :data:upnext:api
+  :data:library:api --> :core:network-util:api
+  :data:library:api --> :data:account-manager:api
+  :data:library:api --> :data:database:sqldelight
+  :data:library:api --> :data:datastore:api
+  :data:seasondetails:api --> :data:database:sqldelight
+  :data:seasons:api --> :data:database:sqldelight
+  :data:showdetails:api --> :data:database:sqldelight
+  :data:similar:api --> :data:database:sqldelight
+  :data:trailers:api --> :data:database:sqldelight
+  :data:watchproviders:api --> :data:database:sqldelight
   :domain:backup --> :core:base
+  :domain:backup --> :core:logger:api
+  :domain:backup --> :core:network-util:api
+  :domain:backup --> :core:tasks:api
   :domain:backup --> :core:view
   :domain:backup --> :data:backup:api
+  :domain:backup --> :domain:showdetails
+  :domain:showdetails --> :core:base
+  :domain:showdetails --> :core:util:api
+  :domain:showdetails --> :data:cast:api
+  :domain:showdetails --> :data:episode:api
+  :domain:showdetails --> :data:followedshows:api
+  :domain:showdetails --> :data:library:api
+  :domain:showdetails --> :data:seasondetails:api
+  :domain:showdetails --> :data:seasons:api
+  :domain:showdetails --> :data:showdetails:api
+  :domain:showdetails --> :data:similar:api
+  :domain:showdetails --> :data:trailers:api
+  :domain:showdetails --> :data:watchproviders:api
 
 classDef application fill:#CAFFBF,stroke:#000,stroke-width:2px,color:#000;
 classDef multiplatform fill:#FFD6A5,stroke:#000,stroke-width:2px,color:#000;

--- a/domain/backup/build.gradle.kts
+++ b/domain/backup/build.gradle.kts
@@ -12,7 +12,11 @@ kotlin {
             dependencies {
                 api(projects.core.base)
                 api(projects.core.view)
+                api(projects.core.logger.api)
+                api(projects.core.networkUtil.api)
+                api(projects.core.tasks.api)
                 api(projects.data.backup.api)
+                api(projects.domain.showdetails)
 
                 implementation(libs.coroutines.core)
             }
@@ -21,6 +25,7 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(libs.bundles.unittest)
+                implementation(projects.core.tasks.testing)
                 implementation(projects.data.backup.testing)
             }
         }

--- a/domain/backup/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/backup/RestoreBackupInteractor.kt
+++ b/domain/backup/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/backup/RestoreBackupInteractor.kt
@@ -1,6 +1,7 @@
 package com.thomaskioko.tvmaniac.domain.backup
 
 import com.thomaskioko.tvmaniac.core.base.interactor.ResultInteractor
+import com.thomaskioko.tvmaniac.core.tasks.api.BackgroundTaskScheduler
 import com.thomaskioko.tvmaniac.data.backup.api.BackupRepository
 import com.thomaskioko.tvmaniac.data.backup.api.RestoreResult
 import dev.zacsweers.metro.Inject
@@ -8,9 +9,16 @@ import dev.zacsweers.metro.Inject
 @Inject
 public class RestoreBackupInteractor(
     private val backupRepository: BackupRepository,
+    private val taskScheduler: BackgroundTaskScheduler,
 ) : ResultInteractor<RestoreBackupInteractor.Params, RestoreResult>() {
 
     public data class Params(val location: String)
 
-    override suspend fun doWork(params: Params): RestoreResult = backupRepository.restoreBackup(params.location)
+    override suspend fun doWork(params: Params): RestoreResult {
+        val result = backupRepository.restoreBackup(params.location)
+        if (result is RestoreResult.Restored) {
+            taskScheduler.scheduleAndExecute(RestoredShowsRefillWorker.REQUEST)
+        }
+        return result
+    }
 }

--- a/domain/backup/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/backup/RestoredShowsRefillWorker.kt
+++ b/domain/backup/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/backup/RestoredShowsRefillWorker.kt
@@ -1,0 +1,45 @@
+package com.thomaskioko.tvmaniac.domain.backup
+
+import com.thomaskioko.tvmaniac.core.logger.Logger
+import com.thomaskioko.tvmaniac.core.tasks.api.BackgroundWorker
+import com.thomaskioko.tvmaniac.core.tasks.api.PeriodicTaskRequest
+import com.thomaskioko.tvmaniac.core.tasks.api.TaskConstraints
+import com.thomaskioko.tvmaniac.core.tasks.api.WorkerResult
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoSet
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.CancellationException
+
+@SingleIn(AppScope::class)
+@ContributesIntoSet(AppScope::class)
+public class RestoredShowsRefillWorker(
+    private val syncRestoredShowsInteractor: Lazy<SyncRestoredShowsInteractor>,
+    private val logger: Logger,
+) : BackgroundWorker {
+
+    override val workerName: String = WORKER_NAME
+
+    override suspend fun doWork(): WorkerResult = try {
+        syncRestoredShowsInteractor.value.executeSync(Unit)
+        WorkerResult.Success
+    } catch (cancellation: CancellationException) {
+        logger.debug(TAG, "Metadata refill cancelled: ${cancellation.message}")
+        WorkerResult.Retry("Cancelled, will retry")
+    } catch (cause: Exception) {
+        logger.error(TAG, "Metadata refill failed: ${cause.message}")
+        WorkerResult.Failure(cause.message)
+    }
+
+    public companion object {
+        public const val WORKER_NAME: String = "com.thomaskioko.tvmaniac.showrefill"
+        private const val TAG = "RestoredShowsRefillWorker"
+        private const val TWELVE_HOURS_MS = 12L * 60 * 60 * 1000
+
+        public val REQUEST: PeriodicTaskRequest = PeriodicTaskRequest(
+            id = WORKER_NAME,
+            intervalMs = TWELVE_HOURS_MS,
+            constraints = TaskConstraints(requiresNetwork = true),
+            longRunning = true,
+        )
+    }
+}

--- a/domain/backup/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/backup/SyncRestoredShowsInteractor.kt
+++ b/domain/backup/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/backup/SyncRestoredShowsInteractor.kt
@@ -1,0 +1,68 @@
+package com.thomaskioko.tvmaniac.domain.backup
+
+import com.thomaskioko.tvmaniac.core.base.interactor.Interactor
+import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
+import com.thomaskioko.tvmaniac.core.logger.Logger
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.SyncError
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.toSyncError
+import com.thomaskioko.tvmaniac.data.backup.api.BackupRepository
+import com.thomaskioko.tvmaniac.data.backup.api.ShowRefillReporter
+import com.thomaskioko.tvmaniac.domain.showdetails.SyncShowMetadataInteractor
+import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+
+@Inject
+public class SyncRestoredShowsInteractor(
+    private val backupRepository: BackupRepository,
+    private val syncShowMetadataInteractor: SyncShowMetadataInteractor,
+    private val refillReporter: ShowRefillReporter,
+    private val dispatchers: AppCoroutineDispatchers,
+    private val logger: Logger,
+) : Interactor<Unit>() {
+
+    override suspend fun doWork(params: Unit) {
+        val showIds = backupRepository.showsNeedingMetadata()
+        if (showIds.isEmpty()) {
+            logger.debug(TAG, "No restored shows need metadata")
+            refillReporter.clear()
+            return
+        }
+
+        logger.debug(TAG, "Refilling metadata for ${showIds.size} restored shows")
+        refillReporter.begin(showIds.size)
+
+        withContext(dispatchers.io) {
+            for (showId in showIds) {
+                currentCoroutineContext().ensureActive()
+
+                val failure = runCatching {
+                    syncShowMetadataInteractor.executeSync(
+                        SyncShowMetadataInteractor.Param(showId = showId, forceRefresh = true),
+                    )
+                }.exceptionOrNull()
+
+                if (failure == null) {
+                    refillReporter.advance()
+                    continue
+                }
+                if (failure is CancellationException) throw failure
+
+                logger.warning(TAG, "Metadata refill failed for $showId: ${failure.message}")
+                if (failure.toSyncError() is SyncError.Retryable) {
+                    logger.warning(TAG, "Stopping metadata refill after a retryable failure on $showId")
+                    return@withContext
+                }
+                refillReporter.advance()
+            }
+        }
+
+        refillReporter.clear()
+    }
+
+    private companion object {
+        private const val TAG = "SyncRestoredShows"
+    }
+}

--- a/domain/backup/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/backup/RestoreBackupInteractorTest.kt
+++ b/domain/backup/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/backup/RestoreBackupInteractorTest.kt
@@ -1,0 +1,38 @@
+package com.thomaskioko.tvmaniac.domain.backup
+
+import com.thomaskioko.tvmaniac.core.base.interactor.executeSync
+import com.thomaskioko.tvmaniac.core.tasks.testing.FakeBackgroundTaskScheduler
+import com.thomaskioko.tvmaniac.data.backup.api.RestoreFailure
+import com.thomaskioko.tvmaniac.data.backup.api.RestoreResult
+import com.thomaskioko.tvmaniac.data.backup.testing.FakeBackupRepository
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+internal class RestoreBackupInteractorTest {
+
+    private val repository = FakeBackupRepository()
+    private val scheduler = FakeBackgroundTaskScheduler()
+    private val interactor = RestoreBackupInteractor(repository, scheduler)
+
+    @Test
+    fun `should schedule the metadata refill given a backup is restored`() = runTest {
+        interactor.executeSync(RestoreBackupInteractor.Params(LOCATION))
+
+        scheduler.getScheduledRequests().map { it.id } shouldBe listOf(RestoredShowsRefillWorker.WORKER_NAME)
+    }
+
+    @Test
+    fun `should schedule nothing given the restore fails`() = runTest {
+        repository.setRestoreResult(RestoreResult.Failed(RestoreFailure.SyncInProgress))
+
+        interactor.executeSync(RestoreBackupInteractor.Params(LOCATION))
+
+        scheduler.getScheduledRequests().shouldBeEmpty()
+    }
+
+    private companion object {
+        private const val LOCATION = "content://downloads/backup.json"
+    }
+}

--- a/features/root/presenter/README.md
+++ b/features/root/presenter/README.md
@@ -251,8 +251,12 @@ graph TB
   :domain:account-switcher --> :domain:library
   :domain:account-switcher --> :domain:user
   :domain:backup --> :core:base
+  :domain:backup --> :core:logger:api
+  :domain:backup --> :core:network-util:api
+  :domain:backup --> :core:tasks:api
   :domain:backup --> :core:view
   :domain:backup --> :data:backup:api
+  :domain:backup --> :domain:showdetails
   :domain:continue-watching --> :core:base
   :domain:continue-watching --> :core:feature-flags:api
   :domain:continue-watching --> :core:logger:api

--- a/features/root/ui/README.md
+++ b/features/root/ui/README.md
@@ -259,8 +259,12 @@ graph TB
   :domain:account-switcher --> :domain:library
   :domain:account-switcher --> :domain:user
   :domain:backup --> :core:base
+  :domain:backup --> :core:logger:api
+  :domain:backup --> :core:network-util:api
+  :domain:backup --> :core:tasks:api
   :domain:backup --> :core:view
   :domain:backup --> :data:backup:api
+  :domain:backup --> :domain:showdetails
   :domain:continue-watching --> :core:base
   :domain:continue-watching --> :core:feature-flags:api
   :domain:continue-watching --> :core:logger:api

--- a/features/settings/presenter/README.md
+++ b/features/settings/presenter/README.md
@@ -213,8 +213,12 @@ graph TB
   :domain:account-switcher --> :domain:library
   :domain:account-switcher --> :domain:user
   :domain:backup --> :core:base
+  :domain:backup --> :core:logger:api
+  :domain:backup --> :core:network-util:api
+  :domain:backup --> :core:tasks:api
   :domain:backup --> :core:view
   :domain:backup --> :data:backup:api
+  :domain:backup --> :domain:showdetails
   :domain:continue-watching --> :core:base
   :domain:continue-watching --> :core:feature-flags:api
   :domain:continue-watching --> :core:logger:api

--- a/features/settings/presenter/build.gradle.kts
+++ b/features/settings/presenter/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(libs.bundles.unittest)
+                implementation(projects.core.tasks.testing)
                 implementation(projects.core.base.testing)
                 implementation(projects.data.backup.testing)
                 implementation(projects.core.featureFlags.testing)

--- a/features/settings/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/settings/SettingsPresenterTest.kt
+++ b/features/settings/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/settings/SettingsPresenterTest.kt
@@ -11,6 +11,7 @@ import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAccountManager
 import com.thomaskioko.tvmaniac.accountmanager.testing.FakeAuthManager
 import com.thomaskioko.tvmaniac.core.base.coroutines.FakeAppScopeLauncher
 import com.thomaskioko.tvmaniac.core.logger.fixture.FakeLogger
+import com.thomaskioko.tvmaniac.core.tasks.testing.FakeBackgroundTaskScheduler
 import com.thomaskioko.tvmaniac.core.view.ErrorToStringMapper
 import com.thomaskioko.tvmaniac.core.view.UiMessageType
 import com.thomaskioko.tvmaniac.data.backup.api.BackupFailure
@@ -190,7 +191,7 @@ class SettingsPresenterTest {
                 rewatchRepository = FakeRewatchRepository(),
             ),
             exportBackupInteractor = ExportBackupInteractor(backupRepository),
-            restoreBackupInteractor = RestoreBackupInteractor(backupRepository),
+            restoreBackupInteractor = RestoreBackupInteractor(backupRepository, FakeBackgroundTaskScheduler()),
         )
     }
 

--- a/features/settings/ui/README.md
+++ b/features/settings/ui/README.md
@@ -220,8 +220,12 @@ graph TB
   :domain:account-switcher --> :domain:library
   :domain:account-switcher --> :domain:user
   :domain:backup --> :core:base
+  :domain:backup --> :core:logger:api
+  :domain:backup --> :core:network-util:api
+  :domain:backup --> :core:tasks:api
   :domain:backup --> :core:view
   :domain:backup --> :data:backup:api
+  :domain:backup --> :domain:showdetails
   :domain:continue-watching --> :core:base
   :domain:continue-watching --> :core:feature-flags:api
   :domain:continue-watching --> :core:logger:api

--- a/ios-framework/README.md
+++ b/ios-framework/README.md
@@ -895,8 +895,12 @@ graph TB
   :domain:account-switcher --> :domain:library
   :domain:account-switcher --> :domain:user
   :domain:backup --> :core:base
+  :domain:backup --> :core:logger:api
+  :domain:backup --> :core:network-util:api
+  :domain:backup --> :core:tasks:api
   :domain:backup --> :core:view
   :domain:backup --> :data:backup:api
+  :domain:backup --> :domain:showdetails
   :domain:calendar --> :core:base
   :domain:calendar --> :core:util:api
   :domain:calendar --> :data:calendar:api

--- a/ios/ios/Info.plist
+++ b/ios/ios/Info.plist
@@ -10,6 +10,7 @@
 		<string>com.thomaskioko.tvmaniac.upnextsync</string>
 		<string>com.thomaskioko.tvmaniac.pendinguploads</string>
 		<string>com.thomaskioko.tvmaniac.watchlistsync</string>
+		<string>com.thomaskioko.tvmaniac.showrefill</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>


### PR DESCRIPTION
## Description
This PR adds a background refill that fetches details, seasons and episodes for the shows a restore left without them, so a restored library fills in on its own.

## Changes
- Refill restored shows in the background, so a library restored onto a device with no cached data fills in without the user opening every show.
- Refill only the shows the user follows or has watch history for, and skip a show that already has its metadata, so a repeat run costs almost nothing.
- Stop a run after a retryable network failure instead of continuing to call the API, and carry on past a failure that affects a single show.
- Register the refill task identifier on iOS, without which the task never runs.
