### PR TITLE
feat: Add the iOS widget publisher

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1267,6 +1267,7 @@ graph TB
   :domain:widget --> :core:files:api
   :domain:widget --> :core:logger:api
   :domain:widget --> :core:tasks:api
+  :domain:widget --> :core:util:api
   :domain:widget --> :data:upnext:api
   :features:calendar:presenter -.-> :core:base
   :features:calendar:presenter --> :core:logger:api

--- a/domain/widget/README.md
+++ b/domain/widget/README.md
@@ -22,6 +22,10 @@ graph TB
     direction TB
     :core:tasks:api[api]:::multiplatform
   end
+  subgraph :core:util
+    direction TB
+    :core:util:api[api]:::multiplatform
+  end
   subgraph :data:upnext
     direction TB
     :data:upnext:api[api]:::multiplatform
@@ -38,6 +42,7 @@ graph TB
   :domain:widget --> :core:files:api
   :domain:widget --> :core:logger:api
   :domain:widget --> :core:tasks:api
+  :domain:widget --> :core:util:api
   :domain:widget --> :data:upnext:api
 
 classDef application fill:#CAFFBF,stroke:#000,stroke-width:2px,color:#000;

--- a/domain/widget/build.gradle.kts
+++ b/domain/widget/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
                 implementation(projects.core.files.implementation)
                 implementation(projects.core.files.testing)
                 implementation(projects.core.logger.testing)
+                implementation(projects.core.tasks.testing)
                 implementation(projects.core.util.testing)
                 implementation(projects.data.upnext.testing)
             }

--- a/domain/widget/build.gradle.kts
+++ b/domain/widget/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
                 api(projects.core.files.api)
                 api(projects.core.logger.api)
                 api(projects.core.tasks.api)
+                api(projects.core.util.api)
                 api(projects.data.upnext.api)
             }
         }
@@ -26,7 +27,10 @@ kotlin {
             dependencies {
                 implementation(libs.bundles.unittest)
                 implementation(libs.kotlinx.serialization.json)
+                implementation(projects.core.files.implementation)
+                implementation(projects.core.files.testing)
                 implementation(projects.core.logger.testing)
+                implementation(projects.core.util.testing)
                 implementation(projects.data.upnext.testing)
             }
         }

--- a/domain/widget/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/widget/PosterDownloader.kt
+++ b/domain/widget/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/widget/PosterDownloader.kt
@@ -1,0 +1,8 @@
+package com.thomaskioko.tvmaniac.domain.widget
+
+public interface PosterDownloader {
+
+    public suspend fun download(url: String, directoryPath: String, fileName: String): Boolean
+
+    public fun deleteExcept(directoryPath: String, fileNames: Set<String>)
+}

--- a/domain/widget/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/widget/SnapshotWidgetPublisher.kt
+++ b/domain/widget/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/widget/SnapshotWidgetPublisher.kt
@@ -1,0 +1,49 @@
+package com.thomaskioko.tvmaniac.domain.widget
+
+import com.thomaskioko.tvmaniac.core.files.api.JsonFileManager
+import com.thomaskioko.tvmaniac.domain.widget.model.WidgetShow
+import com.thomaskioko.tvmaniac.domain.widget.model.WidgetSnapshot
+import com.thomaskioko.tvmaniac.domain.widget.model.WidgetSnapshotEntry
+import com.thomaskioko.tvmaniac.util.api.DateTimeProvider
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+public class SnapshotWidgetPublisher(
+    private val widgetManager: WidgetManager,
+    private val jsonFileManager: JsonFileManager,
+    private val dateTimeProvider: DateTimeProvider,
+) : WidgetPublisher {
+
+    override suspend fun hasInstalledWidgets(): Boolean = suspendCoroutine { continuation ->
+        widgetManager.hasInstalledWidgets { continuation.resume(it) }
+    }
+
+    override suspend fun publish(shows: List<WidgetShow>) {
+        val directoryPath = widgetManager.containerPath() ?: return
+
+        jsonFileManager.writeToFile(
+            directoryPath = directoryPath,
+            fileName = SNAPSHOT_FILE_NAME,
+            value = WidgetSnapshot(
+                writtenAtMillis = dateTimeProvider.nowMillis(),
+                entries = shows.map { it.toEntry() },
+            ),
+            type = WidgetSnapshot::class,
+        )
+
+        widgetManager.reloadTimelines()
+    }
+
+    private fun WidgetShow.toEntry(): WidgetSnapshotEntry = WidgetSnapshotEntry(
+        tmdbId = tmdbId,
+        showName = showName,
+        episodeName = episodeName,
+        seasonNumber = seasonNumber,
+        episodeNumber = episodeNumber,
+        posterFileName = null,
+    )
+
+    public companion object {
+        public const val SNAPSHOT_FILE_NAME: String = "widget-snapshot.json"
+    }
+}

