### PR TITLE
chore: CI tests improvement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,14 +190,32 @@ jobs:
             -   name: 🐘 Setup Gradle Environment
                 uses: ./.github/actions/setup-gradle
 
-            -   name: Run Linux Tests
-                run: ./gradlew linuxTest -Papp.debugOnly=false
+            -   name: Run Unit Tests
+                run: ./gradlew linuxTest -Papp.debugOnly=false -x :app:testDebugUnitTest
 
             -   name: Upload Test Reports
                 uses: actions/upload-artifact@v7
                 if: ${{ !cancelled() }}
                 with:
                     name: linux-test-report
+                    path: '**/build/reports/*'
+
+    integration-test:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v7
+
+            -   name: 🐘 Setup Gradle Environment
+                uses: ./.github/actions/setup-gradle
+
+            -   name: Run Integration Tests
+                run: ./gradlew :app:testDebugUnitTest -Papp.debugOnly=false --continue
+
+            -   name: Upload Test Reports
+                uses: actions/upload-artifact@v7
+                if: ${{ !cancelled() }}
+                with:
+                    name: integration-test-report
                     path: '**/build/reports/*'
 
     ios-test:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,16 @@ android {
     }
 }
 
+tasks.withType<Test>().configureEach {
+    develocity.testRetry {
+        maxRetries = providers.environmentVariable("CI").map { 2 }.orElse(0)
+        failOnPassedAfterRetry = false
+        filter {
+            includeClasses.add("com.thomaskioko.tvmaniac.app.test.compose.*")
+        }
+    }
+}
+
 dependencies {
     implementation(projects.androidDesignsystem)
     implementation(projects.features.root.ui)

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/BaseAppFlowTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/BaseAppFlowTest.kt
@@ -3,7 +3,6 @@ package com.thomaskioko.tvmaniac.app.test
 import androidx.compose.ui.test.AndroidComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runAndroidComposeUiTest
-import androidx.datastore.preferences.core.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.arkivanov.decompose.ComponentContext
@@ -33,31 +32,14 @@ import com.thomaskioko.tvmaniac.app.test.compose.robot.WatchDateSelectionRobot
 import com.thomaskioko.tvmaniac.app.test.compose.stubs.Scenarios
 import com.thomaskioko.tvmaniac.testing.integration.MockEngineHandler
 import com.thomaskioko.tvmaniac.util.testing.FlakyTestRule
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
-/**
- * Base for app-level flow tests that drive the real `TvManiacTestActivity` through Compose.
- *
- * Subclasses wrap their assertions in [runAppFlowTest] which:
- *   * resets the singleton [MockEngineHandler] so stubs from the prior test do not leak,
- *   * recreates the [TestAppComponent] so `Dispatchers.Main.immediate` is captured AFTER
- *     `runAndroidComposeUiTest` installs its own [kotlinx.coroutines.test.TestDispatcher],
- *   * launches the activity inside the v2 `runTest` scope so Compose's main clock and the
- *     coroutines test scheduler share a single [kotlinx.coroutines.test.TestScheduler],
- *   * logs the fake Trakt repository out as a default starting state.
- *
- * The v2 [runAndroidComposeUiTest][androidx.compose.ui.test.v2.runAndroidComposeUiTest] uses
- * `StandardTestDispatcher` semantics: dispatched coroutines queue rather than running
- * immediately. Robots advance the scheduler through `waitForIdle` / `mainClock` calls inside
- * the existing assertion helpers.
- *
- * `@Config(application = TvManiacTestApplication::class)` is honoured by Robolectric;
- * instrumentation ignores it because `TvManiacInstrumentationRunner.newApplication` returns the
- * same Application subclass.
- */
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [33], application = TvManiacTestApplication::class)
 @OptIn(ExperimentalTestApi::class)
