### PR TITLE
feat: Save show and episode details in the backup file

### DIFF
--- a/data/backup/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/api/BackupFile.kt
+++ b/data/backup/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/api/BackupFile.kt
@@ -16,12 +16,49 @@ public data class BackupFile(
 public data class BackupShow(
     val tmdbId: Long,
     val title: String,
+    val overview: String? = null,
+    val posterPath: String? = null,
+    val backdropPath: String? = null,
+    val year: String? = null,
+    val language: String? = null,
+    val status: String? = null,
+    val runtime: Long? = null,
+    val ratings: Double? = null,
+    val voteCount: Long? = null,
+    val genres: List<String> = emptyList(),
+    val seasonNumbers: String? = null,
+    val episodeNumbers: String? = null,
+    val seasons: List<BackupSeason> = emptyList(),
     val followedAt: Long? = null,
     val watchStatus: String? = null,
     val rating: BackupRating? = null,
     val watchedEpisodes: List<BackupWatchedEpisode> = emptyList(),
     val seasonRatings: List<BackupSeasonRating> = emptyList(),
     val episodeRatings: List<BackupEpisodeRating> = emptyList(),
+)
+
+@Serializable
+public data class BackupSeason(
+    val tmdbId: Long,
+    val seasonNumber: Long,
+    val title: String,
+    val episodeCount: Long,
+    val overview: String? = null,
+    val imageUrl: String? = null,
+    val episodes: List<BackupEpisode> = emptyList(),
+)
+
+@Serializable
+public data class BackupEpisode(
+    val tmdbId: Long,
+    val episodeNumber: Long,
+    val title: String,
+    val overview: String? = null,
+    val runtime: Long? = null,
+    val voteCount: Long? = null,
+    val ratings: Double? = null,
+    val imageUrl: String? = null,
+    val firstAired: Long? = null,
 )
 
 @Serializable

--- a/data/backup/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/BackupImporter.kt
+++ b/data/backup/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/BackupImporter.kt
@@ -4,7 +4,9 @@ import com.thomaskioko.tvmaniac.data.backup.api.BackupFile
 import com.thomaskioko.tvmaniac.data.backup.api.BackupShow
 import com.thomaskioko.tvmaniac.data.backup.api.RestoreSummary
 import com.thomaskioko.tvmaniac.db.DatabaseTransactionRunner
+import com.thomaskioko.tvmaniac.db.EpisodeId
 import com.thomaskioko.tvmaniac.db.Id
+import com.thomaskioko.tvmaniac.db.SeasonId
 import com.thomaskioko.tvmaniac.db.ShowId
 import com.thomaskioko.tvmaniac.db.TmdbId
 import com.thomaskioko.tvmaniac.db.TvManiacDatabase
@@ -35,6 +37,7 @@ internal class BackupImporter(
             }
 
             showCount++
+            restoreSeasonsAndEpisodes(show, showId)
             episodeCount += restoreShow(show, showId)
             skippedSeasonRatings += restoreSeasonRatings(show, showId)
             skippedEpisodeRatings += restoreEpisodeRatings(show, showId)
@@ -72,19 +75,49 @@ internal class BackupImporter(
         database.tvShowQueries.upsert(
             tmdb_id = tmdbId,
             name = show.title,
-            overview = "",
-            language = null,
-            year = null,
-            ratings = 0.0,
-            vote_count = 0,
-            genres = null,
-            status = null,
-            episode_numbers = null,
-            season_numbers = null,
-            poster_path = null,
-            backdrop_path = null,
+            overview = show.overview.orEmpty(),
+            language = show.language,
+            year = show.year,
+            ratings = show.ratings ?: 0.0,
+            vote_count = show.voteCount ?: 0,
+            genres = show.genres.takeIf { it.isNotEmpty() },
+            status = show.status,
+            episode_numbers = show.episodeNumbers,
+            season_numbers = show.seasonNumbers,
+            poster_path = show.posterPath,
+            backdrop_path = show.backdropPath,
         )
         return database.tvShowQueries.getShowIdByTmdbId(tmdbId).executeAsOneOrNull()
+    }
+
+    private fun restoreSeasonsAndEpisodes(show: BackupShow, showId: Id<ShowId>) {
+        show.seasons.forEach { season ->
+            val seasonId = Id<SeasonId>(season.tmdbId)
+            restoreQueries.restoreSeason(
+                seasonId = seasonId,
+                showId = showId,
+                seasonNumber = season.seasonNumber,
+                episodeCount = season.episodeCount,
+                title = season.title,
+                overview = season.overview,
+                imageUrl = season.imageUrl,
+            )
+            season.episodes.forEach { episode ->
+                restoreQueries.restoreEpisode(
+                    episodeId = Id<EpisodeId>(episode.tmdbId),
+                    seasonId = seasonId,
+                    showId = showId,
+                    episodeNumber = episode.episodeNumber,
+                    title = episode.title,
+                    overview = episode.overview.orEmpty(),
+                    runtime = episode.runtime,
+                    voteCount = episode.voteCount ?: 0,
+                    ratings = episode.ratings ?: 0.0,
+                    imageUrl = episode.imageUrl,
+                    firstAired = episode.firstAired,
+                )
+            }
+        }
     }
 
     private fun restoreShow(show: BackupShow, showId: Id<ShowId>): Int {

--- a/data/backup/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/BackupJson.kt
+++ b/data/backup/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/BackupJson.kt
@@ -9,9 +9,9 @@ import kotlinx.serialization.json.jsonPrimitive
 public object BackupJson {
 
     private val json = Json {
-        prettyPrint = true
         ignoreUnknownKeys = true
-        encodeDefaults = true
+        encodeDefaults = false
+        explicitNulls = false
     }
 
     public fun encode(backup: BackupFile): String = json.encodeToString(backup)

--- a/data/backup/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultBackupRepository.kt
+++ b/data/backup/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultBackupRepository.kt
@@ -3,6 +3,7 @@ package com.thomaskioko.tvmaniac.data.backup.implementation
 import com.thomaskioko.tvmaniac.appconfig.AppMetadata
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.data.backup.api.BackupDestination
+import com.thomaskioko.tvmaniac.data.backup.api.BackupEpisode
 import com.thomaskioko.tvmaniac.data.backup.api.BackupEpisodeRating
 import com.thomaskioko.tvmaniac.data.backup.api.BackupFailure
 import com.thomaskioko.tvmaniac.data.backup.api.BackupFile
@@ -11,6 +12,7 @@ import com.thomaskioko.tvmaniac.data.backup.api.BackupPreferences
 import com.thomaskioko.tvmaniac.data.backup.api.BackupRating
 import com.thomaskioko.tvmaniac.data.backup.api.BackupRepository
 import com.thomaskioko.tvmaniac.data.backup.api.BackupResult
+import com.thomaskioko.tvmaniac.data.backup.api.BackupSeason
 import com.thomaskioko.tvmaniac.data.backup.api.BackupSeasonRating
 import com.thomaskioko.tvmaniac.data.backup.api.BackupShow
 import com.thomaskioko.tvmaniac.data.backup.api.BackupWatchedEpisode
@@ -147,11 +149,50 @@ public class DefaultBackupRepository(
                 )
             }
 
+        val episodesBySeason = queries.backupEpisodes().executeAsList().groupBy { it.season_id.id }
+        val seasonsByShow = queries.backupSeasons().executeAsList()
+            .groupBy({ it.tmdb_id.id }) { season ->
+                BackupSeason(
+                    tmdbId = season.id.id,
+                    seasonNumber = season.season_number,
+                    title = season.title,
+                    episodeCount = season.episode_count,
+                    overview = season.overview,
+                    imageUrl = season.image_url,
+                    episodes = episodesBySeason[season.id.id].orEmpty().map { episode ->
+                        BackupEpisode(
+                            tmdbId = episode.id.id,
+                            episodeNumber = episode.episode_number,
+                            title = episode.title,
+                            overview = episode.overview,
+                            runtime = episode.runtime,
+                            voteCount = episode.vote_count,
+                            ratings = episode.ratings,
+                            imageUrl = episode.image_url,
+                            firstAired = episode.first_aired,
+                        )
+                    },
+                )
+            }
+
         queries.backupShows().executeAsList().map { show ->
             val tmdbId = show.tmdb_id.id
             BackupShow(
                 tmdbId = tmdbId,
                 title = show.name,
+                overview = show.overview,
+                posterPath = show.poster_path,
+                backdropPath = show.backdrop_path,
+                year = show.year,
+                language = show.language,
+                status = show.status,
+                runtime = show.runtime,
+                ratings = show.ratings,
+                voteCount = show.vote_count,
+                genres = show.genres.orEmpty(),
+                seasonNumbers = show.season_numbers,
+                episodeNumbers = show.episode_numbers,
+                seasons = seasonsByShow[tmdbId].orEmpty(),
                 followedAt = followedAt[tmdbId],
                 watchStatus = watchStatus[tmdbId],
                 rating = showRatings[tmdbId],

--- a/data/backup/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/BackupJsonTest.kt
+++ b/data/backup/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/BackupJsonTest.kt
@@ -20,7 +20,7 @@ internal class BackupJsonTest {
     }
 
     @Test
-    fun `should fail given the file carries no version`() {
+    fun `should fail given the file has no version`() {
         val contents = """
             {"createdAt": "2026-01-01T00:00:00Z", "appVersion": "1.0.0"}
         """.trimIndent()
@@ -29,7 +29,7 @@ internal class BackupJsonTest {
     }
 
     @Test
-    fun `should read a file given it carries a field the reader does not know`() {
+    fun `should read a file given it has an unknown field`() {
         val contents = """
             {
               "version": ${BackupFormat.VERSION},

--- a/data/backup/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultBackupRepositoryRestoreTest.kt
+++ b/data/backup/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultBackupRepositoryRestoreTest.kt
@@ -1,9 +1,11 @@
 package com.thomaskioko.tvmaniac.data.backup.implementation
 
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
+import com.thomaskioko.tvmaniac.data.backup.api.BackupEpisode
 import com.thomaskioko.tvmaniac.data.backup.api.BackupFile
 import com.thomaskioko.tvmaniac.data.backup.api.BackupFormat
 import com.thomaskioko.tvmaniac.data.backup.api.BackupRating
+import com.thomaskioko.tvmaniac.data.backup.api.BackupSeason
 import com.thomaskioko.tvmaniac.data.backup.api.BackupSeasonRating
 import com.thomaskioko.tvmaniac.data.backup.api.BackupShow
 import com.thomaskioko.tvmaniac.data.backup.api.BackupWatchedEpisode
@@ -138,7 +140,7 @@ internal class DefaultBackupRepositoryRestoreTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun `should count a show skipped given it carries no tmdb id`() = runTest(testDispatcher) {
+    fun `should count a show skipped given it has no tmdb id`() = runTest(testDispatcher) {
         val result = repository.restoreBackup(
             fileWith(BackupShow(tmdbId = 0L, title = "Nameless", followedAt = NOW)),
         )
@@ -197,7 +199,7 @@ internal class DefaultBackupRepositoryRestoreTest : BaseDatabaseTest() {
 
         repository.restoreBackup(fileWith(BackupShow(tmdbId = OTHER_TMDB_ID, title = "Better Call Saul")))
 
-        safetyCopy().shouldNotBeNull() shouldContain "\"season\": 9"
+        safetyCopy().shouldNotBeNull() shouldContain "\"season\":9"
     }
 
     @Test
@@ -210,7 +212,7 @@ internal class DefaultBackupRepositoryRestoreTest : BaseDatabaseTest() {
         val result = repository.restoreBackup(fileWith(breakingBad()))
 
         result.shouldBeInstanceOf<RestoreResult.Failed>().reason shouldBe RestoreFailure.ImportFailed
-        safetyCopy().shouldNotBeNull() shouldContain "\"season\": 9"
+        safetyCopy().shouldNotBeNull() shouldContain "\"season\":9"
         watchedEpisodes() shouldHaveSize 1
     }
 
@@ -247,7 +249,7 @@ internal class DefaultBackupRepositoryRestoreTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun `should import given the file carries an unknown field`() = runTest(testDispatcher) {
+    fun `should import given the file has an unknown field`() = runTest(testDispatcher) {
         val source = fileWith(
             """{"version": 1, "createdAt": "now", "appVersion": "1.0", "lists": [], "shows": []}""",
         )
@@ -267,7 +269,7 @@ internal class DefaultBackupRepositoryRestoreTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun `should restore the watch status given the file carries one`() = runTest(testDispatcher) {
+    fun `should restore the watch status given the file has one`() = runTest(testDispatcher) {
         repository.restoreBackup(fileWith(breakingBad().copy(watchStatus = "COMPLETED")))
 
         val showId = database.tvShowQueries.getShowIdByTmdbId(Id<TmdbId>(BREAKING_BAD_TMDB_ID)).executeAsOne()
@@ -287,6 +289,64 @@ internal class DefaultBackupRepositoryRestoreTest : BaseDatabaseTest() {
         repository.restoreBackup(fileWith(breakingBad()))
 
         database.continueWatchingQueries.entries().executeAsList() shouldHaveSize 1
+    }
+
+    @Test
+    fun `should restore seasons and episodes given the file has them`() = runTest(testDispatcher) {
+        val show = breakingBad().copy(
+            seasons = listOf(
+                BackupSeason(
+                    tmdbId = 3572,
+                    seasonNumber = 1,
+                    title = "Season 1",
+                    episodeCount = 2,
+                    episodes = listOf(
+                        BackupEpisode(tmdbId = 62085, episodeNumber = 1, title = "Pilot"),
+                        BackupEpisode(tmdbId = 62086, episodeNumber = 2, title = "Cat in the Bag"),
+                    ),
+                ),
+            ),
+        )
+
+        repository.restoreBackup(fileWith(show))
+
+        val showId = database.tvShowQueries.getShowIdByTmdbId(Id<TmdbId>(BREAKING_BAD_TMDB_ID)).executeAsOne()
+        database.seasonsQueries.getSeasonByShowAndNumber(showId, 1).executeAsOneOrNull().shouldNotBeNull()
+        database.episodesQueries.countEpisodesForShow(showId, 1).executeAsOne() shouldBe 2
+    }
+
+    @Test
+    fun `should link watch history to the restored episodes`() = runTest(testDispatcher) {
+        val show = breakingBad().copy(
+            seasons = listOf(
+                BackupSeason(
+                    tmdbId = 3572,
+                    seasonNumber = 1,
+                    title = "Season 1",
+                    episodeCount = 2,
+                    episodes = listOf(
+                        BackupEpisode(tmdbId = 62085, episodeNumber = 1, title = "Pilot"),
+                        BackupEpisode(tmdbId = 62086, episodeNumber = 2, title = "Cat in the Bag"),
+                    ),
+                ),
+            ),
+        )
+
+        repository.restoreBackup(fileWith(show))
+
+        watchedEpisodes().all { it.episode_id != null } shouldBe true
+    }
+
+    @Test
+    fun `should restore the show details given the file has them`() = runTest(testDispatcher) {
+        val show = breakingBad().copy(overview = "A chemistry teacher", posterPath = "/poster.jpg", year = "2008")
+
+        repository.restoreBackup(fileWith(show))
+
+        val backup = repository.createBackup()
+        val restored = backup.shows.single()
+        restored.overview shouldBe "A chemistry teacher"
+        restored.posterPath shouldBe "/poster.jpg"
     }
 
     private fun buildRepository(transactionRunner: DatabaseTransactionRunner) = DefaultBackupRepository(

--- a/data/backup/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultBackupRepositoryRestoreTest.kt
+++ b/data/backup/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultBackupRepositoryRestoreTest.kt
@@ -349,6 +349,23 @@ internal class DefaultBackupRepositoryRestoreTest : BaseDatabaseTest() {
         restored.posterPath shouldBe "/poster.jpg"
     }
 
+    @Test
+    fun `should import a file written before seasons were added`() = runTest(testDispatcher) {
+        val result = repository.restoreBackup(fileWith(VERSION_ONE_FILE))
+
+        val summary = result.shouldBeInstanceOf<RestoreResult.Restored>().summary
+        summary.showCount shouldBe 1
+        summary.episodeCount shouldBe 1
+        watchedEpisodes() shouldHaveSize 1
+    }
+
+    @Test
+    fun `should leave a show from an older file for the refill`() = runTest(testDispatcher) {
+        repository.restoreBackup(fileWith(VERSION_ONE_FILE))
+
+        repository.showsNeedingMetadata() shouldHaveSize 1
+    }
+
     private fun buildRepository(transactionRunner: DatabaseTransactionRunner) = DefaultBackupRepository(
         database = database,
         datastoreRepository = datastoreRepository,
@@ -462,6 +479,12 @@ internal class DefaultBackupRepositoryRestoreTest : BaseDatabaseTest() {
         private const val SHOW_TITLE = "Breaking Bad"
         private const val NOW = 1_700_000_000_000L
         private const val SOURCE = "content://downloads/backup.json"
+        private val VERSION_ONE_FILE = """
+            {"version":1,"createdAt":"2026-01-01T00:00:00Z","appVersion":"1.0.0","shows":[
+              {"tmdbId":$BREAKING_BAD_TMDB_ID,"title":"$SHOW_TITLE","followedAt":$NOW,
+               "watchedEpisodes":[{"season":1,"episode":1,"watchedAt":$NOW}]}
+            ]}
+        """.trimIndent()
         private val SEASON_ID = Id<SeasonId>(3572L)
     }
 }

--- a/data/backup/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultBackupRepositoryTest.kt
+++ b/data/backup/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultBackupRepositoryTest.kt
@@ -69,7 +69,7 @@ internal class DefaultBackupRepositoryTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun `should carry the format version given a backup is created`() = runTest(testDispatcher) {
+    fun `should include the format version given a backup is created`() = runTest(testDispatcher) {
         val backup = repository.createBackup()
 
         backup.version shouldBe BackupFormat.VERSION
@@ -133,7 +133,7 @@ internal class DefaultBackupRepositoryTest : BaseDatabaseTest() {
 
         val contents = BackupJson.encode(repository.createBackup())
 
-        contents shouldContain "\"tmdbId\": $BREAKING_BAD_TMDB_ID"
+        contents shouldContain "\"tmdbId\":$BREAKING_BAD_TMDB_ID"
         contents shouldNotContain "showId"
         contents shouldNotContain "episodeId"
         contents shouldNotContain "seasonId"

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Backup.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Backup.sq
@@ -9,7 +9,19 @@ import com.thomaskioko.tvmaniac.db.WatchStatus;
 backupShows:
 SELECT DISTINCT
     tvshow.tmdb_id,
-    tvshow.name
+    tvshow.name,
+    tvshow.overview,
+    tvshow.poster_path,
+    tvshow.backdrop_path,
+    tvshow.year,
+    tvshow.language,
+    tvshow.status,
+    tvshow.runtime,
+    tvshow.ratings,
+    tvshow.vote_count,
+    tvshow.genres,
+    tvshow.season_numbers,
+    tvshow.episode_numbers
 FROM tvshow
 WHERE tvshow.id IN (
     SELECT show_id FROM followed_shows WHERE pending_action != 'DELETE'
@@ -82,3 +94,55 @@ INNER JOIN season ON season.id = episode.season_id
 INNER JOIN tvshow ON tvshow.id = episode.show_id
 WHERE episode_ratings.pending_action != 'DELETE'
   AND episode_ratings.user_rating IS NOT NULL;
+
+-- Seasons and episodes travel with the file so a restore renders without a network call. Both key on
+-- the id the network layer assigns, which is a TMDB id rather than a local row id, so the rule that
+-- no local id reaches the file still holds. Images, casts and trailers stay out.
+backupSeasons:
+SELECT
+    tvshow.tmdb_id,
+    season.id,
+    season.season_number,
+    season.title,
+    season.episode_count,
+    season.overview,
+    season.image_url
+FROM season
+INNER JOIN tvshow ON tvshow.id = season.show_id
+WHERE 1 = 1
+  AND tvshow.id IN (
+    SELECT show_id FROM followed_shows WHERE pending_action != 'DELETE'
+    UNION
+    SELECT show_id FROM watched_episodes WHERE pending_action NOT IN ('DELETE', 'SYNCED_DELETE')
+    UNION
+    SELECT show_id FROM show_ratings WHERE pending_action != 'DELETE' AND user_rating IS NOT NULL
+    UNION
+    SELECT show_id FROM show_watch_status WHERE status IS NOT NULL
+  );
+
+backupEpisodes:
+SELECT
+    tvshow.tmdb_id,
+    episode.season_id,
+    episode.id,
+    episode.episode_number,
+    episode.title,
+    episode.overview,
+    episode.runtime,
+    episode.vote_count,
+    episode.ratings,
+    episode.image_url,
+    episode.first_aired
+FROM episode
+INNER JOIN tvshow ON tvshow.id = episode.show_id
+WHERE 1 = 1
+  AND tvshow.id IN (
+    SELECT show_id FROM followed_shows WHERE pending_action != 'DELETE'
+    UNION
+    SELECT show_id FROM watched_episodes WHERE pending_action NOT IN ('DELETE', 'SYNCED_DELETE')
+    UNION
+    SELECT show_id FROM show_ratings WHERE pending_action != 'DELETE' AND user_rating IS NOT NULL
+    UNION
+    SELECT show_id FROM show_watch_status WHERE status IS NOT NULL
+  );
+

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Restore.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Restore.sq
@@ -102,3 +102,35 @@ WHERE tvshow.overview = ''
     SELECT show_id FROM watched_episodes WHERE pending_action NOT IN ('DELETE', 'SYNCED_DELETE')
   );
 
+restoreSeason:
+INSERT INTO season(id, show_id, season_number, episode_count, title, overview, image_url)
+VALUES(:seasonId, :showId, :seasonNumber, :episodeCount, :title, :overview, :imageUrl)
+ON CONFLICT(id) DO UPDATE SET
+    show_id = excluded.show_id,
+    season_number = excluded.season_number,
+    episode_count = excluded.episode_count,
+    title = excluded.title,
+    overview = excluded.overview,
+    image_url = excluded.image_url;
+
+restoreEpisode:
+INSERT INTO episode(
+    id, season_id, show_id, episode_number, title, overview, runtime, vote_count, ratings,
+    image_url, first_aired
+)
+VALUES(
+    :episodeId, :seasonId, :showId, :episodeNumber, :title, :overview, :runtime, :voteCount,
+    :ratings, :imageUrl, :firstAired
+)
+ON CONFLICT(id) DO UPDATE SET
+    season_id = excluded.season_id,
+    show_id = excluded.show_id,
+    episode_number = excluded.episode_number,
+    title = excluded.title,
+    overview = excluded.overview,
+    runtime = excluded.runtime,
+    vote_count = excluded.vote_count,
+    ratings = excluded.ratings,
+    image_url = excluded.image_url,
+    first_aired = excluded.first_aired;
+

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Restore.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Restore.sq
@@ -89,7 +89,7 @@ LIMIT 1;
 rewatchSessionCount:
 SELECT COUNT(*) FROM rewatch_session;
 
--- A restore inserts stub shows carrying only a tmdb id and a title, because the backup file holds no
+-- A restore inserts stub shows with only a tmdb id and a title, because the backup file holds no
 -- cached metadata. This finds the ones worth refilling: a stub the user either follows or has watch
 -- history for. A stub reached only by a rating is left alone.
 showsNeedingMetadata:

--- a/domain/backup/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/backup/ExportBackupInteractorTest.kt
+++ b/domain/backup/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/backup/ExportBackupInteractorTest.kt
@@ -34,7 +34,7 @@ internal class ExportBackupInteractorTest {
     }
 
     @Test
-    fun `should carry the reason given the backup cannot be written`() = runTest {
+    fun `should report the reason given the backup cannot be written`() = runTest {
         repository.setWriteResult(BackupResult.Failed(BackupFailure.VerificationFailed))
 
         val failure = assertFailsWith<BackupExportException> {

--- a/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/DiscoverShowsPresenter.kt
+++ b/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/DiscoverShowsPresenter.kt
@@ -58,9 +58,12 @@ public class DiscoverShowsPresenter(
     public val state: StateFlow<DiscoverViewState> = combine(
         featuredPresenter.state,
         catalogPresenter.state,
-    ) { featured, catalog ->
+        upNextPresenter.state,
+        startWatchingPresenter.state,
+    ) { featured, catalog, upNext, startWatching ->
         val isRefreshing = featured.isRefreshing || catalog.isRefreshing
-        val isEmpty = featured.isEmpty && catalog.isEmpty
+        val hasLocalShows = upNext.nextEpisodes.isNotEmpty() || startWatching.startWatchingShows.isNotEmpty()
+        val isEmpty = featured.isEmpty && catalog.isEmpty && !hasLocalShows
         val message = featured.message ?: catalog.message
         DiscoverViewState(
             isRefreshing = isRefreshing,

--- a/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/catalog/DiscoverCatalogPresenter.kt
+++ b/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/catalog/DiscoverCatalogPresenter.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 @ChildPresenter(scope = DiscoverChildScope::class, parentScope = DiscoverRoot::class)
@@ -156,6 +157,7 @@ public class DiscoverCatalogPresenter internal constructor(
     }
 
     private fun fetchShows(forceRefresh: Boolean = false) {
+        _state.update { it.copy(isInitial = false) }
         coroutineScope.launch {
             genreShowsInteractor(forceRefresh)
                 .collectStatus(genreLoadingState, logger, uiMessageManager, "Genres", errorToStringMapper)

--- a/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/featured/DiscoverFeaturedPresenter.kt
+++ b/features/discover/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/discover/presenter/featured/DiscoverFeaturedPresenter.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 @ChildPresenter(scope = DiscoverChildScope::class, parentScope = DiscoverRoot::class)
@@ -100,6 +101,7 @@ public class DiscoverFeaturedPresenter(
     }
 
     private fun fetchFeaturedShows(forceRefresh: Boolean = false) {
+        _state.update { it.copy(isInitial = false) }
         coroutineScope.launch {
             featuredShowsInteractor(forceRefresh)
                 .collectStatus(loadingState, logger, uiMessageManager, "Featured Shows", errorToStringMapper)

--- a/features/discover/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/discover/presenter/DiscoverShowsPresenterTest.kt
+++ b/features/discover/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/discover/presenter/DiscoverShowsPresenterTest.kt
@@ -43,10 +43,12 @@ import com.thomaskioko.tvmaniac.navigation.testing.TestNavigator
 import com.thomaskioko.tvmaniac.navigation.testing.test
 import com.thomaskioko.tvmaniac.search.nav.SearchRoute
 import com.thomaskioko.tvmaniac.shows.api.model.ShowEntity
+import com.thomaskioko.tvmaniac.startwatching.api.StartWatchingShow
 import com.thomaskioko.tvmaniac.startwatching.testing.FakeStartWatchingRepository
 import com.thomaskioko.tvmaniac.topratedshows.data.api.TopRatedShowsInteractor
 import com.thomaskioko.tvmaniac.upnext.testing.FakeUpNextRepository
 import io.kotest.matchers.shouldBe
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -103,6 +105,35 @@ class DiscoverShowsPresenterTest {
             state.isLoading shouldBe false
             state.isEmpty shouldBe false
             state.isRefreshing shouldBe false
+            state.showError shouldBe false
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `should show content given only the local shows have data`() = runTest {
+        startWatchingRepository.setStartWatchingShows(
+            listOf(
+                StartWatchingShow(
+                    showId = 1L,
+                    tmdbId = 11L,
+                    title = "Breaking Bad",
+                    posterPath = "/1.jpg",
+                    year = "2008",
+                    inLibrary = true,
+                ),
+            ),
+        )
+        val presenter = buildPresenter()
+
+        presenter.state.test {
+            setCatalogData(persistentListOf())
+
+            testScheduler.advanceUntilIdle()
+
+            val state = expectMostRecentItem()
+            state.isEmpty shouldBe false
+            state.isLoading shouldBe false
             state.showError shouldBe false
             cancelAndIgnoreRemainingEvents()
         }

--- a/features/discover/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/discover/presenter/catalog/DiscoverCatalogPresenterTest.kt
+++ b/features/discover/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/discover/presenter/catalog/DiscoverCatalogPresenterTest.kt
@@ -76,6 +76,22 @@ class DiscoverCatalogPresenterTest {
     }
 
     @Test
+    fun `should stop refreshing given the load finished with nothing to show`() = runTest {
+        val presenter = buildPresenter()
+
+        presenter.state.test {
+            var state = awaitItem()
+            while (state.isRefreshing) {
+                state = awaitItem()
+            }
+
+            state.isRefreshing shouldBe false
+            state.isInitial shouldBe false
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `should emit rail shows and titles when repositories have data`() = runTest {
         val presenter = buildPresenter()
 

--- a/features/settings/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/settings/SettingsPresenterTest.kt
+++ b/features/settings/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/settings/SettingsPresenterTest.kt
@@ -933,7 +933,7 @@ class SettingsPresenterTest {
     }
 
     @Test
-    fun `should carry the backup labels given the state is first read`() = runTest {
+    fun `should include the backup labels given the state is first read`() = runTest {
         testScheduler.advanceUntilIdle()
 
         presenter.state.test {


### PR DESCRIPTION
## Description
This PR saves show details, seasons and episodes in the backup file, so restoring on a new device renders the library without a single network call.

## Changes
- Save show details, seasons and episodes alongside the watch history, so a restored device shows the library, Up Next and show progress straight away.
- Restore season and episode ratings, which a file without episodes could not bring back.
- Write the file compactly, which more than halves its size.
- Import a file written before this change, leaving those shows to the background refill.

## Fixes
- Stop the Discover screen loading forever when its first load fails and the message is cleared.
- Show Up Next and Start Watching on Discover when the network sections have nothing to show, instead of replacing the screen with an empty state.