--- a/domain/widget/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/widget/SnapshotWidgetPublisher.kt
+++ b/domain/widget/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/widget/SnapshotWidgetPublisher.kt
@@ -11,6 +11,7 @@ import kotlin.coroutines.suspendCoroutine
 public class SnapshotWidgetPublisher(
     private val widgetManager: WidgetManager,
     private val jsonFileManager: JsonFileManager,
+    private val posterDownloader: PosterDownloader,
     private val dateTimeProvider: DateTimeProvider,
 ) : WidgetPublisher {
 
@@ -20,13 +21,17 @@ public class SnapshotWidgetPublisher(
 
     override suspend fun publish(shows: List<WidgetShow>) {
         val directoryPath = widgetManager.containerPath() ?: return
+        val postersPath = "$directoryPath/$POSTERS_FOLDER_NAME"
+
+        val entries = shows.map { show -> show.toEntry(postersPath) }
+        posterDownloader.deleteExcept(postersPath, entries.mapNotNull { it.posterFileName }.toSet())
 
         jsonFileManager.writeToFile(
             directoryPath = directoryPath,
             fileName = SNAPSHOT_FILE_NAME,
             value = WidgetSnapshot(
                 writtenAtMillis = dateTimeProvider.nowMillis(),
-                entries = shows.map { it.toEntry() },
+                entries = entries,
             ),
             type = WidgetSnapshot::class,
         )
@@ -34,16 +39,30 @@ public class SnapshotWidgetPublisher(
         widgetManager.reloadTimelines()
     }
 
-    private fun WidgetShow.toEntry(): WidgetSnapshotEntry = WidgetSnapshotEntry(
+    private suspend fun WidgetShow.toEntry(postersPath: String): WidgetSnapshotEntry = WidgetSnapshotEntry(
         tmdbId = tmdbId,
         showName = showName,
         episodeName = episodeName,
         seasonNumber = seasonNumber,
         episodeNumber = episodeNumber,
-        posterFileName = null,
+        posterFileName = downloadPoster(postersPath),
     )
+
+    private suspend fun WidgetShow.downloadPoster(postersPath: String): String? {
+        val path = posterUrl ?: return null
+        val fileName = "$tmdbId.jpg"
+        val downloaded = posterDownloader.download(
+            url = POSTER_URL_PREFIX + path,
+            directoryPath = postersPath,
+            fileName = fileName,
+        )
+        return if (downloaded) fileName else null
+    }
 
     public companion object {
         public const val SNAPSHOT_FILE_NAME: String = "widget-snapshot.json"
+        public const val POSTERS_FOLDER_NAME: String = "widget-posters"
+
+        private const val POSTER_URL_PREFIX = "https://image.tmdb.org/t/p/w185"
     }
 }

--- a/domain/widget/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/widget/WidgetManager.kt
+++ b/domain/widget/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/widget/WidgetManager.kt
@@ -1,0 +1,10 @@
+package com.thomaskioko.tvmaniac.domain.widget
+
+public interface WidgetManager {
+
+    public fun hasInstalledWidgets(onResult: (Boolean) -> Unit)
+
+    public fun containerPath(): String?
+
+    public fun reloadTimelines()
+}

--- a/domain/widget/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/widget/WidgetTasksInitializer.kt
+++ b/domain/widget/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/widget/WidgetTasksInitializer.kt
@@ -1,0 +1,51 @@
+package com.thomaskioko.tvmaniac.domain.widget
+
+import com.thomaskioko.tvmaniac.core.base.IoCoroutineScope
+import com.thomaskioko.tvmaniac.core.logger.Logger
+import com.thomaskioko.tvmaniac.core.tasks.api.BackgroundTaskScheduler
+import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
+
+@Inject
+public class WidgetTasksInitializer(
+    private val scheduler: BackgroundTaskScheduler,
+    private val observeWidgetShowsInteractor: ObserveWidgetShowsInteractor,
+    private val widgetPublishers: Set<WidgetPublisher>,
+    private val logger: Logger,
+    @IoCoroutineScope private val coroutineScope: CoroutineScope,
+) {
+
+    public fun init() {
+        if (widgetPublishers.isEmpty()) return
+
+        scheduler.schedulePeriodic(WidgetRefreshWorker.REQUEST)
+        publishOnChange()
+    }
+
+    private fun publishOnChange() {
+        coroutineScope.launch {
+            observeWidgetShowsInteractor.flow
+                .onStart { observeWidgetShowsInteractor(Unit) }
+                .distinctUntilChanged()
+                .collect { shows ->
+                    try {
+                        widgetPublishers
+                            .filter { it.hasInstalledWidgets() }
+                            .forEach { it.publish(shows) }
+                    } catch (cancellation: CancellationException) {
+                        throw cancellation
+                    } catch (throwable: Exception) {
+                        logger.error(TAG, "Widget publish failed: ${throwable.message}")
+                    }
+                }
+        }
+    }
+
+    private companion object {
+        private const val TAG = "WidgetTasksInitializer"
+    }
+}

--- a/domain/widget/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/widget/di/WidgetTasksInitializerBindingContainer.kt
+++ b/domain/widget/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/widget/di/WidgetTasksInitializerBindingContainer.kt
@@ -1,0 +1,23 @@
+package com.thomaskioko.tvmaniac.domain.widget.di
+
+import com.thomaskioko.tvmaniac.core.base.AsyncInitializers
+import com.thomaskioko.tvmaniac.core.base.Initializer
+import com.thomaskioko.tvmaniac.domain.widget.WidgetTasksInitializer
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.IntoSet
+import dev.zacsweers.metro.Provides
+
+@BindingContainer
+@ContributesTo(AppScope::class)
+public interface WidgetTasksInitializerBindingContainer {
+    public companion object {
+        @Provides
+        @IntoSet
+        @AsyncInitializers
+        public fun provideWidgetTasksInitializer(
+            bind: WidgetTasksInitializer,
+        ): Initializer = Initializer { bind.init() }
+    }
+}

--- a/domain/widget/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/widget/FakePosterDownloader.kt
+++ b/domain/widget/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/widget/FakePosterDownloader.kt
@@ -1,0 +1,24 @@
+package com.thomaskioko.tvmaniac.domain.widget
+
+class FakePosterDownloader : PosterDownloader {
+    private var succeeds: Boolean = true
+    private val requestedUrls = mutableListOf<String>()
+    private var keptFileNames: Set<String>? = null
+
+    fun setSucceeds(succeeds: Boolean) {
+        this.succeeds = succeeds
+    }
+
+    fun getRequestedUrls(): List<String> = requestedUrls.toList()
+
+    fun getKeptFileNames(): Set<String>? = keptFileNames
+
+    override suspend fun download(url: String, directoryPath: String, fileName: String): Boolean {
+        requestedUrls += url
+        return succeeds
+    }
+
+    override fun deleteExcept(directoryPath: String, fileNames: Set<String>) {
+        keptFileNames = fileNames
+    }
+}

--- a/domain/widget/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/widget/FakeWidgetManager.kt
+++ b/domain/widget/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/widget/FakeWidgetManager.kt
@@ -1,0 +1,27 @@
+package com.thomaskioko.tvmaniac.domain.widget
+
+class FakeWidgetManager : WidgetManager {
+    private var installed: Boolean = false
+    private var path: String? = null
+    private var reloadCount: Int = 0
+
+    fun setInstalled(installed: Boolean) {
+        this.installed = installed
+    }
+
+    fun setContainerPath(path: String?) {
+        this.path = path
+    }
+
+    fun getReloadCount(): Int = reloadCount
+
+    override fun hasInstalledWidgets(onResult: (Boolean) -> Unit) {
+        onResult(installed)
+    }
+
+    override fun containerPath(): String? = path
+
+    override fun reloadTimelines() {
+        reloadCount++
+    }
+}

--- a/domain/widget/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/widget/SnapshotWidgetPublisherTest.kt
+++ b/domain/widget/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/widget/SnapshotWidgetPublisherTest.kt
@@ -1,0 +1,85 @@
+package com.thomaskioko.tvmaniac.domain.widget
+
+import com.thomaskioko.tvmaniac.core.files.implementation.DefaultJsonFileManager
+import com.thomaskioko.tvmaniac.core.files.testing.FakeFileManager
+import com.thomaskioko.tvmaniac.domain.widget.model.WidgetShow
+import com.thomaskioko.tvmaniac.domain.widget.model.WidgetSnapshot
+import com.thomaskioko.tvmaniac.util.testing.FakeDateTimeProvider
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class SnapshotWidgetPublisherTest {
+
+    private val directory = "/containers/group.com.thomaskioko.tvmaniac"
+    private val bridge = FakeWidgetManager()
+    private val fileManager = FakeFileManager()
+    private val jsonFileManager = DefaultJsonFileManager(fileManager)
+    private val publisher = SnapshotWidgetPublisher(
+        widgetManager = bridge,
+        jsonFileManager = jsonFileManager,
+        dateTimeProvider = FakeDateTimeProvider(),
+    )
+
+    @Test
+    fun `should report widgets are installed given one is added`() = runTest {
+        bridge.setInstalled(true)
+
+        publisher.hasInstalledWidgets() shouldBe true
+    }
+
+    @Test
+    fun `should report no widgets given none is added`() = runTest {
+        bridge.setInstalled(false)
+
+        publisher.hasInstalledWidgets() shouldBe false
+    }
+
+    @Test
+    fun `should write the shows given a container exists`() = runTest {
+        bridge.setContainerPath(directory)
+
+        publisher.publish(listOf(show()))
+
+        val written = jsonFileManager.getFileContent(directory, SnapshotWidgetPublisher.SNAPSHOT_FILE_NAME, WidgetSnapshot::class)
+        written?.entries?.single()?.showName shouldBe "Breaking Bad"
+    }
+
+    @Test
+    fun `should reload the widget given the shows were written`() = runTest {
+        bridge.setContainerPath(directory)
+
+        publisher.publish(listOf(show()))
+
+        bridge.getReloadCount() shouldBe 1
+    }
+
+    @Test
+    fun `should write nothing given no container exists`() = runTest {
+        bridge.setContainerPath(null)
+
+        publisher.publish(listOf(show()))
+
+        fileManager.contentsOf(directory, SnapshotWidgetPublisher.SNAPSHOT_FILE_NAME) shouldBe null
+        bridge.getReloadCount() shouldBe 0
+    }
+
+    @Test
+    fun `should write an empty list given no shows`() = runTest {
+        bridge.setContainerPath(directory)
+
+        publisher.publish(emptyList())
+
+        val written = jsonFileManager.getFileContent(directory, SnapshotWidgetPublisher.SNAPSHOT_FILE_NAME, WidgetSnapshot::class)
+        written?.entries shouldBe emptyList()
+    }
+
+    private fun show() = WidgetShow(
+        tmdbId = 1396,
+        showName = "Breaking Bad",
+        episodeName = "Pilot",
+        seasonNumber = 1,
+        episodeNumber = 1,
+        posterUrl = "/poster.jpg",
+    )
+}

--- a/domain/widget/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/widget/SnapshotWidgetPublisherTest.kt
+++ b/domain/widget/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/widget/SnapshotWidgetPublisherTest.kt
@@ -77,6 +77,16 @@ class SnapshotWidgetPublisherTest {
     }
 
     @Test
+    fun `should delete every poster given the watchlist was cleared`() = runTest {
+        bridge.setContainerPath(directory)
+        publisher.publish(listOf(show()))
+
+        publisher.publish(emptyList())
+
+        posterDownloader.getKeptFileNames() shouldBe emptySet()
+    }
+
+    @Test
     fun `should request the poster at the widget size`() = runTest {
         bridge.setContainerPath(directory)
 

--- a/domain/widget/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/widget/SnapshotWidgetPublisherTest.kt
+++ b/domain/widget/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/widget/SnapshotWidgetPublisherTest.kt
@@ -15,9 +15,11 @@ class SnapshotWidgetPublisherTest {
     private val bridge = FakeWidgetManager()
     private val fileManager = FakeFileManager()
     private val jsonFileManager = DefaultJsonFileManager(fileManager)
+    private val posterDownloader = FakePosterDownloader()
     private val publisher = SnapshotWidgetPublisher(
         widgetManager = bridge,
         jsonFileManager = jsonFileManager,
+        posterDownloader = posterDownloader,
         dateTimeProvider = FakeDateTimeProvider(),
     )
 
@@ -72,6 +74,54 @@ class SnapshotWidgetPublisherTest {
 
         val written = jsonFileManager.getFileContent(directory, SnapshotWidgetPublisher.SNAPSHOT_FILE_NAME, WidgetSnapshot::class)
         written?.entries shouldBe emptyList()
+    }
+
+    @Test
+    fun `should request the poster at the widget size`() = runTest {
+        bridge.setContainerPath(directory)
+
+        publisher.publish(listOf(show()))
+
+        posterDownloader.getRequestedUrls().single() shouldBe "https://image.tmdb.org/t/p/w185/poster.jpg"
+    }
+
+    @Test
+    fun `should name the poster after the show`() = runTest {
+        bridge.setContainerPath(directory)
+
+        publisher.publish(listOf(show()))
+
+        val written = jsonFileManager.getFileContent(directory, SnapshotWidgetPublisher.SNAPSHOT_FILE_NAME, WidgetSnapshot::class)
+        written?.entries?.single()?.posterFileName shouldBe "1396.jpg"
+    }
+
+    @Test
+    fun `should write no poster name given the download fails`() = runTest {
+        bridge.setContainerPath(directory)
+        posterDownloader.setSucceeds(false)
+
+        publisher.publish(listOf(show()))
+
+        val written = jsonFileManager.getFileContent(directory, SnapshotWidgetPublisher.SNAPSHOT_FILE_NAME, WidgetSnapshot::class)
+        written?.entries?.single()?.posterFileName shouldBe null
+    }
+
+    @Test
+    fun `should write no poster name given the show has none`() = runTest {
+        bridge.setContainerPath(directory)
+
+        publisher.publish(listOf(show().copy(posterUrl = null)))
+
+        posterDownloader.getRequestedUrls() shouldBe emptyList()
+    }
+
+    @Test
+    fun `should keep only the posters it wrote`() = runTest {
+        bridge.setContainerPath(directory)
+
+        publisher.publish(listOf(show()))
+
+        posterDownloader.getKeptFileNames() shouldBe setOf("1396.jpg")
     }
 
     private fun show() = WidgetShow(

--- a/domain/widget/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/widget/WidgetTasksInitializerTest.kt
+++ b/domain/widget/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/widget/WidgetTasksInitializerTest.kt
@@ -1,0 +1,124 @@
+package com.thomaskioko.tvmaniac.domain.widget
+
+import com.thomaskioko.tvmaniac.core.logger.fixture.FakeLogger
+import com.thomaskioko.tvmaniac.core.tasks.testing.FakeBackgroundTaskScheduler
+import com.thomaskioko.tvmaniac.upnext.api.model.NextEpisodeWithShow
+import com.thomaskioko.tvmaniac.upnext.testing.FakeUpNextRepository
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WidgetTasksInitializerTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val scheduler = FakeBackgroundTaskScheduler()
+    private val repository = FakeUpNextRepository()
+    private val interactor = ObserveWidgetShowsInteractor(repository)
+
+    @Test
+    fun `should schedule the refresh worker given a publisher exists`() = runTest(testDispatcher) {
+        buildInitializer(FakeWidgetPublisher()).init()
+        runCurrent()
+
+        scheduler.getScheduledRequests().single().id shouldBe WidgetRefreshWorker.WORKER_NAME
+    }
+
+    @Test
+    fun `should schedule nothing given no publisher exists`() = runTest(testDispatcher) {
+        buildInitializer().init()
+        runCurrent()
+
+        scheduler.getScheduledRequests() shouldBe emptyList()
+    }
+
+    @Test
+    fun `should publish the shows given a widget is added`() = runTest(testDispatcher) {
+        repository.setNextEpisodesForWatchlist(listOf(episode()))
+        val publisher = FakeWidgetPublisher().apply { setInstalled(true) }
+
+        buildInitializer(publisher).init()
+        runCurrent()
+
+        publisher.getPublishedShows()?.single()?.showName shouldBe "Breaking Bad"
+    }
+
+    @Test
+    fun `should publish nothing given no widget is added`() = runTest(testDispatcher) {
+        repository.setNextEpisodesForWatchlist(listOf(episode()))
+        val publisher = FakeWidgetPublisher().apply { setInstalled(false) }
+
+        buildInitializer(publisher).init()
+        runCurrent()
+
+        publisher.getPublishedShows() shouldBe null
+    }
+
+    @Test
+    fun `should publish again given the watchlist changed`() = runTest(testDispatcher) {
+        repository.setNextEpisodesForWatchlist(listOf(episode()))
+        val publisher = FakeWidgetPublisher().apply { setInstalled(true) }
+
+        buildInitializer(publisher).init()
+        runCurrent()
+
+        repository.setNextEpisodesForWatchlist(listOf(episode(showId = 60059, showName = "Better Call Saul")))
+        runCurrent()
+
+        publisher.getPublishedShows()?.single()?.showName shouldBe "Better Call Saul"
+    }
+
+    @Test
+    fun `should keep collecting given publishing fails`() = runTest(testDispatcher) {
+        repository.setNextEpisodesForWatchlist(listOf(episode()))
+        val publisher = FakeWidgetPublisher().apply {
+            setInstalled(true)
+            setFailure(IllegalStateException("no container"))
+        }
+
+        buildInitializer(publisher).init()
+        runCurrent()
+
+        scheduler.getScheduledRequests().single().id shouldBe WidgetRefreshWorker.WORKER_NAME
+    }
+
+    private val collectScope = CoroutineScope(testDispatcher + Job())
+
+    @AfterTest
+    fun tearDown() {
+        collectScope.cancel()
+    }
+
+    private fun buildInitializer(vararg publishers: WidgetPublisher) = WidgetTasksInitializer(
+        scheduler = scheduler,
+        observeWidgetShowsInteractor = interactor,
+        widgetPublishers = publishers.toSet(),
+        logger = FakeLogger(),
+        coroutineScope = collectScope,
+    )
+
+    private fun episode(showId: Long = 1396, showName: String = "Breaking Bad") = NextEpisodeWithShow(
+        showId = showId,
+        showName = showName,
+        showPoster = "/poster.jpg",
+        showStatus = "Ended",
+        showYear = "2008",
+        episodeId = 1,
+        episodeName = "Pilot",
+        seasonId = 1,
+        seasonNumber = 1,
+        episodeNumber = 1,
+        runtime = 45,
+        stillPath = "/still.jpg",
+        overview = "",
+        watchedCount = 0,
+        totalCount = 62,
+    )
+}

--- a/ios-framework/README.md
+++ b/ios-framework/README.md
@@ -322,6 +322,7 @@ graph TB
     :domain:theme[theme]:::multiplatform
     :domain:traktlists[traktlists]:::multiplatform
     :domain:user[user]:::multiplatform
+    :domain:widget[widget]:::multiplatform
   end
   subgraph :features:calendar
     direction TB
@@ -1053,6 +1054,12 @@ graph TB
   :domain:user --> :data:account-manager:api
   :domain:user --> :data:traktlists:api
   :domain:user --> :data:user:api
+  :domain:widget --> :core:base
+  :domain:widget --> :core:files:api
+  :domain:widget --> :core:logger:api
+  :domain:widget --> :core:tasks:api
+  :domain:widget --> :core:util:api
+  :domain:widget --> :data:upnext:api
   :features:calendar:presenter -.-> :core:base
   :features:calendar:presenter --> :core:logger:api
   :features:calendar:presenter --> :core:view
@@ -1537,6 +1544,7 @@ graph TB
   :ios-framework -.-> :domain:theme
   :ios-framework -.-> :domain:traktlists
   :ios-framework -.-> :domain:user
+  :ios-framework --> :domain:widget
   :ios-framework --> :features:calendar:presenter
   :ios-framework --> :features:continue-watching:presenter
   :ios-framework --> :features:debug:presenter

--- a/ios-framework/build.gradle.kts
+++ b/ios-framework/build.gradle.kts
@@ -126,6 +126,7 @@ kotlin {
                 implementation(projects.features.seasonDetails.nav)
                 api(projects.features.showDetails.nav)
                 api(projects.core.files.api)
+                api(projects.domain.widget)
                 api(projects.core.files.implementation)
                 api(projects.core.deeplink.api)
                 api(projects.core.deeplink.implementation)

--- a/ios-framework/src/iosMain/kotlin/com.thomaskioko.tvmaniac.iosframework/IosApplicationGraph.kt
+++ b/ios-framework/src/iosMain/kotlin/com.thomaskioko.tvmaniac.iosframework/IosApplicationGraph.kt
@@ -9,6 +9,7 @@ import com.thomaskioko.tvmaniac.core.base.AppInitializers
 import com.thomaskioko.tvmaniac.core.base.IsDebugBuild
 import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.core.tasks.api.BackgroundTaskScheduler
+import com.thomaskioko.tvmaniac.domain.widget.WidgetManager
 import com.thomaskioko.tvmaniac.featureflags.RemoteConfigBridge
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.DependencyGraph
@@ -30,6 +31,7 @@ public interface IosApplicationGraph {
         public fun create(
             @Provides @IsDebugBuild isDebug: Boolean,
             @Provides remoteConfigBridge: RemoteConfigBridge,
+            @Provides widgetManager: WidgetManager,
         ): IosApplicationGraph
     }
 }

--- a/ios-framework/src/iosMain/kotlin/com.thomaskioko.tvmaniac.iosframework/di/WidgetPublisherBindingContainer.kt
+++ b/ios-framework/src/iosMain/kotlin/com.thomaskioko.tvmaniac.iosframework/di/WidgetPublisherBindingContainer.kt
@@ -1,0 +1,31 @@
+package com.thomaskioko.tvmaniac.iosframework.di
+
+import com.thomaskioko.tvmaniac.core.files.api.JsonFileManager
+import com.thomaskioko.tvmaniac.domain.widget.SnapshotWidgetPublisher
+import com.thomaskioko.tvmaniac.domain.widget.WidgetManager
+import com.thomaskioko.tvmaniac.domain.widget.WidgetPublisher
+import com.thomaskioko.tvmaniac.util.api.DateTimeProvider
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.IntoSet
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+
+@BindingContainer
+@ContributesTo(AppScope::class)
+public object WidgetPublisherBindingContainer {
+
+    @Provides
+    @IntoSet
+    @SingleIn(AppScope::class)
+    public fun provideWidgetPublisher(
+        widgetManager: WidgetManager,
+        jsonFileManager: JsonFileManager,
+        dateTimeProvider: DateTimeProvider,
+    ): WidgetPublisher = SnapshotWidgetPublisher(
+        widgetManager = widgetManager,
+        jsonFileManager = jsonFileManager,
+        dateTimeProvider = dateTimeProvider,
+    )
+}

--- a/ios-framework/src/iosMain/kotlin/com.thomaskioko.tvmaniac.iosframework/di/WidgetPublisherBindingContainer.kt
+++ b/ios-framework/src/iosMain/kotlin/com.thomaskioko.tvmaniac.iosframework/di/WidgetPublisherBindingContainer.kt
@@ -1,9 +1,12 @@
 package com.thomaskioko.tvmaniac.iosframework.di
 
 import com.thomaskioko.tvmaniac.core.files.api.JsonFileManager
+import com.thomaskioko.tvmaniac.core.logger.Logger
+import com.thomaskioko.tvmaniac.domain.widget.PosterDownloader
 import com.thomaskioko.tvmaniac.domain.widget.SnapshotWidgetPublisher
 import com.thomaskioko.tvmaniac.domain.widget.WidgetManager
 import com.thomaskioko.tvmaniac.domain.widget.WidgetPublisher
+import com.thomaskioko.tvmaniac.iosframework.widget.IosPosterDownloader
 import com.thomaskioko.tvmaniac.util.api.DateTimeProvider
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.BindingContainer
@@ -17,15 +20,21 @@ import dev.zacsweers.metro.SingleIn
 public object WidgetPublisherBindingContainer {
 
     @Provides
+    @SingleIn(AppScope::class)
+    public fun providePosterDownloader(logger: Logger): PosterDownloader = IosPosterDownloader(logger)
+
+    @Provides
     @IntoSet
     @SingleIn(AppScope::class)
     public fun provideWidgetPublisher(
         widgetManager: WidgetManager,
         jsonFileManager: JsonFileManager,
+        posterDownloader: PosterDownloader,
         dateTimeProvider: DateTimeProvider,
     ): WidgetPublisher = SnapshotWidgetPublisher(
         widgetManager = widgetManager,
         jsonFileManager = jsonFileManager,
+        posterDownloader = posterDownloader,
         dateTimeProvider = dateTimeProvider,
     )
 }

--- a/ios-framework/src/iosMain/kotlin/com.thomaskioko.tvmaniac.iosframework/widget/IosPosterDownloader.kt
+++ b/ios-framework/src/iosMain/kotlin/com.thomaskioko.tvmaniac.iosframework/widget/IosPosterDownloader.kt
@@ -1,0 +1,53 @@
+package com.thomaskioko.tvmaniac.iosframework.widget
+
+import com.thomaskioko.tvmaniac.core.logger.Logger
+import com.thomaskioko.tvmaniac.domain.widget.PosterDownloader
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSData
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSURL
+import platform.Foundation.dataWithContentsOfURL
+import platform.Foundation.writeToFile
+import platform.UIKit.UIImage
+import platform.UIKit.UIImageJPEGRepresentation
+
+@OptIn(ExperimentalForeignApi::class)
+public class IosPosterDownloader(
+    private val logger: Logger,
+) : PosterDownloader {
+
+    override suspend fun download(url: String, directoryPath: String, fileName: String): Boolean {
+        val destination = "$directoryPath/$fileName"
+        if (NSFileManager.defaultManager.fileExistsAtPath(destination)) return true
+
+        val remoteUrl = NSURL.URLWithString(url) ?: return false
+        val data = NSData.dataWithContentsOfURL(remoteUrl) ?: return false
+        val image = UIImage.imageWithData(data) ?: return false
+        val jpeg = UIImageJPEGRepresentation(image, JPEG_QUALITY) ?: return false
+
+        NSFileManager.defaultManager.createDirectoryAtPath(
+            path = directoryPath,
+            withIntermediateDirectories = true,
+            attributes = null,
+            error = null,
+        )
+
+        val written = jpeg.writeToFile(destination, atomically = true)
+        if (!written) logger.error(TAG, "Could not write poster to $destination")
+        return written
+    }
+
+    override fun deleteExcept(directoryPath: String, fileNames: Set<String>) {
+        val manager = NSFileManager.defaultManager
+        val existing = manager.contentsOfDirectoryAtPath(directoryPath, error = null) ?: return
+
+        existing.filterIsInstance<String>()
+            .filterNot { fileNames.contains(it) }
+            .forEach { manager.removeItemAtPath("$directoryPath/$it", error = null) }
+    }
+
+    private companion object {
+        private const val TAG = "IosPosterDownloader"
+        private const val JPEG_QUALITY = 0.8
+    }
+}

--- a/ios/Packages/TvManiacKit/Sources/TvManiacKit/AppDelegate.swift
+++ b/ios/Packages/TvManiacKit/Sources/TvManiacKit/AppDelegate.swift
@@ -10,7 +10,8 @@ import UserNotifications
 public class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
     public lazy var appGraph: IosApplicationGraph = IosApplicationGraphCompanion.shared.create(
         isDebug: Self.isDebugBuild,
-        remoteConfigBridge: Self.makeRemoteConfigBridge()
+        remoteConfigBridge: Self.makeRemoteConfigBridge(),
+        widgetManager: IosWidgetManager()
     )
 
     public lazy var logger = appGraph.logger

--- a/ios/Packages/TvManiacKit/Sources/TvManiacKit/IosWidgetManager.swift
+++ b/ios/Packages/TvManiacKit/Sources/TvManiacKit/IosWidgetManager.swift
@@ -1,0 +1,26 @@
+import Models
+import TvManiac
+import WidgetKit
+
+final class IosWidgetManager: WidgetWidgetManager {
+    private let kind = "TvManiacUpNextWidget"
+
+    func hasInstalledWidgets(onResult: @escaping (KotlinBoolean) -> Void) {
+        WidgetCenter.shared.getCurrentConfigurations { result in
+            switch result {
+            case let .success(widgets):
+                onResult(KotlinBoolean(bool: !widgets.isEmpty))
+            case .failure:
+                onResult(KotlinBoolean(bool: false))
+            }
+        }
+    }
+
+    func containerPath() -> String? {
+        WidgetContainer.directoryURL()?.path
+    }
+
+    func reloadTimelines() {
+        WidgetCenter.shared.reloadTimelines(ofKind: kind)
+    }
+}


### PR DESCRIPTION
## Description
This PR fills the Up Next widget with your watchlist. The widget shows the next episode for each show you are watching, with its poster, and updates when you mark an episode watched or change what you follow.

## Changes
- Add the Up Next widget to the home screen in three sizes, showing one show at small and a list at medium and large
- Update the widget when the watchlist changes, and again on a background refresh every six hours
- Download each poster at the size the widget draws it, and delete posters the widget no longer shows
- Skip both the download and the refresh when no widget has been added
