### PR TITLE
feat: Open shows and episodes from a deeplink on Android

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,18 @@
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
+
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+
+        <data android:scheme="tvmaniac" />
+        <data android:host="show" />
+        <data android:host="episode" />
+
+      </intent-filter>
     </activity>
 
     <activity

--- a/app/src/main/kotlin/com/thomaskioko/tvmaniac/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/thomaskioko/tvmaniac/app/MainActivity.kt
@@ -23,6 +23,7 @@ import androidx.core.animation.doOnEnd
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
 import com.thomaskioko.root.model.DeepLinkDestination
+import com.thomaskioko.root.model.DeepLinkParser
 import com.thomaskioko.tvmaniac.app.di.ActivityGraph
 import com.thomaskioko.tvmaniac.app.ui.di.AppRootContent
 import com.thomaskioko.tvmaniac.compose.theme.TvManiacTheme
@@ -108,15 +109,21 @@ public class MainActivity : ComponentActivity() {
             }
         }
 
-        handleNotificationIntent(intent)
+        handleIntent(intent)
     }
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        handleNotificationIntent(intent)
+        handleIntent(intent)
     }
 
-    private fun handleNotificationIntent(intent: Intent?) {
+    private fun handleIntent(intent: Intent?) {
+        val destination = DeepLinkParser.parse(intent?.dataString)
+        if (destination != null) {
+            graph.rootPresenter.onDeepLink(destination)
+            return
+        }
+
         val deepLink = intent?.getStringExtra(DeepLinkDestination.EXTRA_DEEP_LINK)
         if (deepLink == DeepLinkDestination.DEEP_LINK_DEBUG_MENU) {
             graph.rootPresenter.onDeepLink(DeepLinkDestination.DebugMenu)

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/deeplink/DeepLinkToShowDetailsFlowTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/deeplink/DeepLinkToShowDetailsFlowTest.kt
@@ -1,0 +1,25 @@
+package com.thomaskioko.tvmaniac.app.test.compose.flows.deeplink
+
+import com.thomaskioko.root.model.DeepLinkParser
+import com.thomaskioko.tvmaniac.app.test.BaseAppFlowTest
+import org.junit.Test
+
+internal class DeepLinkToShowDetailsFlowTest : BaseAppFlowTest() {
+
+    private val breakingBadTmdbId = 1396L
+
+    @Test
+    fun deepLinkToShowDetailsJourney() = runAppFlowTest {
+        scenarios.discover.stubBrowseGraph()
+
+        discoverRobot.assertFeaturedPagerDisplayed()
+
+        activityGraph.rootPresenter.onDeepLink(
+            requireNotNull(DeepLinkParser.parse("tvmaniac://show/$breakingBadTmdbId")),
+        )
+
+        showDetailsRobot
+            .waitForIdle()
+            .assertShowDetailsDisplayed()
+    }
+}


### PR DESCRIPTION
## Description
This PR registers the `tvmaniac` link scheme on Android and opens the app at the show or episode a link names. Nothing inside the app produces these links yet, so they arrive only from outside until the widget lands.
