### PR TITLE
feat: Restore followed shows for connected accounts

### DIFF
--- a/data/backup/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/api/BackupRepository.kt
+++ b/data/backup/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/api/BackupRepository.kt
@@ -5,7 +5,10 @@ public interface BackupRepository {
 
     public suspend fun writeBackup(location: String): BackupResult
 
-    public suspend fun restoreBackup(location: String): RestoreResult
+    public suspend fun restoreBackup(
+        location: String,
+        addToConnectedAccount: Boolean = false,
+    ): RestoreResult
 
     public suspend fun showsNeedingMetadata(): List<Long>
 }

--- a/data/backup/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/api/BackupRepository.kt
+++ b/data/backup/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/api/BackupRepository.kt
@@ -7,7 +7,7 @@ public interface BackupRepository {
 
     public suspend fun restoreBackup(
         location: String,
-        addToConnectedAccount: Boolean = false,
+        syncWithConnectedAccount: Boolean = false,
     ): RestoreResult
 
     public suspend fun showsNeedingMetadata(): List<Long>

--- a/data/backup/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/BackupImporter.kt
+++ b/data/backup/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/BackupImporter.kt
@@ -23,7 +23,7 @@ internal class BackupImporter(
     fun import(
         backup: BackupFile,
         includeSpecials: Boolean,
-        addToConnectedAccount: Boolean,
+        syncWithConnectedAccount: Boolean,
     ): RestoreSummary = transactionRunner {
         clearRestoredTables()
 
@@ -45,7 +45,7 @@ internal class BackupImporter(
             episodeCount += restoreShow(
                 show = show,
                 showId = showId,
-                addToConnectedAccount = addToConnectedAccount,
+                syncWithConnectedAccount = syncWithConnectedAccount,
             )
             skippedSeasonRatings += restoreSeasonRatings(show, showId)
             skippedEpisodeRatings += restoreEpisodeRatings(show, showId)
@@ -128,10 +128,10 @@ internal class BackupImporter(
         }
     }
 
-    private fun restoreShow(show: BackupShow, showId: Id<ShowId>, addToConnectedAccount: Boolean): Int {
+    private fun restoreShow(show: BackupShow, showId: Id<ShowId>, syncWithConnectedAccount: Boolean): Int {
         show.followedAt?.let { followedAt ->
             when {
-                addToConnectedAccount -> restoreQueries.restoreFollowedShowForUpload(
+                syncWithConnectedAccount -> restoreQueries.restoreFollowedShowForUpload(
                     showId = showId,
                     tmdbId = Id(show.tmdbId),
                     followedAt = followedAt,

--- a/data/backup/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/BackupImporter.kt
+++ b/data/backup/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/BackupImporter.kt
@@ -20,7 +20,11 @@ internal class BackupImporter(
 
     private val restoreQueries = database.restoreQueries
 
-    fun import(backup: BackupFile, includeSpecials: Boolean): RestoreSummary = transactionRunner {
+    fun import(
+        backup: BackupFile,
+        includeSpecials: Boolean,
+        addToConnectedAccount: Boolean,
+    ): RestoreSummary = transactionRunner {
         clearRestoredTables()
 
         var showCount = 0
@@ -38,7 +42,11 @@ internal class BackupImporter(
 
             showCount++
             restoreSeasonsAndEpisodes(show, showId)
-            episodeCount += restoreShow(show, showId)
+            episodeCount += restoreShow(
+                show = show,
+                showId = showId,
+                addToConnectedAccount = addToConnectedAccount,
+            )
             skippedSeasonRatings += restoreSeasonRatings(show, showId)
             skippedEpisodeRatings += restoreEpisodeRatings(show, showId)
             recalculateMetadata(showId, includeSpecials)
@@ -120,13 +128,20 @@ internal class BackupImporter(
         }
     }
 
-    private fun restoreShow(show: BackupShow, showId: Id<ShowId>): Int {
+    private fun restoreShow(show: BackupShow, showId: Id<ShowId>, addToConnectedAccount: Boolean): Int {
         show.followedAt?.let { followedAt ->
-            restoreQueries.restoreFollowedShow(
-                showId = showId,
-                tmdbId = Id(show.tmdbId),
-                followedAt = followedAt,
-            )
+            when {
+                addToConnectedAccount -> restoreQueries.restoreFollowedShowForUpload(
+                    showId = showId,
+                    tmdbId = Id(show.tmdbId),
+                    followedAt = followedAt,
+                )
+                else -> restoreQueries.restoreFollowedShow(
+                    showId = showId,
+                    tmdbId = Id(show.tmdbId),
+                    followedAt = followedAt,
+                )
+            }
         }
 
         watchStatusOrNull(show.watchStatus)?.let { status ->

--- a/data/backup/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultBackupRepository.kt
+++ b/data/backup/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultBackupRepository.kt
@@ -86,7 +86,7 @@ public class DefaultBackupRepository(
         )
     }
 
-    override suspend fun restoreBackup(location: String, addToConnectedAccount: Boolean): RestoreResult {
+    override suspend fun restoreBackup(location: String, syncWithConnectedAccount: Boolean): RestoreResult {
         if (syncObserver.isSyncing.value) return RestoreResult.Failed(RestoreFailure.SyncInProgress)
 
         val backup = try {
@@ -109,7 +109,7 @@ public class DefaultBackupRepository(
                     importer.import(
                         backup = backup,
                         includeSpecials = includeSpecials,
-                        addToConnectedAccount = addToConnectedAccount,
+                        syncWithConnectedAccount = syncWithConnectedAccount,
                     )
                 }
                 writePreferences(backup.preferences)

--- a/data/backup/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultBackupRepository.kt
+++ b/data/backup/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultBackupRepository.kt
@@ -86,7 +86,7 @@ public class DefaultBackupRepository(
         )
     }
 
-    override suspend fun restoreBackup(location: String): RestoreResult {
+    override suspend fun restoreBackup(location: String, addToConnectedAccount: Boolean): RestoreResult {
         if (syncObserver.isSyncing.value) return RestoreResult.Failed(RestoreFailure.SyncInProgress)
 
         val backup = try {
@@ -106,7 +106,11 @@ public class DefaultBackupRepository(
             try {
                 val includeSpecials = datastoreRepository.getIncludeSpecials()
                 val summary = withContext(dispatchers.databaseWrite) {
-                    importer.import(backup, includeSpecials)
+                    importer.import(
+                        backup = backup,
+                        includeSpecials = includeSpecials,
+                        addToConnectedAccount = addToConnectedAccount,
+                    )
                 }
                 writePreferences(backup.preferences)
                 RestoreResult.Restored(summary)

--- a/data/backup/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultBackupRepositoryRestoreTest.kt
+++ b/data/backup/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultBackupRepositoryRestoreTest.kt
@@ -123,7 +123,7 @@ internal class DefaultBackupRepositoryRestoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should mark a restored followed show for upload given user is signed in`() = runTest(testDispatcher) {
-        repository.restoreBackup(fileWith(breakingBad()), addToConnectedAccount = true)
+        repository.restoreBackup(fileWith(breakingBad()), syncWithConnectedAccount = true)
 
         database.followedShowsQueries.entries().executeAsList()
             .all { it.pending_action == PendingAction.UPLOAD.value } shouldBe true
@@ -131,7 +131,7 @@ internal class DefaultBackupRepositoryRestoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should survive a library sync given user is signed in`() = runTest(testDispatcher) {
-        repository.restoreBackup(fileWith(breakingBad()), addToConnectedAccount = true)
+        repository.restoreBackup(fileWith(breakingBad()), syncWithConnectedAccount = true)
 
         val survivors = database.followedShowsQueries.entriesWithNoPendingAction().executeAsList()
 
@@ -141,7 +141,7 @@ internal class DefaultBackupRepositoryRestoreTest : BaseDatabaseTest() {
 
     @Test
     fun `should be removed by a library sync given user is signed out`() = runTest(testDispatcher) {
-        repository.restoreBackup(fileWith(breakingBad()), addToConnectedAccount = false)
+        repository.restoreBackup(fileWith(breakingBad()), syncWithConnectedAccount = false)
 
         val exposed = database.followedShowsQueries.entriesWithNoPendingAction().executeAsList()
 

--- a/data/backup/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultBackupRepositoryRestoreTest.kt
+++ b/data/backup/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/backup/implementation/DefaultBackupRepositoryRestoreTest.kt
@@ -122,6 +122,33 @@ internal class DefaultBackupRepositoryRestoreTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun `should mark a restored followed show for upload given user is signed in`() = runTest(testDispatcher) {
+        repository.restoreBackup(fileWith(breakingBad()), addToConnectedAccount = true)
+
+        database.followedShowsQueries.entries().executeAsList()
+            .all { it.pending_action == PendingAction.UPLOAD.value } shouldBe true
+    }
+
+    @Test
+    fun `should survive a library sync given user is signed in`() = runTest(testDispatcher) {
+        repository.restoreBackup(fileWith(breakingBad()), addToConnectedAccount = true)
+
+        val survivors = database.followedShowsQueries.entriesWithNoPendingAction().executeAsList()
+
+        survivors shouldHaveSize 0
+        database.followedShowsQueries.entries().executeAsList() shouldHaveSize 1
+    }
+
+    @Test
+    fun `should be removed by a library sync given user is signed out`() = runTest(testDispatcher) {
+        repository.restoreBackup(fileWith(breakingBad()), addToConnectedAccount = false)
+
+        val exposed = database.followedShowsQueries.entriesWithNoPendingAction().executeAsList()
+
+        exposed shouldHaveSize 1
+    }
+
+    @Test
     fun `should leave no provider id on a restored watched episode`() = runTest(testDispatcher) {
         repository.restoreBackup(fileWith(breakingBad()))
 

--- a/data/backup/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/testing/FakeBackupRepository.kt
+++ b/data/backup/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/testing/FakeBackupRepository.kt
@@ -23,6 +23,7 @@ public class FakeBackupRepository : BackupRepository {
         private set
 
     public var lastRestoreLocation: String? = null
+    public var lastRestoreAddedToConnectedAccount: Boolean? = null
         private set
 
     private var showsNeedingMetadata: List<Long> = emptyList()
@@ -58,8 +59,9 @@ public class FakeBackupRepository : BackupRepository {
         return writeResult
     }
 
-    override suspend fun restoreBackup(location: String): RestoreResult {
+    override suspend fun restoreBackup(location: String, addToConnectedAccount: Boolean): RestoreResult {
         lastRestoreLocation = location
+        lastRestoreAddedToConnectedAccount = addToConnectedAccount
         return restoreResult
     }
 

--- a/data/backup/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/testing/FakeBackupRepository.kt
+++ b/data/backup/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/backup/testing/FakeBackupRepository.kt
@@ -23,7 +23,7 @@ public class FakeBackupRepository : BackupRepository {
         private set
 
     public var lastRestoreLocation: String? = null
-    public var lastRestoreAddedToConnectedAccount: Boolean? = null
+    public var lastRestoreSyncedWithConnectedAccount: Boolean? = null
         private set
 
     private var showsNeedingMetadata: List<Long> = emptyList()
@@ -59,9 +59,9 @@ public class FakeBackupRepository : BackupRepository {
         return writeResult
     }
 
-    override suspend fun restoreBackup(location: String, addToConnectedAccount: Boolean): RestoreResult {
+    override suspend fun restoreBackup(location: String, syncWithConnectedAccount: Boolean): RestoreResult {
         lastRestoreLocation = location
-        lastRestoreAddedToConnectedAccount = addToConnectedAccount
+        lastRestoreSyncedWithConnectedAccount = syncWithConnectedAccount
         return restoreResult
     }
 

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Restore.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/Restore.sq
@@ -5,10 +5,6 @@ import com.thomaskioko.tvmaniac.db.ShowId;
 import com.thomaskioko.tvmaniac.db.TmdbId;
 import com.thomaskioko.tvmaniac.db.WatchStatus;
 
--- Every insert here hardcodes pending_action to 'NOTHING' and writes no provider id, so a restored
--- row cannot reach somebody's Trakt or Simkl account. The rule is in the query rather than in Kotlin
--- because no caller can then pass 'UPLOAD' by mistake.
-
 restoreFollowedShow:
 INSERT INTO followed_shows(show_id, tmdb_id, followed_at, pending_action)
 VALUES(:showId, :tmdbId, :followedAt, 'NOTHING')
@@ -16,6 +12,14 @@ ON CONFLICT(show_id) DO UPDATE SET
     tmdb_id = excluded.tmdb_id,
     followed_at = excluded.followed_at,
     pending_action = 'NOTHING';
+
+restoreFollowedShowForUpload:
+INSERT INTO followed_shows(show_id, tmdb_id, followed_at, pending_action)
+VALUES(:showId, :tmdbId, :followedAt, 'UPLOAD')
+ON CONFLICT(show_id) DO UPDATE SET
+    tmdb_id = excluded.tmdb_id,
+    followed_at = excluded.followed_at,
+    pending_action = 'UPLOAD';
 
 restoreWatchedEpisode:
 INSERT OR REPLACE INTO watched_episodes(

--- a/domain/backup/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/backup/RestoreBackupInteractor.kt
+++ b/domain/backup/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/backup/RestoreBackupInteractor.kt
@@ -12,10 +12,16 @@ public class RestoreBackupInteractor(
     private val taskScheduler: BackgroundTaskScheduler,
 ) : ResultInteractor<RestoreBackupInteractor.Params, RestoreResult>() {
 
-    public data class Params(val location: String)
+    public data class Params(
+        val location: String,
+        val addToConnectedAccount: Boolean = false,
+    )
 
     override suspend fun doWork(params: Params): RestoreResult {
-        val result = backupRepository.restoreBackup(params.location)
+        val result = backupRepository.restoreBackup(
+            location = params.location,
+            addToConnectedAccount = params.addToConnectedAccount,
+        )
         if (result is RestoreResult.Restored) {
             taskScheduler.scheduleAndExecute(RestoredShowsRefillWorker.REQUEST)
         }

--- a/domain/backup/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/backup/RestoreBackupInteractor.kt
+++ b/domain/backup/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/backup/RestoreBackupInteractor.kt
@@ -14,13 +14,13 @@ public class RestoreBackupInteractor(
 
     public data class Params(
         val location: String,
-        val addToConnectedAccount: Boolean = false,
+        val syncWithConnectedAccount: Boolean = false,
     )
 
     override suspend fun doWork(params: Params): RestoreResult {
         val result = backupRepository.restoreBackup(
             location = params.location,
-            addToConnectedAccount = params.addToConnectedAccount,
+            syncWithConnectedAccount = params.syncWithConnectedAccount,
         )
         if (result is RestoreResult.Restored) {
             taskScheduler.scheduleAndExecute(RestoredShowsRefillWorker.REQUEST)

--- a/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsActions.kt
+++ b/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsActions.kt
@@ -117,6 +117,8 @@ public data object BackupImportClicked : SettingsActions
 
 public data object BackupImportConfirmed : SettingsActions
 
+public data object BackupImportConfirmedWithAccount : SettingsActions
+
 public data object BackupImportCancelled : SettingsActions
 
 public data class BackupSourceSelected(

--- a/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsPresenter.kt
+++ b/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsPresenter.kt
@@ -180,7 +180,7 @@ public class SettingsPresenter internal constructor(
                 isImporting = currentState.backup.isImporting,
                 awaitingDestination = currentState.backup.awaitingDestination,
                 awaitingSource = currentState.backup.awaitingSource,
-                addToConnectedAccount = currentState.backup.addToConnectedAccount,
+                syncWithConnectedAccount = currentState.backup.syncWithConnectedAccount,
                 confirm = currentState.backup.confirm,
                 summary = currentState.backup.summary,
             ),
@@ -363,9 +363,9 @@ public class SettingsPresenter internal constructor(
 
             is BackupImportClicked -> handleImportClicked()
 
-            is BackupImportConfirmed -> handleImportConfirmed(addToConnectedAccount = false)
+            is BackupImportConfirmed -> handleImportConfirmed(syncWithConnectedAccount = false)
 
-            is BackupImportConfirmedWithAccount -> handleImportConfirmed(addToConnectedAccount = true)
+            is BackupImportConfirmedWithAccount -> handleImportConfirmed(syncWithConnectedAccount = true)
 
             is BackupImportCancelled -> _state.update { it.copy(backup = backupLabels) }
 
@@ -410,24 +410,24 @@ public class SettingsPresenter internal constructor(
         _state.update { it.copy(backup = backupLabels.copy(confirm = buildRestoreConfirm())) }
     }
 
-    private fun handleImportConfirmed(addToConnectedAccount: Boolean) {
+    private fun handleImportConfirmed(syncWithConnectedAccount: Boolean) {
         _state.update {
             it.copy(
                 backup = backupLabels.copy(
                     awaitingSource = true,
-                    addToConnectedAccount = addToConnectedAccount,
+                    syncWithConnectedAccount = syncWithConnectedAccount,
                 ),
             )
         }
     }
 
     private fun handleBackupSource(location: String) {
-        val addToConnectedAccount = _state.value.backup.addToConnectedAccount
+        val syncWithConnectedAccount = _state.value.backup.syncWithConnectedAccount
         coroutineScope.launch {
             _state.update { it.copy(backup = backupLabels.copy(isImporting = true)) }
             val params = RestoreBackupInteractor.Params(
                 location = location,
-                addToConnectedAccount = addToConnectedAccount,
+                syncWithConnectedAccount = syncWithConnectedAccount,
             )
             when (val result = restoreBackupInteractor.executeSync(params)) {
                 is RestoreResult.Restored ->

--- a/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsPresenter.kt
+++ b/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsPresenter.kt
@@ -179,6 +179,7 @@ public class SettingsPresenter internal constructor(
                 isImporting = currentState.backup.isImporting,
                 awaitingDestination = currentState.backup.awaitingDestination,
                 awaitingSource = currentState.backup.awaitingSource,
+                addToConnectedAccount = currentState.backup.addToConnectedAccount,
                 confirm = currentState.backup.confirm,
                 summary = currentState.backup.summary,
             ),
@@ -361,7 +362,9 @@ public class SettingsPresenter internal constructor(
 
             is BackupImportClicked -> handleImportClicked()
 
-            is BackupImportConfirmed -> handleImportConfirmed()
+            is BackupImportConfirmed -> handleImportConfirmed(addToConnectedAccount = false)
+
+            is BackupImportConfirmedWithAccount -> handleImportConfirmed(addToConnectedAccount = true)
 
             is BackupImportCancelled -> _state.update { it.copy(backup = backupLabels) }
 
@@ -406,14 +409,26 @@ public class SettingsPresenter internal constructor(
         _state.update { it.copy(backup = backupLabels.copy(confirm = buildRestoreConfirm())) }
     }
 
-    private fun handleImportConfirmed() {
-        _state.update { it.copy(backup = backupLabels.copy(awaitingSource = true)) }
+    private fun handleImportConfirmed(addToConnectedAccount: Boolean) {
+        _state.update {
+            it.copy(
+                backup = backupLabels.copy(
+                    awaitingSource = true,
+                    addToConnectedAccount = addToConnectedAccount,
+                ),
+            )
+        }
     }
 
     private fun handleBackupSource(location: String) {
+        val addToConnectedAccount = _state.value.backup.addToConnectedAccount
         coroutineScope.launch {
             _state.update { it.copy(backup = backupLabels.copy(isImporting = true)) }
-            when (val result = restoreBackupInteractor.executeSync(RestoreBackupInteractor.Params(location))) {
+            val params = RestoreBackupInteractor.Params(
+                location = location,
+                addToConnectedAccount = addToConnectedAccount,
+            )
+            when (val result = restoreBackupInteractor.executeSync(params)) {
                 is RestoreResult.Restored ->
                     _state.update { it.copy(backup = backupLabels.copy(summary = buildRestoreSummary(result.summary))) }
 
@@ -444,20 +459,29 @@ public class SettingsPresenter internal constructor(
         )
     }
 
-    private fun buildRestoreConfirm(): BackupRestoreConfirm {
+    private fun buildRestoreConfirm(): BackupRestoreConfirmationDialog {
+        val title = localizer.getString(StringResourceKey.SettingsBackupRestoreConfirmTitle)
+        val cancelLabel = localizer.getString(StringResourceKey.LabelSettingsTraktDialogButtonSecondary)
         val provider = state.value.activeProvider
-        return BackupRestoreConfirm(
-            title = localizer.getString(StringResourceKey.SettingsBackupRestoreConfirmTitle),
-            message = if (provider == null) {
-                localizer.getString(StringResourceKey.SettingsBackupRestoreConfirmMessage)
-            } else {
-                localizer.getString(
-                    StringResourceKey.SettingsBackupRestoreConfirmMessageConnected,
-                    provider.displayName,
-                )
-            },
-            confirmLabel = localizer.getString(StringResourceKey.SettingsBackupRestoreConfirmButton),
-            cancelLabel = localizer.getString(StringResourceKey.LabelSettingsTraktDialogButtonSecondary),
+            ?: return BackupRestoreConfirmationDialog.Local(
+                title = title,
+                message = localizer.getString(StringResourceKey.SettingsBackupRestoreConfirmMessage),
+                cancelLabel = cancelLabel,
+                confirmLabel = localizer.getString(StringResourceKey.SettingsBackupRestoreConfirmButton),
+            )
+
+        return BackupRestoreConfirmationDialog.Connected(
+            title = title,
+            message = localizer.getString(
+                StringResourceKey.SettingsBackupRestoreConfirmMessageConnected,
+                provider.displayName,
+            ),
+            cancelLabel = cancelLabel,
+            accountLabel = localizer.getString(
+                StringResourceKey.SettingsBackupRestoreConfirmAccountButton,
+                provider.displayName,
+            ),
+            deviceLabel = localizer.getString(StringResourceKey.SettingsBackupRestoreConfirmDeviceButton),
         )
     }
 

--- a/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsPresenter.kt
+++ b/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsPresenter.kt
@@ -150,6 +150,7 @@ public class SettingsPresenter internal constructor(
             multiplePlaysEnabled = preferences.multiplePlaysEnabled,
             isAuthenticated = isLoggedIn,
             activeProvider = activeProvider,
+            activeProviderName = activeProvider?.displayName,
             authProviders = authProviderOptions(simklEnabled),
             accountConnectedDescription = activeProvider?.let { connectedDescription(it) },
             switchTargetProvider = switchTarget,

--- a/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsState.kt
+++ b/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsState.kt
@@ -13,6 +13,7 @@ import kotlinx.collections.immutable.persistentListOf
 public data class SettingsState(
     val isAuthenticated: Boolean,
     val activeProvider: SyncProviderSource? = null,
+    val activeProviderName: String? = null,
     val authProviders: ImmutableList<AuthProviderOption> = persistentListOf(),
     val accountConnectedDescription: String? = null,
     val switchTargetProvider: SyncProviderSource? = null,

--- a/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsState.kt
+++ b/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsState.kt
@@ -97,16 +97,31 @@ public data class BackupSettings(
     val importDescription: String = "",
     val isImporting: Boolean = false,
     val awaitingSource: Boolean = false,
-    val confirm: BackupRestoreConfirm? = null,
+    val addToConnectedAccount: Boolean = false,
+    val confirm: BackupRestoreConfirmationDialog? = null,
     val summary: BackupRestoreSummary? = null,
 )
 
-public data class BackupRestoreConfirm(
-    val title: String,
-    val message: String,
-    val confirmLabel: String,
-    val cancelLabel: String,
-)
+public sealed interface BackupRestoreConfirmationDialog {
+    public val title: String
+    public val message: String
+    public val cancelLabel: String
+
+    public data class Local(
+        override val title: String,
+        override val message: String,
+        override val cancelLabel: String,
+        val confirmLabel: String,
+    ) : BackupRestoreConfirmationDialog
+
+    public data class Connected(
+        override val title: String,
+        override val message: String,
+        override val cancelLabel: String,
+        val accountLabel: String,
+        val deviceLabel: String,
+    ) : BackupRestoreConfirmationDialog
+}
 
 public data class BackupRestoreSummary(
     val title: String,

--- a/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsState.kt
+++ b/features/settings/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/settings/presenter/SettingsState.kt
@@ -98,7 +98,7 @@ public data class BackupSettings(
     val importDescription: String = "",
     val isImporting: Boolean = false,
     val awaitingSource: Boolean = false,
-    val addToConnectedAccount: Boolean = false,
+    val syncWithConnectedAccount: Boolean = false,
     val confirm: BackupRestoreConfirmationDialog? = null,
     val summary: BackupRestoreSummary? = null,
 )

--- a/features/settings/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/settings/SettingsPresenterTest.kt
+++ b/features/settings/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/settings/SettingsPresenterTest.kt
@@ -1000,6 +1000,25 @@ class SettingsPresenterTest {
     }
 
     @Test
+    fun `should resolve the provider name given an account is connected`() = runTest {
+        accountManager.setActiveProvider(SyncProviderSource.SIMKL)
+        testScheduler.advanceUntilIdle()
+
+        presenter.state.test {
+            expectMostRecentItem().activeProviderName shouldBe SyncProviderSource.SIMKL.displayName
+        }
+    }
+
+    @Test
+    fun `should resolve no provider name given user is signed out`() = runTest {
+        testScheduler.advanceUntilIdle()
+
+        presenter.state.test {
+            expectMostRecentItem().activeProviderName.shouldBeNull()
+        }
+    }
+
+    @Test
     fun `should name simkl in the account choice given simkl is connected`() = runTest {
         accountManager.setActiveProvider(SyncProviderSource.SIMKL)
         testScheduler.advanceUntilIdle()

--- a/features/settings/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/settings/SettingsPresenterTest.kt
+++ b/features/settings/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/settings/SettingsPresenterTest.kt
@@ -1057,7 +1057,7 @@ class SettingsPresenterTest {
         presenter.dispatch(BackupSourceSelected(LOCATION))
         testScheduler.advanceUntilIdle()
 
-        backupRepository.lastRestoreAddedToConnectedAccount shouldBe true
+        backupRepository.lastRestoreSyncedWithConnectedAccount shouldBe true
     }
 
     @Test
@@ -1069,7 +1069,7 @@ class SettingsPresenterTest {
         presenter.dispatch(BackupSourceSelected(LOCATION))
         testScheduler.advanceUntilIdle()
 
-        backupRepository.lastRestoreAddedToConnectedAccount shouldBe false
+        backupRepository.lastRestoreSyncedWithConnectedAccount shouldBe false
     }
 
     @Test
@@ -1082,7 +1082,7 @@ class SettingsPresenterTest {
         presenter.dispatch(BackupSourceSelected(LOCATION))
         testScheduler.advanceUntilIdle()
 
-        backupRepository.lastRestoreAddedToConnectedAccount shouldBe false
+        backupRepository.lastRestoreSyncedWithConnectedAccount shouldBe false
     }
 
     @Test

--- a/features/settings/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/settings/SettingsPresenterTest.kt
+++ b/features/settings/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/settings/SettingsPresenterTest.kt
@@ -57,6 +57,9 @@ import com.thomaskioko.tvmaniac.settings.presenter.BackupDestinationSelected
 import com.thomaskioko.tvmaniac.settings.presenter.BackupExportClicked
 import com.thomaskioko.tvmaniac.settings.presenter.BackupImportCancelled
 import com.thomaskioko.tvmaniac.settings.presenter.BackupImportClicked
+import com.thomaskioko.tvmaniac.settings.presenter.BackupImportConfirmed
+import com.thomaskioko.tvmaniac.settings.presenter.BackupImportConfirmedWithAccount
+import com.thomaskioko.tvmaniac.settings.presenter.BackupRestoreConfirmationDialog
 import com.thomaskioko.tvmaniac.settings.presenter.BackupSourceSelected
 import com.thomaskioko.tvmaniac.settings.presenter.BlurUnwatchedToggled
 import com.thomaskioko.tvmaniac.settings.presenter.ConfirmSwitchDiscard
@@ -91,6 +94,7 @@ import com.thomaskioko.tvmaniac.util.testing.FakeDateTimeProvider
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -973,6 +977,93 @@ class SettingsPresenterTest {
                 SyncProviderSource.TRAKT.displayName,
             )
         }
+    }
+
+    @Test
+    fun `should offer the account choice given an account is connected`() = runTest {
+        accountManager.setActiveProvider(SyncProviderSource.TRAKT)
+        testScheduler.advanceUntilIdle()
+
+        presenter.dispatch(BackupImportClicked)
+        testScheduler.advanceUntilIdle()
+
+        presenter.state.test {
+            val confirm = expectMostRecentItem().backup.confirm
+                .shouldBeInstanceOf<BackupRestoreConfirmationDialog.Connected>()
+            confirm.accountLabel shouldBe localizer.getString(
+                StringResourceKey.SettingsBackupRestoreConfirmAccountButton,
+                SyncProviderSource.TRAKT.displayName,
+            )
+            confirm.deviceLabel shouldBe
+                localizer.getString(StringResourceKey.SettingsBackupRestoreConfirmDeviceButton)
+        }
+    }
+
+    @Test
+    fun `should name simkl in the account choice given simkl is connected`() = runTest {
+        accountManager.setActiveProvider(SyncProviderSource.SIMKL)
+        testScheduler.advanceUntilIdle()
+
+        presenter.dispatch(BackupImportClicked)
+        testScheduler.advanceUntilIdle()
+
+        presenter.state.test {
+            val confirm = expectMostRecentItem().backup.confirm
+                .shouldBeInstanceOf<BackupRestoreConfirmationDialog.Connected>()
+            confirm.accountLabel shouldBe localizer.getString(
+                StringResourceKey.SettingsBackupRestoreConfirmAccountButton,
+                SyncProviderSource.SIMKL.displayName,
+            )
+        }
+    }
+
+    @Test
+    fun `should offer no account choice given user is signed out`() = runTest {
+        testScheduler.advanceUntilIdle()
+
+        presenter.dispatch(BackupImportClicked)
+        testScheduler.advanceUntilIdle()
+
+        presenter.state.test {
+            expectMostRecentItem().backup.confirm.shouldBeInstanceOf<BackupRestoreConfirmationDialog.Local>()
+        }
+    }
+
+    @Test
+    fun `should restore to the account given the account choice was taken`() = runTest {
+        accountManager.setActiveProvider(SyncProviderSource.TRAKT)
+        testScheduler.advanceUntilIdle()
+
+        presenter.dispatch(BackupImportConfirmedWithAccount)
+        presenter.dispatch(BackupSourceSelected(LOCATION))
+        testScheduler.advanceUntilIdle()
+
+        backupRepository.lastRestoreAddedToConnectedAccount shouldBe true
+    }
+
+    @Test
+    fun `should restore on the device only given the device choice was taken`() = runTest {
+        accountManager.setActiveProvider(SyncProviderSource.TRAKT)
+        testScheduler.advanceUntilIdle()
+
+        presenter.dispatch(BackupImportConfirmed)
+        presenter.dispatch(BackupSourceSelected(LOCATION))
+        testScheduler.advanceUntilIdle()
+
+        backupRepository.lastRestoreAddedToConnectedAccount shouldBe false
+    }
+
+    @Test
+    fun `should forget the account choice given the confirmation is cancelled`() = runTest {
+        accountManager.setActiveProvider(SyncProviderSource.TRAKT)
+        testScheduler.advanceUntilIdle()
+
+        presenter.dispatch(BackupImportConfirmedWithAccount)
+        presenter.dispatch(BackupImportCancelled)
+        presenter.dispatch(BackupSourceSelected(LOCATION))
+        testScheduler.advanceUntilIdle()
+
+        backupRepository.lastRestoreAddedToConnectedAccount shouldBe false
     }
 
     @Test

--- a/features/settings/ui/src/main/kotlin/com/thomaskioko/tvmaniac/settings/ui/SettingsPreviewParameterProvider.kt
+++ b/features/settings/ui/src/main/kotlin/com/thomaskioko/tvmaniac/settings/ui/SettingsPreviewParameterProvider.kt
@@ -7,7 +7,7 @@ import com.thomaskioko.tvmaniac.datastore.api.DiscoverSection
 import com.thomaskioko.tvmaniac.datastore.api.PosterCornerStyle
 import com.thomaskioko.tvmaniac.datastore.api.PosterWidth
 import com.thomaskioko.tvmaniac.domain.theme.ImageQuality
-import com.thomaskioko.tvmaniac.settings.presenter.BackupRestoreConfirm
+import com.thomaskioko.tvmaniac.settings.presenter.BackupRestoreConfirmationDialog
 import com.thomaskioko.tvmaniac.settings.presenter.BackupRestoreSummary
 import com.thomaskioko.tvmaniac.settings.presenter.BackupSettings
 import com.thomaskioko.tvmaniac.settings.presenter.DiscoverSectionToggle
@@ -266,7 +266,7 @@ internal val backupImportingState = backupState.copy(
 )
 internal val backupRestoreConfirmState = backupState.copy(
     backup = backupState.backup.copy(
-        confirm = BackupRestoreConfirm(
+        confirm = BackupRestoreConfirmationDialog.Local(
             title = "Restore this backup?",
             message = "This replaces the shows and watch history on this device. " +
                 "A copy of your current data is saved first.",

--- a/features/settings/ui/src/main/kotlin/com/thomaskioko/tvmaniac/settings/ui/components/BackupPage.kt
+++ b/features/settings/ui/src/main/kotlin/com/thomaskioko/tvmaniac/settings/ui/components/BackupPage.kt
@@ -41,7 +41,8 @@ import com.thomaskioko.tvmaniac.settings.presenter.BackupExportClicked
 import com.thomaskioko.tvmaniac.settings.presenter.BackupImportCancelled
 import com.thomaskioko.tvmaniac.settings.presenter.BackupImportClicked
 import com.thomaskioko.tvmaniac.settings.presenter.BackupImportConfirmed
-import com.thomaskioko.tvmaniac.settings.presenter.BackupRestoreConfirm
+import com.thomaskioko.tvmaniac.settings.presenter.BackupImportConfirmedWithAccount
+import com.thomaskioko.tvmaniac.settings.presenter.BackupRestoreConfirmationDialog
 import com.thomaskioko.tvmaniac.settings.presenter.BackupRestoreSummary
 import com.thomaskioko.tvmaniac.settings.presenter.BackupSourceCancelled
 import com.thomaskioko.tvmaniac.settings.presenter.BackupSourceSelected
@@ -169,25 +170,34 @@ private fun BackupPageContent(
 
     BackupRestoreConfirmDialog(
         confirm = backup.confirm,
-        onConfirm = { onAction(BackupImportConfirmed) },
-        onCancel = { onAction(BackupImportCancelled) },
+        onAction = onAction,
     )
 }
 
 @Composable
 private fun BackupRestoreConfirmDialog(
-    confirm: BackupRestoreConfirm?,
-    onConfirm: () -> Unit,
-    onCancel: () -> Unit,
+    confirm: BackupRestoreConfirmationDialog?,
+    onAction: (SettingsActions) -> Unit,
 ) {
-    if (confirm != null) {
-        TvManiacAlertDialog(
+    when (confirm) {
+        null -> Unit
+        is BackupRestoreConfirmationDialog.Local -> TvManiacAlertDialog(
             title = confirm.title,
             message = confirm.message,
             confirmButtonText = confirm.confirmLabel,
             dismissButtonText = confirm.cancelLabel,
-            onConfirm = onConfirm,
-            onDismiss = onCancel,
+            onConfirm = { onAction(BackupImportConfirmed) },
+            onDismiss = { onAction(BackupImportCancelled) },
+            confirmButtonTestTag = SettingsTestTags.BACKUP_RESTORE_CONFIRM_BUTTON_TEST_TAG,
+            dismissButtonTestTag = SettingsTestTags.BACKUP_RESTORE_DISMISS_BUTTON_TEST_TAG,
+        )
+        is BackupRestoreConfirmationDialog.Connected -> TvManiacAlertDialog(
+            title = confirm.title,
+            message = confirm.message,
+            confirmButtonText = confirm.accountLabel,
+            dismissButtonText = confirm.cancelLabel,
+            onConfirm = { onAction(BackupImportConfirmedWithAccount) },
+            onDismiss = { onAction(BackupImportCancelled) },
             confirmButtonTestTag = SettingsTestTags.BACKUP_RESTORE_CONFIRM_BUTTON_TEST_TAG,
             dismissButtonTestTag = SettingsTestTags.BACKUP_RESTORE_DISMISS_BUTTON_TEST_TAG,
         )

--- a/i18n/generator/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/base/strings.xml
@@ -599,9 +599,12 @@
     <string name="settings_backup_import_description">Replace what is on this device with a backup file</string>
     <string name="settings_backup_restore_confirm_title">Restore this backup?</string>
     <string name="settings_backup_restore_confirm_message">This replaces the shows and watch history on this device. A copy of your current data is saved first.</string>
-    <string name="settings_backup_restore_confirm_message_connected">This replaces the shows and watch history on this device. %1$s remains the source of truth and the next sync will reconcile. A copy of your current data is saved first.</string>
+    <string name="settings_backup_restore_confirm_message_connected">This replaces the shows and watch history on this device, and a copy of your current data is saved first. You are signed in to %1$s, so shows you do not add to it are removed at the next sync.</string>
     <string name="settings_backup_restore_confirm_button">Restore</string>
+    <string name="settings_backup_restore_confirm_account_button">Add to %1$s</string>
+    <string name="settings_backup_restore_confirm_device_button">This device only</string>
     <string name="settings_backup_restore_summary_title">Restore finished</string>
+    <string name="settings_backup_restore_summary_added_to_account">Added to %1$s</string>
     <string name="settings_backup_restore_summary_rewatch">Repeat viewings were not included in this backup</string>
     <string name="error_backup_save_failed">Could not save the backup. Try another location.</string>
     <string name="error_backup_read_failed">Could not read that file. It may be damaged or from another app.</string>

--- a/i18n/generator/src/commonMain/moko-resources/de/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/de/strings.xml
@@ -591,9 +591,12 @@
     <string name="settings_backup_import_description">Die Daten auf diesem Gerät durch eine Sicherungsdatei ersetzen</string>
     <string name="settings_backup_restore_confirm_title">Diese Sicherung wiederherstellen?</string>
     <string name="settings_backup_restore_confirm_message">Dies ersetzt die Serien und den Wiedergabeverlauf auf diesem Gerät. Eine Kopie Ihrer aktuellen Daten wird vorher gespeichert.</string>
-    <string name="settings_backup_restore_confirm_message_connected">Dies ersetzt die Serien und den Wiedergabeverlauf auf diesem Gerät. %1$s bleibt maßgeblich und die nächste Synchronisierung gleicht die Daten ab. Eine Kopie Ihrer aktuellen Daten wird vorher gespeichert.</string>
+    <string name="settings_backup_restore_confirm_message_connected">Dies ersetzt die Serien und den Wiedergabeverlauf auf diesem Gerät. Eine Kopie Ihrer aktuellen Daten wird vorher gespeichert. Sie sind bei %1$s angemeldet, daher werden Serien, die Sie dort nicht hinzufügen, bei der nächsten Synchronisierung entfernt.</string>
     <string name="settings_backup_restore_confirm_button">Wiederherstellen</string>
+    <string name="settings_backup_restore_confirm_account_button">Zu %1$s hinzufügen</string>
+    <string name="settings_backup_restore_confirm_device_button">Nur auf diesem Gerät</string>
     <string name="settings_backup_restore_summary_title">Wiederherstellung abgeschlossen</string>
+    <string name="settings_backup_restore_summary_added_to_account">Zu %1$s hinzugefügt</string>
     <string name="settings_backup_restore_summary_rewatch">Wiederholte Ansichten waren in dieser Sicherung nicht enthalten</string>
     <string name="error_backup_save_failed">Sicherung konnte nicht gespeichert werden. Versuchen Sie einen anderen Speicherort.</string>
     <string name="error_backup_read_failed">Diese Datei konnte nicht gelesen werden. Sie ist möglicherweise beschädigt oder stammt aus einer anderen App.</string>

--- a/i18n/generator/src/commonMain/moko-resources/fr/strings.xml
+++ b/i18n/generator/src/commonMain/moko-resources/fr/strings.xml
@@ -585,9 +585,12 @@
     <string name="settings_backup_import_description">Remplacer les données de cet appareil par un fichier de sauvegarde</string>
     <string name="settings_backup_restore_confirm_title">Restaurer cette sauvegarde ?</string>
     <string name="settings_backup_restore_confirm_message">Cela remplace les séries et l\'historique de cet appareil. Une copie de vos données actuelles est enregistrée au préalable.</string>
-    <string name="settings_backup_restore_confirm_message_connected">Cela remplace les séries et l\'historique de cet appareil. %1$s reste la référence et la prochaine synchronisation mettra les données à jour. Une copie de vos données actuelles est enregistrée au préalable.</string>
+    <string name="settings_backup_restore_confirm_message_connected">Cela remplace les séries et l\'historique de cet appareil. Une copie de vos données actuelles est enregistrée au préalable. Vous êtes connecté à %1$s, donc les séries que vous n\'y ajoutez pas seront supprimées lors de la prochaine synchronisation.</string>
     <string name="settings_backup_restore_confirm_button">Restaurer</string>
+    <string name="settings_backup_restore_confirm_account_button">Ajouter à %1$s</string>
+    <string name="settings_backup_restore_confirm_device_button">Sur cet appareil uniquement</string>
     <string name="settings_backup_restore_summary_title">Restauration terminée</string>
+    <string name="settings_backup_restore_summary_added_to_account">Ajouté à %1$s</string>
     <string name="settings_backup_restore_summary_rewatch">Les visionnages répétés n\'étaient pas inclus dans cette sauvegarde</string>
     <string name="error_backup_save_failed">Impossible d\'enregistrer la sauvegarde. Essayez un autre emplacement.</string>
     <string name="error_backup_read_failed">Impossible de lire ce fichier. Il est peut-être endommagé ou provient d\'une autre application.</string>

--- a/ios/Packages/Settings/Sources/Settings/Mapper+Extensions.swift
+++ b/ios/Packages/Settings/Sources/Settings/Mapper+Extensions.swift
@@ -33,3 +33,12 @@ public extension BackupRestoreSummary {
         )
     }
 }
+
+// MARK: - SyncProviderSource Mapping
+
+public extension SyncProviderSource {
+    var logoAssetName: String {
+        if self == SyncProviderSource.simkl { return "SimklMono" }
+        return "TraktMono"
+    }
+}

--- a/ios/Packages/Settings/Sources/Settings/SettingsView+Backup.swift
+++ b/ios/Packages/Settings/Sources/Settings/SettingsView+Backup.swift
@@ -94,10 +94,20 @@ extension View {
             uiState.backup.confirm?.title ?? "",
             isPresented: showingConfirm,
             actions: {
-                if let confirm = uiState.backup.confirm {
-                    Button(confirm.confirmLabel) {
+                if let local = uiState.backup.confirm as? BackupRestoreConfirmationDialogLocal {
+                    Button(local.confirmLabel) {
                         presenter.dispatch(action: BackupImportConfirmed())
                     }
+                }
+                if let connected = uiState.backup.confirm as? BackupRestoreConfirmationDialogConnected {
+                    Button(connected.accountLabel) {
+                        presenter.dispatch(action: BackupImportConfirmedWithAccount())
+                    }
+                    Button(connected.deviceLabel) {
+                        presenter.dispatch(action: BackupImportConfirmed())
+                    }
+                }
+                if let confirm = uiState.backup.confirm {
                     Button(confirm.cancelLabel, role: .cancel) {
                         presenter.dispatch(action: BackupImportCancelled())
                     }

--- a/ios/Packages/Settings/Sources/Settings/SettingsView+Backup.swift
+++ b/ios/Packages/Settings/Sources/Settings/SettingsView+Backup.swift
@@ -84,8 +84,8 @@ extension View {
         showingConfirm: Binding<Bool>,
         showingSource: Binding<Bool>
     ) -> some View {
-        onChange(of: uiState.backup.confirm) { _, confirm in
-            showingConfirm.wrappedValue = confirm != nil
+        onChange(of: uiState.backup.confirm != nil) { _, isConfirming in
+            showingConfirm.wrappedValue = isConfirming
         }
         .onChange(of: uiState.backup.awaitingSource) { _, awaitingSource in
             showingSource.wrappedValue = awaitingSource

--- a/ios/Packages/Settings/Sources/Settings/SettingsView+Content.swift
+++ b/ios/Packages/Settings/Sources/Settings/SettingsView+Content.swift
@@ -182,7 +182,7 @@ extension SettingsView {
             isProcessingAuth: uiState.isProcessingAuth,
             logoutLabel: uiState.labels.logout,
             loginLabel: uiState.labels.login,
-            providerName: providerDisplayName(uiState.activeProvider),
+            providerName: uiState.activeProviderName ?? "",
             providerLogoName: uiState.activeProvider?.name == "SIMKL" ? "SimklMono" : "TraktMono",
             authProviders: uiState.authProviders.map { option in
                 SwiftAuthProvider(
@@ -213,10 +213,6 @@ extension SettingsView {
             onConfirmSwitch: { presenter.dispatch(action: ConfirmSwitchDiscard()) },
             onDismissSwitchDialog: { presenter.dispatch(action: DismissSwitchDialog()) }
         )
-    }
-
-    func providerDisplayName(_ provider: SyncProviderSource?) -> String {
-        provider?.name == "SIMKL" ? "Simkl" : "Trakt"
     }
 
     // MARK: - Notification Handling

--- a/ios/Packages/Settings/Sources/Settings/SettingsView+Content.swift
+++ b/ios/Packages/Settings/Sources/Settings/SettingsView+Content.swift
@@ -183,16 +183,15 @@ extension SettingsView {
             logoutLabel: uiState.labels.logout,
             loginLabel: uiState.labels.login,
             providerName: uiState.activeProviderName ?? "",
-            providerLogoName: uiState.activeProvider?.name == "SIMKL" ? "SimklMono" : "TraktMono",
+            providerLogoName: uiState.activeProvider?.logoAssetName ?? SyncProviderSource.trakt.logoAssetName,
             authProviders: uiState.authProviders.map { option in
                 SwiftAuthProvider(
                     id: option.provider.name,
                     label: option.label,
-                    logoName: option.provider.name == "SIMKL" ? "SimklMono" : "TraktMono"
+                    logoName: option.provider.logoAssetName
                 )
             },
-            switchTargetLogoName: uiState.switchTargetProvider?
-                .name == "SIMKL" ? "SimklMono" : (uiState.switchTargetProvider != nil ? "TraktMono" : nil),
+            switchTargetLogoName: uiState.switchTargetProvider?.logoAssetName,
             switchActionLabel: uiState.switchActionLabel,
             isSwitching: uiState.isSwitching,
             showSwitchConfirmation: showingSwitchAlert,


### PR DESCRIPTION
## Description
This PR lets a restore add its followed shows to a connected Trakt or Simkl account, so signed in users keep them instead of losing them at the next library sync. Nothing on screen can choose this yet; the option arrives with the settings work.

## Changes
- Add a query that restores a followed show ready for upload, kept separate from the existing one rather than made a parameter, so reaching somebody's account takes naming that query.
- Take the choice through the backup repository and the importer, defaulting to leaving the connected account untouched.
- Cover the three outcomes with tests: a restore that adds to the account, one that does not, and the sync behaviour each one leads to.

## Bug Fixes
- Restoring a backup with an account connected reported success and left the library empty after the next sync. Every restored row was written with no pending action, which is what stops a restore reaching somebody's real account, and the library sync removes exactly those rows when they are missing from the remote watchlist. Marking them for upload uses the same path as following a show by hand, so the sync carries them up instead.
