### PR TITLE
refactor: Remove the skipped fetch callback from the Store helpers

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -996,7 +996,6 @@ graph TB
   :data:start-watching:api --> :data:account-manager:api
   :data:start-watching:implementation --> :api:tmdb:api
   :data:start-watching:implementation --> :core:base
-  :data:start-watching:implementation --> :core:logger:api
   :data:start-watching:implementation --> :core:network-util:api
   :data:start-watching:implementation --> :core:util:api
   :data:start-watching:implementation --> :data:account-manager:api
@@ -1013,7 +1012,6 @@ graph TB
   :data:sync-activity:api --> :core:network-util:api
   :data:sync-activity:api --> :data:account-manager:api
   :data:sync-activity:implementation --> :core:base
-  :data:sync-activity:implementation --> :core:logger:api
   :data:sync-activity:implementation --> :core:network-util:api
   :data:sync-activity:implementation --> :core:util:api
   :data:sync-activity:implementation --> :data:account-manager:api

--- a/core/integration/infra/README.md
+++ b/core/integration/infra/README.md
@@ -640,7 +640,6 @@ graph TB
   :data:start-watching:api --> :data:account-manager:api
   :data:start-watching:implementation --> :api:tmdb:api
   :data:start-watching:implementation --> :core:base
-  :data:start-watching:implementation --> :core:logger:api
   :data:start-watching:implementation --> :core:network-util:api
   :data:start-watching:implementation --> :core:util:api
   :data:start-watching:implementation --> :data:account-manager:api
@@ -657,7 +656,6 @@ graph TB
   :data:sync-activity:api --> :core:network-util:api
   :data:sync-activity:api --> :data:account-manager:api
   :data:sync-activity:implementation --> :core:base
-  :data:sync-activity:implementation --> :core:logger:api
   :data:sync-activity:implementation --> :core:network-util:api
   :data:sync-activity:implementation --> :core:util:api
   :data:sync-activity:implementation --> :data:account-manager:api