@@ -66,20 +48,6 @@ internal abstract class BaseAppFlowTest {
     @get:Rule
     val flakyRule = FlakyTestRule()
 
-    private fun clearPersistedPreferencesViaCurrentGraph(application: TvManiacTestApplication) {
-        runBlocking {
-            application.graph.dataStore.edit { it.clear() }
-        }
-    }
-
-    /**
-     * Runs [block] inside `runAndroidComposeUiTest<TvManiacTestActivity>`, providing an
-     * [AppFlowScope] with all robots, the dependency graph, and ready-made scenarios.
-     *
-     * The scope is rebuilt on every call. The application graph is reset before the activity
-     * launches so the [kotlinx.coroutines.test.TestDispatcher] installed by
-     * [runAndroidComposeUiTest] is the one captured by `AppCoroutineDispatchers`.
-     */
     protected fun runAppFlowTest(block: AppFlowScope.() -> Unit) {
         MockEngineHandler.handler.reset()
         val application = InstrumentationRegistry.getInstrumentation()
@@ -88,17 +56,22 @@ internal abstract class BaseAppFlowTest {
 
         application.resetAppComponent()
         application.clearPersistentTestState()
-        clearPersistedPreferencesViaCurrentGraph(application)
 
-        runAndroidComposeUiTest<TvManiacTestActivity> {
-            val graph = application.graph
-            graph.traktAuthRepository.logout()
-            val scope = AppFlowScope(this, graph)
-            try {
-                scope.block()
-            } finally {
-                scope.tearDown()
+        val testDispatcher = StandardTestDispatcher()
+        Dispatchers.setMain(testDispatcher)
+        try {
+            runAndroidComposeUiTest<TvManiacTestActivity>(effectContext = testDispatcher) {
+                val graph = application.graph
+                graph.traktAuthRepository.logout()
+                val scope = AppFlowScope(this, graph)
+                try {
+                    scope.block()
+                } finally {
+                    scope.tearDown()
+                }
             }
+        } finally {
+            Dispatchers.resetMain()
         }
     }
 }

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/BaseAppFlowTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/BaseAppFlowTest.kt
@@ -120,6 +120,7 @@ internal class AppFlowScope(
             mockHandler = MockEngineHandler.handler,
             graph = graph,
             rootRobot = rootRobot,
+            composeUi = composeUi,
         )
     }
 

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/journey/SimklCalendarJourneyTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/journey/SimklCalendarJourneyTest.kt
@@ -12,8 +12,9 @@ internal class SimklCalendarJourneyTest : BaseAppFlowTest() {
     @Test
     fun givenSimklSession_whenCalendarOpened_thenShowsTrackedShowEpisode() = runAppFlowTest {
         scenarios.stubUnauthenticatedState()
-        scenarios.stubActiveProvider(SyncProviderSource.SIMKL)
-        scenarios.simkl.stubPlanToWatchWatchlist()
+        scenarios.stubActiveProvider(SyncProviderSource.SIMKL) {
+            scenarios.simkl.stubPlanToWatchWatchlist()
+        }
 
         homeRobot
             .clickMyShowsTab()

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/stubs/Scenarios.kt
@@ -1,5 +1,6 @@
 package com.thomaskioko.tvmaniac.app.test.compose.stubs
 
+import androidx.compose.ui.test.ComposeUiTest
 import androidx.datastore.preferences.core.edit
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountAuthState
 import com.thomaskioko.tvmaniac.accountmanager.api.AuthState
@@ -13,7 +14,10 @@ import com.thomaskioko.tvmaniac.testing.integration.MockEngineHandler
 import com.thomaskioko.tvmaniac.testing.integration.TEST_PROFILE_SLUG
 import com.thomaskioko.tvmaniac.testing.integration.TEST_TODAY
 import io.ktor.http.HttpStatusCode
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
 
@@ -34,8 +38,22 @@ internal class Scenarios(
     mockHandler: MockEngineHandler,
     private val graph: TestAppComponent,
     private val rootRobot: RootRobot,
+    private val composeUi: ComposeUiTest,
 ) {
     private val http: HttpScenarios = HttpScenarios(mockHandler)
+
+    private fun runSetup(block: suspend () -> Unit) {
+        var failure: Throwable? = null
+        val job = CoroutineScope(Dispatchers.Main).launch(start = CoroutineStart.UNDISPATCHED) {
+            runCatching { block() }.onFailure { failure = it }
+        }
+        if (!job.isCompleted) composeUi.waitForIdle()
+        check(job.isCompleted) {
+            "Scenario setup did not complete. It must not block the test thread, because every " +
+                "dispatcher role resolves to the scheduler this thread advances."
+        }
+        failure?.let { throw it }
+    }
 
     val auth: Auth = Auth()
     val discover: Discover = Discover()
@@ -51,8 +69,8 @@ internal class Scenarios(
     val settings: Settings = Settings()
 
     fun signInAndDismissRationale() {
-        stubLoggedInUser(SyncProviderSource.TRAKT)
         stubProfileEndpoints(SyncProviderSource.TRAKT)
+        stubLoggedInUser(SyncProviderSource.TRAKT)
         rootRobot.dismissNotificationRationale()
     }
 
@@ -98,17 +116,17 @@ internal class Scenarios(
     }
 
     fun stubAuthenticatedSimklProfile() {
-        stubLoggedInUser(SyncProviderSource.SIMKL)
         stubProfileEndpoints(SyncProviderSource.SIMKL)
         stubLibrarySyncEndpoints(SyncProviderSource.SIMKL)
         simkl.stubActivities()
+        stubLoggedInUser(SyncProviderSource.SIMKL)
     }
 
     fun stubAuthenticatedSimklStartWatching() {
-        stubLoggedInUser(SyncProviderSource.SIMKL)
         stubProfileEndpoints(SyncProviderSource.SIMKL)
         stubWatchlistSyncEndpoints(SyncProviderSource.SIMKL)
         simkl.stubActivities()
+        stubLoggedInUser(SyncProviderSource.SIMKL)
     }
 
     fun stubAuthenticatedSync() {
@@ -144,16 +162,22 @@ internal class Scenarios(
      * Always pair this with [stubPublicCatalog]: it is the only source of TMDB/discover coverage
      * for either provider.
      */
-    fun stubActiveProvider(provider: SyncProviderSource) {
+    fun stubActiveProvider(
+        provider: SyncProviderSource,
+        overrides: () -> Unit = {},
+    ) {
         when (provider) {
             SyncProviderSource.TRAKT -> {
                 stubLoggedInUser(SyncProviderSource.TRAKT)
                 http.stubTraktAuthenticatedEndpoints()
+                overrides()
             }
             SyncProviderSource.SIMKL -> {
                 flags.enableSimklLogin()
                 http.stubSimklAuthenticatedEndpoints()
-                // Sign in LAST (see TRAKT note) so login-triggered sync finds its stubs.
+                // Overrides register after the catalog set because the last stub for a path wins,
+                // and before sign-in because login-triggered sync must find them already there.
+                overrides()
                 stubLoggedInUser(SyncProviderSource.SIMKL)
             }
         }
@@ -227,7 +251,7 @@ internal class Scenarios(
             )
             graph.traktAuthRepository.setAuthState(authState)
             graph.traktAuthRepository.setRefreshOutcome(TokenRefreshResult.Success(authState))
-            runBlocking { graph.traktAuthRepository.setState(AccountAuthState.LOGGED_IN) }
+            runSetup { graph.traktAuthRepository.setState(AccountAuthState.LOGGED_IN) }
             // Mirror the production sign-in path: a successful OAuth handshake
             // calls `saveTokens` which emits `loginEvents`. The fake's
             // `setState(LOGGED_IN)` only flips state, so we also emit the
@@ -242,7 +266,7 @@ internal class Scenarios(
             refreshToken: String = "simkl-test-refresh",
             tokenLifetimeSeconds: Long = 3600,
         ) {
-            runBlocking {
+            runSetup {
                 graph.authStateHolder.saveTokens(
                     provider = SyncProviderSource.SIMKL,
                     accessToken = accessToken,
@@ -357,7 +381,7 @@ internal class Scenarios(
 
     inner class Settings {
         fun disableMultiplePlays() {
-            runBlocking {
+            runSetup {
                 graph.dataStore.edit { preferences ->
                     preferences[DefaultDatastoreRepository.KEY_MULTIPLE_PLAYS_ENABLED] = false
                 }

--- a/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingPresenter.kt
+++ b/features/continue-watching/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/continuewatching/presenter/ContinueWatchingPresenter.kt
@@ -221,11 +221,9 @@ public class ContinueWatchingPresenter internal constructor(
     }
 
     public fun onQueryChanged(query: String) {
-        coroutineScope.launch {
-            queryFlow.emit(query)
-            observeWatchlistSectionsInteractor(query)
-            observeUpNextSectionsInteractor(query)
-        }
+        queryFlow.value = query
+        observeWatchlistSectionsInteractor(query)
+        observeUpNextSectionsInteractor(query)
     }
 
     /**

--- a/features/library/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/library/LibraryPresenter.kt
+++ b/features/library/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presentation/library/LibraryPresenter.kt
@@ -224,17 +224,13 @@ public class LibraryPresenter internal constructor(
     }
 
     private fun updateQuery(query: String) {
-        coroutineScope.launch {
-            queryFlow.emit(query)
-            observeLibrary()
-        }
+        queryFlow.value = query
+        observeLibrary()
     }
 
     private fun clearQuery() {
-        coroutineScope.launch {
-            queryFlow.emit("")
-            observeLibrary()
-        }
+        queryFlow.value = ""
+        observeLibrary()
     }
 
     private fun toggleSearchActive() {


### PR DESCRIPTION
## Description
This PR moves the Robolectric tests into their own job with retry enabled. This should prevent the linux test job from failing and only isolate flaky tests.

## Changes
- Add an `integration-test` job for `:app:testDebugUnitTest` and exclude that task from `linux-test`.
- Enable Develocity test retry on the app flow test package only.
- Share one `StandardTestDispatcher` between app coroutines and composition in `BaseAppFlowTest`.
- Replace the blocking calls in `Scenarios` with a non-blocking setup helper.
- Add an `overrides` block to `stubActiveProvider` so a scenario can replace a saved response before sign-in.

## Bug Fixes
- Update My Shows and Library search so the query text and the filtered list change in the same frame.
