### PR TITLE
feat: Add deeplink parsing and routing for shows and episodes

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1546,10 +1546,12 @@ graph TB
   :features:root:presenter -.-> :core:view
   :features:root:presenter --> :data:account-manager:api
   :features:root:presenter --> :data:datastore:api
+  :features:root:presenter --> :domain:episode
   :features:root:presenter --> :domain:logout
   :features:root:presenter -.-> :domain:theme
   :features:root:presenter --> :domain:user
   :features:root:presenter -.-> :features:debug:nav
+  :features:root:presenter -.-> :features:episode-sheet:nav
   :features:root:presenter --> :features:home:presenter
   :features:root:presenter --> :features:root:nav
   :features:root:presenter -.-> :features:season-details:nav

--- a/core/integration/infra/README.md
+++ b/core/integration/infra/README.md
@@ -254,6 +254,10 @@ graph TB
     direction TB
     :features:discover:nav[nav]:::multiplatform
   end
+  subgraph :features:episode-sheet
+    direction TB
+    :features:episode-sheet:nav[nav]:::multiplatform
+  end
   subgraph :features:home
     direction TB
     :features:home:nav[nav]:::multiplatform
@@ -788,6 +792,7 @@ graph TB
   :domain:user --> :data:user:api
   :features:debug:nav --> :navigation:api
   :features:discover:nav --> :navigation:api
+  :features:episode-sheet:nav --> :navigation:api
   :features:home:nav --> :navigation:api
   :features:home:presenter --> :core:base
   :features:home:presenter --> :domain:user
@@ -810,10 +815,12 @@ graph TB
   :features:root:presenter -.-> :core:view
   :features:root:presenter --> :data:account-manager:api
   :features:root:presenter --> :data:datastore:api
+  :features:root:presenter --> :domain:episode
   :features:root:presenter --> :domain:logout
   :features:root:presenter -.-> :domain:theme
   :features:root:presenter --> :domain:user
   :features:root:presenter -.-> :features:debug:nav
+  :features:root:presenter -.-> :features:episode-sheet:nav
   :features:root:presenter --> :features:home:presenter
   :features:root:presenter --> :features:root:nav
   :features:root:presenter -.-> :features:season-details:nav

--- a/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/EpisodeRepository.kt
+++ b/data/episode/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/api/EpisodeRepository.kt
@@ -135,6 +135,12 @@ public interface EpisodeRepository {
 
     public suspend fun getShowMetadataSyncInfo(showId: Long): ShowMetadataSyncInfo?
 
+    public suspend fun getEpisodeId(
+        showId: Long,
+        seasonNumber: Long,
+        episodeNumber: Long,
+    ): Long?
+
     public companion object {
         public const val ALL_SEASONS: Long = Long.MAX_VALUE
     }

--- a/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepository.kt
+++ b/data/episode/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/implementation/DefaultEpisodeRepository.kt
@@ -277,6 +277,16 @@ public class DefaultEpisodeRepository(
             )
         }
 