--- a/core/network-util/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/networkutil/api/extensions/StoreExtensions.kt
+++ b/core/network-util/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/networkutil/api/extensions/StoreExtensions.kt
@@ -59,18 +59,11 @@ public inline fun <Key : Any, reified Output : Any> apiFetcher(
  *
  * Note: Token expiry for authenticated users is handled upstream by the active provider's Ktor
  * Auth plugin, which refreshes the token and surfaces a session-expired error to the presentation layer.
- *
- * @param onSkipped Optional callback invoked with a message when a fetch is skipped
- *   due to missing authentication. Useful for debug logging.
  */
-public suspend fun <Key : Any, Output : Any> Store<Key, Output>.get(
-    key: Key,
-    onSkipped: ((String) -> Unit)? = null,
-) {
+public suspend fun <Key : Any, Output : Any> Store<Key, Output>.get(key: Key) {
     try {
         get(key)
-    } catch (e: AuthenticationException) {
-        onSkipped?.invoke("Skipping Store.get: ${e.message}")
+    } catch (_: AuthenticationException) {
     }
 }
 
@@ -82,18 +75,11 @@ public suspend fun <Key : Any, Output : Any> Store<Key, Output>.get(
  *
  * Note: Token expiry for authenticated users is handled upstream by the active provider's Ktor
  * Auth plugin, which refreshes the token and surfaces a session-expired error to the presentation layer.
- *
- * @param onSkipped Optional callback invoked with a message when a fetch is skipped
- *   due to missing authentication. Useful for debug logging.
  */
-public suspend fun <Key : Any, Output : Any> Store<Key, Output>.fresh(
-    key: Key,
-    onSkipped: ((String) -> Unit)? = null,
-) {
+public suspend fun <Key : Any, Output : Any> Store<Key, Output>.fresh(key: Key) {
     try {
         fresh(key)
-    } catch (e: AuthenticationException) {
-        onSkipped?.invoke("Skipping Store.fresh: ${e.message}")
+    } catch (_: AuthenticationException) {
     }
 }
 

--- a/data/library/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/DefaultLibraryRepository.kt
+++ b/data/library/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/library/implementation/DefaultLibraryRepository.kt
@@ -155,8 +155,8 @@ public class DefaultLibraryRepository(
 
         val sortOption = currentSortOption()
         when {
-            forceRefresh -> libraryStore.fresh(sortOption) { logger.debug(TAG, it) }
-            else -> libraryStore.get(sortOption) { logger.debug(TAG, it) }
+            forceRefresh -> libraryStore.fresh(sortOption)
+            else -> libraryStore.get(sortOption)
         }
 
         logger.debug(TAG, "Sync completed")

--- a/data/start-watching/implementation/README.md
+++ b/data/start-watching/implementation/README.md
@@ -69,7 +69,6 @@ graph TB
   :data:start-watching:api --> :data:account-manager:api
   :data:start-watching:implementation --> :api:tmdb:api
   :data:start-watching:implementation --> :core:base
-  :data:start-watching:implementation --> :core:logger:api
   :data:start-watching:implementation --> :core:network-util:api
   :data:start-watching:implementation --> :core:util:api
   :data:start-watching:implementation --> :data:account-manager:api

--- a/data/start-watching/implementation/build.gradle.kts
+++ b/data/start-watching/implementation/build.gradle.kts
@@ -14,7 +14,6 @@ kotlin {
                 api(libs.store5)
                 api(projects.api.tmdb.api)
                 api(projects.core.base)
-                api(projects.core.logger.api)
                 api(projects.core.networkUtil.api)
                 api(projects.core.util.api)
                 api(projects.data.accountManager.api)

--- a/data/start-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/implementation/DefaultStartWatchingRepository.kt
+++ b/data/start-watching/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/startwatching/implementation/DefaultStartWatchingRepository.kt
@@ -2,7 +2,6 @@ package com.thomaskioko.tvmaniac.startwatching.implementation
 
 import com.thomaskioko.tvmaniac.accountmanager.api.AccountManager
 import com.thomaskioko.tvmaniac.core.base.IoCoroutineScope
-import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.fresh
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.get
 import com.thomaskioko.tvmaniac.startwatching.api.StartWatchingDao
@@ -21,7 +20,6 @@ import kotlinx.coroutines.flow.shareIn
 public class DefaultStartWatchingRepository(
     private val startWatchingStore: StartWatchingWatchlistStore,
     private val accountManager: AccountManager,
-    private val logger: Logger,
     dao: StartWatchingDao,
     @IoCoroutineScope scope: CoroutineScope,
 ) : StartWatchingRepository {
@@ -36,13 +34,12 @@ public class DefaultStartWatchingRepository(
         if (accountManager.getActiveProvider() == null) return
 
         when {
-            forceRefresh -> startWatchingStore.fresh(Unit) { logger.debug(TAG, it) }
-            else -> startWatchingStore.get(Unit) { logger.debug(TAG, it) }
+            forceRefresh -> startWatchingStore.fresh(Unit)
+            else -> startWatchingStore.get(Unit)
         }
     }
 
     private companion object {
-        private const val TAG = "StartWatchingRepository"
         private const val SHARING_STOP_TIMEOUT_MS = 5_000L
     }
 }

--- a/data/sync-activity/implementation/README.md
+++ b/data/sync-activity/implementation/README.md
@@ -53,7 +53,6 @@ graph TB
   :data:sync-activity:api --> :core:network-util:api
   :data:sync-activity:api --> :data:account-manager:api
   :data:sync-activity:implementation --> :core:base
-  :data:sync-activity:implementation --> :core:logger:api
   :data:sync-activity:implementation --> :core:network-util:api
   :data:sync-activity:implementation --> :core:util:api
   :data:sync-activity:implementation --> :data:account-manager:api

--- a/data/sync-activity/implementation/build.gradle.kts
+++ b/data/sync-activity/implementation/build.gradle.kts
@@ -13,7 +13,6 @@ kotlin {
                 api(libs.coroutines.core)
                 api(libs.store5)
                 api(projects.core.base)
-                api(projects.core.logger.api)
                 api(projects.core.networkUtil.api)
                 api(projects.core.util.api)
                 api(projects.data.accountManager.api)

--- a/data/sync-activity/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/syncactivity/implementation/DefaultTraktActivityRepository.kt
+++ b/data/sync-activity/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/syncactivity/implementation/DefaultTraktActivityRepository.kt
@@ -1,7 +1,6 @@
 package com.thomaskioko.tvmaniac.syncactivity.implementation
 
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
-import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.fresh
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.get
 import com.thomaskioko.tvmaniac.syncactivity.api.TraktActivityDao
@@ -17,13 +16,12 @@ public class DefaultTraktActivityRepository(
     private val store: TraktActivityStore,
     private val activityDao: TraktActivityDao,
     private val dispatchers: AppCoroutineDispatchers,
-    private val logger: Logger,
 ) : TraktActivityRepository {
 
     override suspend fun fetchLatestActivities(forceRefresh: Boolean) {
         when {
-            forceRefresh -> store.fresh(Unit) { logger.debug(TAG, it) }
-            else -> store.get(Unit) { logger.debug(TAG, it) }
+            forceRefresh -> store.fresh(Unit)
+            else -> store.get(Unit)
         }
     }
 
@@ -31,9 +29,5 @@ public class DefaultTraktActivityRepository(
         withContext(dispatchers.io) {
             activityDao.deleteAll()
         }
-    }
-
-    private companion object {
-        private const val TAG = "TraktActivityRepository"
     }
 }

--- a/data/user/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/UserStatsStoreTest.kt
+++ b/data/user/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/UserStatsStoreTest.kt
@@ -110,10 +110,7 @@ internal class UserStatsStoreTest : BaseDatabaseTest() {
             errorMessage = "Endpoint not found",
         )
 
-        var skippedMessage: String? = null
-        store.get("test-user") { skippedMessage = it }
-
-        skippedMessage.shouldNotBeNull()
+        store.get("test-user")
 
         userStatsDao.observeUserProfileStats("test-user").test {
             awaitItem().shouldBeNull()

--- a/ios-framework/README.md
+++ b/ios-framework/README.md
@@ -782,7 +782,6 @@ graph TB
   :data:start-watching:api --> :data:account-manager:api
   :data:start-watching:implementation --> :api:tmdb:api
   :data:start-watching:implementation --> :core:base
-  :data:start-watching:implementation --> :core:logger:api
   :data:start-watching:implementation --> :core:network-util:api
   :data:start-watching:implementation --> :core:util:api
   :data:start-watching:implementation --> :data:account-manager:api
@@ -799,7 +798,6 @@ graph TB
   :data:sync-activity:api --> :core:network-util:api
   :data:sync-activity:api --> :data:account-manager:api
   :data:sync-activity:implementation --> :core:base
-  :data:sync-activity:implementation --> :core:logger:api
   :data:sync-activity:implementation --> :core:network-util:api
   :data:sync-activity:implementation --> :core:util:api
   :data:sync-activity:implementation --> :data:account-manager:api


### PR DESCRIPTION
## Description
This PR removes the `onSkipped` callback from the `Store.get` and `Store.fresh` helpers that skip a fetch when the user is signed out. Three repositories passed it to write a debug line saying the user was signed out, which the `signed_in` key on every crash report already records, so the callback and the loggers those repositories kept only for it are gone.