+    override suspend fun getEpisodeId(
+        showId: Long,
+        seasonNumber: Long,
+        episodeNumber: Long,
+    ): Long? = episodesDao.getEpisodeByShowSeasonEpisodeNumber(
+        showId = showId,
+        seasonNumber = seasonNumber,
+        episodeNumber = episodeNumber,
+    )?.episode_id?.id
+
     private suspend fun getIncludeSpecials(): Boolean = datastoreRepository.getIncludeSpecials()
 
     private suspend fun cancelPendingSeasonNotifications(

--- a/data/episode/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/testing/FakeEpisodeRepository.kt
+++ b/data/episode/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/episodes/testing/FakeEpisodeRepository.kt
@@ -85,6 +85,7 @@ public class FakeEpisodeRepository : EpisodeRepository {
     private val upcomingEpisodesFlow = MutableStateFlow<List<UpcomingEpisode>>(emptyList())
     private val recentlyWatchedFlow = MutableStateFlow<List<RecentlyWatchedEpisode>>(emptyList())
     private val showMetadataSyncInfo = mutableMapOf<Long, ShowMetadataSyncInfo?>()
+    private val episodeIds = mutableMapOf<Triple<Long, Long, Long>, Long?>()
 
     public var lastMarkEpisodeWatchedCall: MarkEpisodeWatchedCall? = null
         private set
@@ -145,6 +146,15 @@ public class FakeEpisodeRepository : EpisodeRepository {
 
     public fun setShowMetadataSyncInfo(showId: Long, info: ShowMetadataSyncInfo?) {
         showMetadataSyncInfo[showId] = info
+    }
+
+    public fun setEpisodeId(
+        showId: Long,
+        seasonNumber: Long,
+        episodeNumber: Long,
+        episodeId: Long?,
+    ) {
+        episodeIds[Triple(showId, seasonNumber, episodeNumber)] = episodeId
     }
 
     override fun observeEpisodeById(episodeId: Long): Flow<EpisodeById?> =
@@ -285,4 +295,10 @@ public class FakeEpisodeRepository : EpisodeRepository {
 
     override suspend fun getShowMetadataSyncInfo(showId: Long): ShowMetadataSyncInfo? =
         showMetadataSyncInfo[showId]
+
+    override suspend fun getEpisodeId(
+        showId: Long,
+        seasonNumber: Long,
+        episodeNumber: Long,
+    ): Long? = episodeIds[Triple(showId, seasonNumber, episodeNumber)]
 }

--- a/domain/episode/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/episode/ResolveEpisodeIdInteractor.kt
+++ b/domain/episode/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/episode/ResolveEpisodeIdInteractor.kt
@@ -1,0 +1,24 @@
+package com.thomaskioko.tvmaniac.domain.episode
+
+import com.thomaskioko.tvmaniac.core.base.interactor.ResultInteractor
+import com.thomaskioko.tvmaniac.episodes.api.EpisodeRepository
+import dev.zacsweers.metro.Inject
+
+@Inject
+public class ResolveEpisodeIdInteractor(
+    private val episodeRepository: EpisodeRepository,
+) : ResultInteractor<ResolveEpisodeIdParams, Long?>() {
+
+    override suspend fun doWork(params: ResolveEpisodeIdParams): Long? =
+        episodeRepository.getEpisodeId(
+            showId = params.showId,
+            seasonNumber = params.seasonNumber,
+            episodeNumber = params.episodeNumber,
+        )
+}
+
+public data class ResolveEpisodeIdParams(
+    val showId: Long,
+    val seasonNumber: Long,
+    val episodeNumber: Long,
+)

--- a/domain/episode/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/episode/ResolveEpisodeIdInteractorTest.kt
+++ b/domain/episode/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/episode/ResolveEpisodeIdInteractorTest.kt
@@ -1,0 +1,47 @@
+package com.thomaskioko.tvmaniac.domain.episode
+
+import com.thomaskioko.tvmaniac.episodes.testing.FakeEpisodeRepository
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class ResolveEpisodeIdInteractorTest {
+
+    private val episodeRepository = FakeEpisodeRepository()
+    private val interactor = ResolveEpisodeIdInteractor(episodeRepository)
+
+    @Test
+    fun `should return the episode id given the episode is cached`() = runTest {
+        episodeRepository.setEpisodeId(
+            showId = 1399,
+            seasonNumber = 1,
+            episodeNumber = 2,
+            episodeId = 63056,
+        )
+
+        interactor.executeSync(
+            ResolveEpisodeIdParams(showId = 1399, seasonNumber = 1, episodeNumber = 2),
+        ) shouldBe 63056
+    }
+
+    @Test
+    fun `should return null given the episode is not cached`() = runTest {
+        interactor.executeSync(
+            ResolveEpisodeIdParams(showId = 1399, seasonNumber = 1, episodeNumber = 2),
+        ) shouldBe null
+    }
+
+    @Test
+    fun `should return null given only another episode of the same show is cached`() = runTest {
+        episodeRepository.setEpisodeId(
+            showId = 1399,
+            seasonNumber = 1,
+            episodeNumber = 1,
+            episodeId = 63055,
+        )
+
+        interactor.executeSync(
+            ResolveEpisodeIdParams(showId = 1399, seasonNumber = 1, episodeNumber = 2),
+        ) shouldBe null
+    }
+}

--- a/domain/notifications/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/notifications/interactor/SyncCalendarInteractorTest.kt
+++ b/domain/notifications/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/notifications/interactor/SyncCalendarInteractorTest.kt
@@ -129,6 +129,7 @@ private class CountingCalendarEpisodeRepository : EpisodeRepository {
     override fun observeUnwatchedCountInPreviousSeasons(showId: Long, seasonNumber: Long): Flow<Long> = flowOf(0L)
     override suspend fun getUpcomingEpisodesFromFollowedShows(limit: Duration): List<UpcomingEpisode> = emptyList()
     override suspend fun getShowMetadataSyncInfo(showId: Long): ShowMetadataSyncInfo? = null
+    override suspend fun getEpisodeId(showId: Long, seasonNumber: Long, episodeNumber: Long): Long? = null
     override suspend fun syncUpcomingEpisodes(startDate: String, days: Int, forceRefresh: Boolean) {
         syncUpcomingCount++
         lastForceRefresh = forceRefresh

--- a/features/episode-sheet/nav/src/commonMain/kotlin/com/thomaskioko/tvmaniac/espisodedetails/nav/model/ScreenSource.kt
+++ b/features/episode-sheet/nav/src/commonMain/kotlin/com/thomaskioko/tvmaniac/espisodedetails/nav/model/ScreenSource.kt
@@ -8,4 +8,5 @@ public enum class ScreenSource {
     DISCOVER,
     UP_NEXT,
     CALENDAR,
+    DEEP_LINK,
 }

--- a/features/root/nav/build.gradle.kts
+++ b/features/root/nav/build.gradle.kts
@@ -13,5 +13,11 @@ kotlin {
                 api(projects.domain.theme)
             }
         }
+
+        commonTest {
+            dependencies {
+                implementation(libs.bundles.unittest)
+            }
+        }
     }
 }

--- a/features/root/nav/src/commonMain/kotlin/com/thomaskioko/root/model/DeepLinkDestination.kt
+++ b/features/root/nav/src/commonMain/kotlin/com/thomaskioko/root/model/DeepLinkDestination.kt
@@ -16,6 +16,12 @@ public sealed class DeepLinkDestination {
         val forceRefresh: Boolean = false,
     ) : DeepLinkDestination()
 
+    public data class Episode(
+        val showId: Long,
+        val seasonNumber: Long,
+        val episodeNumber: Long,
+    ) : DeepLinkDestination()
+
     public data object DebugMenu : DeepLinkDestination()
 
     public companion object {

--- a/features/root/nav/src/commonMain/kotlin/com/thomaskioko/root/model/DeepLinkParser.kt
+++ b/features/root/nav/src/commonMain/kotlin/com/thomaskioko/root/model/DeepLinkParser.kt
@@ -1,0 +1,48 @@
+package com.thomaskioko.root.model
+
+public object DeepLinkParser {
+
+    public const val SCHEME: String = "tvmaniac"
+
+    private const val HOST_SHOW = "show"
+    private const val HOST_EPISODE = "episode"
+    private const val SHOW_SEGMENTS = 1
+    private const val EPISODE_SEGMENTS = 3
+
+    public fun parse(url: String?): DeepLinkDestination? {
+        val remainder = url?.trim()?.removePrefixOrNull("$SCHEME://") ?: return null
+        val segments = remainder.substringBefore('?')
+            .substringBefore('#')
+            .split('/')
+            .filter { it.isNotBlank() }
+        val host = segments.firstOrNull() ?: return null
+        val path = segments.drop(1)
+
+        return when (host) {
+            HOST_SHOW -> parseShow(path)
+            HOST_EPISODE -> parseEpisode(path)
+            else -> null
+        }
+    }
+
+    private fun parseShow(path: List<String>): DeepLinkDestination? {
+        if (path.size != SHOW_SEGMENTS) return null
+        val showId = path[0].toLongOrNull() ?: return null
+        return DeepLinkDestination.ShowDetails(showId = showId)
+    }
+
+    private fun parseEpisode(path: List<String>): DeepLinkDestination? {
+        if (path.size != EPISODE_SEGMENTS) return null
+        val showId = path[0].toLongOrNull() ?: return null
+        val seasonNumber = path[1].toLongOrNull() ?: return null
+        val episodeNumber = path[2].toLongOrNull() ?: return null
+        return DeepLinkDestination.Episode(
+            showId = showId,
+            seasonNumber = seasonNumber,
+            episodeNumber = episodeNumber,
+        )
+    }
+
+    private fun String.removePrefixOrNull(prefix: String): String? =
+        if (startsWith(prefix, ignoreCase = true)) substring(prefix.length) else null
+}

--- a/features/root/nav/src/commonTest/kotlin/com/thomaskioko/root/model/DeepLinkParserTest.kt
+++ b/features/root/nav/src/commonTest/kotlin/com/thomaskioko/root/model/DeepLinkParserTest.kt
@@ -1,0 +1,76 @@
+package com.thomaskioko.root.model
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class DeepLinkParserTest {
+
+    @Test
+    fun `should return show details given a show url`() {
+        DeepLinkParser.parse("tvmaniac://show/1399") shouldBe
+            DeepLinkDestination.ShowDetails(showId = 1399)
+    }
+
+    @Test
+    fun `should return episode given an episode url`() {
+        DeepLinkParser.parse("tvmaniac://episode/1399/1/2") shouldBe
+            DeepLinkDestination.Episode(
+                showId = 1399,
+                seasonNumber = 1,
+                episodeNumber = 2,
+            )
+    }
+
+    @Test
+    fun `should ignore a query string given a url carrying one`() {
+        DeepLinkParser.parse("tvmaniac://show/1399?source=widget") shouldBe
+            DeepLinkDestination.ShowDetails(showId = 1399)
+    }
+
+    @Test
+    fun `should return null given an unknown host`() {
+        DeepLinkParser.parse("tvmaniac://season/1399/1") shouldBe null
+    }
+
+    @Test
+    fun `should return null given the oauth redirect`() {
+        DeepLinkParser.parse("tvmaniac://auth/trakt") shouldBe null
+    }
+
+    @Test
+    fun `should return null given a missing segment`() {
+        DeepLinkParser.parse("tvmaniac://episode/1399/1") shouldBe null
+    }
+
+    @Test
+    fun `should return null given a trailing segment`() {
+        DeepLinkParser.parse("tvmaniac://show/1399/extra") shouldBe null
+    }
+
+    @Test
+    fun `should return null given a non numeric id`() {
+        DeepLinkParser.parse("tvmaniac://show/breaking-bad") shouldBe null
+    }
+
+    @Test
+    fun `should return null given a non numeric episode number`() {
+        DeepLinkParser.parse("tvmaniac://episode/1399/1/pilot") shouldBe null
+    }
+
+    @Test
+    fun `should return null given another scheme`() {
+        DeepLinkParser.parse("https://show/1399") shouldBe null
+    }
+
+    @Test
+    fun `should return null given no id`() {
+        DeepLinkParser.parse("tvmaniac://show") shouldBe null
+    }
+
+    @Test
+    fun `should return null given a blank or absent url`() {
+        DeepLinkParser.parse(null) shouldBe null
+        DeepLinkParser.parse("") shouldBe null
+        DeepLinkParser.parse("tvmaniac://") shouldBe null
+    }
+}

--- a/features/root/presenter/README.md
+++ b/features/root/presenter/README.md
@@ -166,6 +166,10 @@ graph TB
     direction TB
     :features:discover:nav[nav]:::multiplatform
   end
+  subgraph :features:episode-sheet
+    direction TB
+    :features:episode-sheet:nav[nav]:::multiplatform
+  end
   subgraph :features:home
     direction TB
     :features:home:nav[nav]:::multiplatform
@@ -353,6 +357,7 @@ graph TB
   :domain:user --> :data:user:api
   :features:debug:nav --> :navigation:api
   :features:discover:nav --> :navigation:api
+  :features:episode-sheet:nav --> :navigation:api
   :features:home:nav --> :navigation:api
   :features:home:presenter --> :core:base
   :features:home:presenter --> :domain:user
@@ -375,10 +380,12 @@ graph TB
   :features:root:presenter -.-> :core:view
   :features:root:presenter --> :data:account-manager:api
   :features:root:presenter --> :data:datastore:api
+  :features:root:presenter --> :domain:episode
   :features:root:presenter --> :domain:logout
   :features:root:presenter -.-> :domain:theme
   :features:root:presenter --> :domain:user
   :features:root:presenter -.-> :features:debug:nav
+  :features:root:presenter -.-> :features:episode-sheet:nav
   :features:root:presenter --> :features:home:presenter
   :features:root:presenter --> :features:root:nav
   :features:root:presenter -.-> :features:season-details:nav

--- a/features/root/presenter/build.gradle.kts
+++ b/features/root/presenter/build.gradle.kts
@@ -36,8 +36,10 @@ kotlin {
                 api(libs.coroutines.core)
 
                 implementation(projects.core.view)
+                implementation(projects.domain.episode)
                 implementation(projects.domain.theme)
                 implementation(projects.features.debug.nav)
+                implementation(projects.features.episodeSheet.nav)
                 implementation(projects.features.seasonDetails.nav)
                 implementation(projects.features.settings.presenter)
                 implementation(projects.features.showDetails.nav)

--- a/features/root/presenter/build.gradle.kts
+++ b/features/root/presenter/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
                 api(projects.core.syncstate.api)
                 api(projects.data.accountManager.api)
                 api(projects.data.datastore.api)
+                api(projects.domain.episode)
                 api(projects.domain.logout)
                 api(projects.domain.user)
                 api(projects.features.home.presenter)
@@ -36,7 +37,6 @@ kotlin {
                 api(libs.coroutines.core)
 
                 implementation(projects.core.view)
-                implementation(projects.domain.episode)
                 implementation(projects.domain.theme)
                 implementation(projects.features.debug.nav)
                 implementation(projects.features.episodeSheet.nav)

--- a/features/root/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenter.kt
+++ b/features/root/presenter/src/commonMain/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenter.kt
@@ -25,8 +25,13 @@ import com.thomaskioko.tvmaniac.core.view.UiMessageManager
 import com.thomaskioko.tvmaniac.core.view.collectStatus
 import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
 import com.thomaskioko.tvmaniac.debug.nav.DebugRoute
+import com.thomaskioko.tvmaniac.domain.episode.ResolveEpisodeIdInteractor
+import com.thomaskioko.tvmaniac.domain.episode.ResolveEpisodeIdParams
 import com.thomaskioko.tvmaniac.domain.logout.LogoutInteractor
 import com.thomaskioko.tvmaniac.domain.user.UpdateUserProfileData
+import com.thomaskioko.tvmaniac.espisodedetails.nav.model.EpisodeSheetParam
+import com.thomaskioko.tvmaniac.espisodedetails.nav.model.EpisodeSheetRoute
+import com.thomaskioko.tvmaniac.espisodedetails.nav.model.ScreenSource
 import com.thomaskioko.tvmaniac.i18n.StringResourceKey
 import com.thomaskioko.tvmaniac.i18n.api.Localizer
 import com.thomaskioko.tvmaniac.navigation.NavDestination
@@ -83,6 +88,7 @@ public class DefaultRootPresenter(
     private val accountManager: AccountManager,
     private val updateUserProfileData: UpdateUserProfileData,
     private val logoutInteractor: LogoutInteractor,
+    private val resolveEpisodeIdInteractor: ResolveEpisodeIdInteractor,
     private val logger: Logger,
     private val datastoreRepository: DatastoreRepository,
     private val syncObserver: SyncObserver,
@@ -324,9 +330,33 @@ public class DefaultRootPresenter(
                     ),
                 )
             }
+            is DeepLinkDestination.Episode -> openEpisode(destination)
             is DeepLinkDestination.DebugMenu -> {
                 navigator.navigateTo(DebugRoute)
             }
+        }
+    }
+
+    private fun openEpisode(destination: DeepLinkDestination.Episode) {
+        navigator.navigateTo(
+            ShowDetailsRoute(param = ShowDetailsParam(showId = destination.showId)),
+        )
+        coroutineScope.launch {
+            val episodeId = resolveEpisodeIdInteractor.executeSync(
+                ResolveEpisodeIdParams(
+                    showId = destination.showId,
+                    seasonNumber = destination.seasonNumber,
+                    episodeNumber = destination.episodeNumber,
+                ),
+            ) ?: return@launch
+            navigator.navigateTo(
+                EpisodeSheetRoute(
+                    param = EpisodeSheetParam(
+                        episodeId = episodeId,
+                        source = ScreenSource.DEEP_LINK,
+                    ),
+                ),
+            )
         }
     }
 

--- a/features/root/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenterTest.kt
+++ b/features/root/presenter/src/commonTest/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenterTest.kt
@@ -276,6 +276,21 @@ abstract class DefaultRootPresenterTest {
     }
 
     @Test
+    fun `should open show details given an episode deep link that is not cached`() = runTest(testDispatcher) {
+        presenter.activeTabStack.test {
+            awaitItem().active.instance.shouldBeInstanceOf<RootChild>()
+
+            presenter.onDeepLink(
+                DeepLinkDestination.Episode(showId = 1399, seasonNumber = 1, episodeNumber = 2),
+            )
+            runCurrent()
+
+            awaitItem().active.configuration shouldBe
+                ShowDetailsRoute(param = ShowDetailsParam(showId = 1399))
+        }
+    }
+
+    @Test
     fun `should return initial theme state`() = runTest(testDispatcher) {
         presenter.appUiState.value shouldBe AppUiState()
     }

--- a/features/root/ui/README.md
+++ b/features/root/ui/README.md
@@ -168,6 +168,10 @@ graph TB
     direction TB
     :features:discover:nav[nav]:::multiplatform
   end
+  subgraph :features:episode-sheet
+    direction TB
+    :features:episode-sheet:nav[nav]:::multiplatform
+  end
   subgraph :features:home
     direction TB
     :features:home:nav[nav]:::multiplatform
@@ -361,6 +365,7 @@ graph TB
   :domain:user --> :data:user:api
   :features:debug:nav --> :navigation:api
   :features:discover:nav --> :navigation:api
+  :features:episode-sheet:nav --> :navigation:api
   :features:home:nav --> :navigation:api
   :features:home:presenter --> :core:base
   :features:home:presenter --> :domain:user
@@ -393,10 +398,12 @@ graph TB
   :features:root:presenter -.-> :core:view
   :features:root:presenter --> :data:account-manager:api
   :features:root:presenter --> :data:datastore:api
+  :features:root:presenter --> :domain:episode
   :features:root:presenter --> :domain:logout
   :features:root:presenter -.-> :domain:theme
   :features:root:presenter --> :domain:user
   :features:root:presenter -.-> :features:debug:nav
+  :features:root:presenter -.-> :features:episode-sheet:nav
   :features:root:presenter --> :features:home:presenter
   :features:root:presenter --> :features:root:nav
   :features:root:presenter -.-> :features:season-details:nav

--- a/ios-framework/README.md
+++ b/ios-framework/README.md
@@ -1224,10 +1224,12 @@ graph TB
   :features:root:presenter -.-> :core:view
   :features:root:presenter --> :data:account-manager:api
   :features:root:presenter --> :data:datastore:api
+  :features:root:presenter --> :domain:episode
   :features:root:presenter --> :domain:logout
   :features:root:presenter -.-> :domain:theme
   :features:root:presenter --> :domain:user
   :features:root:presenter -.-> :features:debug:nav
+  :features:root:presenter -.-> :features:episode-sheet:nav
   :features:root:presenter --> :features:home:presenter
   :features:root:presenter --> :features:root:nav
   :features:root:presenter -.-> :features:season-details:nav


### PR DESCRIPTION
## Description
This PR adds deeplink parsing and the routing that opens a show or an episode from a `tvmaniac://` link. Neither platform registers the scheme yet, so nothing reaches this code until the Android and iOS handlers land.

## Changes
- Add `DeepLinkParser` for `tvmaniac://show/{tmdbId}` and `tvmaniac://episode/{showTmdbId}/{season}/{episode}`.
- Add an `Episode` entry to `DeepLinkDestination` and route it to show details with the episode sheet above it.
- Add `getEpisodeId` to `EpisodeRepository` and `ResolveEpisodeIdInteractor`.
- Add a `DEEP_LINK` entry to `ScreenSource`.
