### PR TITLE
test: Fix iOS tests and the datastore repository test

### DIFF
--- a/data/datastore/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/datastore/implemetation/DatastoreRepositoryTest.kt
+++ b/data/datastore/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/datastore/implemetation/DatastoreRepositoryTest.kt
@@ -3,14 +3,9 @@ package com.thomaskioko.tvmaniac.datastore.implemetation
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.edit
 import app.cash.turbine.test
 import com.thomaskioko.tvmaniac.datastore.api.AppTheme
 import com.thomaskioko.tvmaniac.datastore.implementation.DefaultDatastoreRepository
-import com.thomaskioko.tvmaniac.datastore.implementation.DefaultDatastoreRepository.Companion.KEY_ACCOUNT_TYPE
-import com.thomaskioko.tvmaniac.datastore.implementation.DefaultDatastoreRepository.Companion.KEY_QUICK_RATE_ENABLED
-import com.thomaskioko.tvmaniac.datastore.implementation.DefaultDatastoreRepository.Companion.KEY_THEME
-import com.thomaskioko.tvmaniac.datastore.implementation.DefaultDatastoreRepository.Companion.KEY_WIDGET_THEME
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -18,6 +13,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import okio.FileSystem
+import kotlin.random.Random
 import kotlin.test.AfterTest
 import kotlin.test.Test
 
@@ -25,7 +21,7 @@ internal class DatastoreRepositoryTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
     private var preferencesScope: CoroutineScope = CoroutineScope(testDispatcher + Job())
-    private val testFile = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "test.preferences_pb"
+    private val testFile = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "datastore-test-${Random.nextLong()}.preferences_pb"
     private val dataStore: DataStore<Preferences> = PreferenceDataStoreFactory.createWithPath(
         corruptionHandler = null,
         migrations = emptyList(),
@@ -39,14 +35,9 @@ internal class DatastoreRepositoryTest {
     )
 
     @AfterTest
-    fun clearDataStore() = runTest {
-        dataStore.edit {
-            it.remove(KEY_THEME)
-            it.remove(KEY_ACCOUNT_TYPE)
-            it.remove(KEY_QUICK_RATE_ENABLED)
-            it.remove(KEY_WIDGET_THEME)
-        }
+    fun deleteDataStore() {
         preferencesScope.cancel()
+        FileSystem.SYSTEM.delete(testFile, mustExist = false)
     }
 
     @Test

--- a/features/home/presenter/src/iosTest/kotlin/com/thomaskioko/tvmaniac/presenter/home/HomePresenterIosTest.kt
+++ b/features/home/presenter/src/iosTest/kotlin/com/thomaskioko/tvmaniac/presenter/home/HomePresenterIosTest.kt
@@ -1,13 +1,17 @@
 package com.thomaskioko.tvmaniac.presenter.home
 
 import com.arkivanov.decompose.ComponentContext
+import com.thomaskioko.tvmaniac.core.logger.fixture.FakeCrashlyticsConfiguration
 import com.thomaskioko.tvmaniac.featureflags.testing.FakeRemoteConfigBridge
 import com.thomaskioko.tvmaniac.testing.di.TestGraph
 import dev.zacsweers.metro.createGraphFactory
 
 internal class HomePresenterIosTest : HomePresenterTest() {
     private val testGraph: TestGraph by lazy {
-        createGraphFactory<TestGraph.Factory>().create(remoteConfigBridge = FakeRemoteConfigBridge())
+        createGraphFactory<TestGraph.Factory>().create(
+            remoteConfigBridge = FakeRemoteConfigBridge(),
+            crashlyticsConfiguration = FakeCrashlyticsConfiguration(isConfigured = false),
+        )
     }
 
     override fun createHomePresenter(componentContext: ComponentContext): HomePresenter =

--- a/features/root/presenter/src/iosTest/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenterIosTest.kt
+++ b/features/root/presenter/src/iosTest/kotlin/com/thomaskioko/tvmaniac/presenter/root/DefaultRootPresenterIosTest.kt
@@ -1,6 +1,7 @@
 package com.thomaskioko.tvmaniac.presenter.root
 
 import com.thomaskioko.tvmaniac.core.connectivity.testing.FakeInternetConnectionChecker
+import com.thomaskioko.tvmaniac.core.logger.fixture.FakeCrashlyticsConfiguration
 import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
 import com.thomaskioko.tvmaniac.featureflags.testing.FakeRemoteConfigBridge
 import com.thomaskioko.tvmaniac.navigation.Navigator
@@ -10,7 +11,10 @@ import dev.zacsweers.metro.createGraphFactory
 
 internal class DefaultRootPresenterIosTest : DefaultRootPresenterTest() {
     private val testGraph: TestGraph by lazy {
-        createGraphFactory<TestGraph.Factory>().create(remoteConfigBridge = FakeRemoteConfigBridge())
+        createGraphFactory<TestGraph.Factory>().create(
+            remoteConfigBridge = FakeRemoteConfigBridge(),
+            crashlyticsConfiguration = FakeCrashlyticsConfiguration(isConfigured = false),
+        )
     }
 
     override val rootPresenterFactory: RootPresenter.Factory

--- a/ios-framework/build.gradle.kts
+++ b/ios-framework/build.gradle.kts
@@ -2,6 +2,8 @@
 
 import org.jetbrains.kotlin.gradle.plugin.mpp.DisableCacheInKotlinVersion
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCacheApi
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable
 import java.net.URI
 
 plugins {
@@ -80,6 +82,12 @@ scaffold {
 }
 
 kotlin {
+    targets.withType<KotlinNativeTarget>().configureEach {
+        binaries.withType<TestExecutable>().configureEach {
+            linkerOpts("-U", "_FIRCLSExceptionRecordNSException", "-U", "_FIRCheckLinkDependencies")
+        }
+    }
+
     sourceSets {
         commonMain {
             dependencies {

--- a/ios-framework/build.gradle.kts
+++ b/ios-framework/build.gradle.kts
@@ -258,5 +258,10 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.bundles.unittest)
         }
+
+        iosTest.dependencies {
+            implementation(projects.core.featureFlags.testing)
+            implementation(projects.core.logger.testing)
+        }
     }
 }

--- a/ios-framework/src/iosTest/kotlin/com/thomaskioko/tvmaniac/iosframework/IosApplicationGraphTest.kt
+++ b/ios-framework/src/iosTest/kotlin/com/thomaskioko/tvmaniac/iosframework/IosApplicationGraphTest.kt
@@ -1,7 +1,9 @@
 package com.thomaskioko.tvmaniac.iosframework
 
 import com.thomaskioko.tvmaniac.appconfig.Platform
-import com.thomaskioko.tvmaniac.featureflags.RemoteConfigBridge
+import com.thomaskioko.tvmaniac.core.logger.fixture.FakeCrashlyticsConfiguration
+import com.thomaskioko.tvmaniac.domain.widget.WidgetManager
+import com.thomaskioko.tvmaniac.featureflags.testing.FakeRemoteConfigBridge
 import dev.zacsweers.metro.createGraphFactory
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
@@ -10,39 +12,36 @@ class IosApplicationGraphTest {
 
     @Test
     fun `should return debugBuild true when factory receives isDebug true`() {
-        val graph = createGraphFactory<IosApplicationGraph.Factory>().create(
-            isDebug = true,
-            remoteConfigBridge = FakeRemoteConfigBridge,
-        )
+        val graph = createGraph(isDebug = true)
 
         graph.debugConfig.isDebug shouldBe true
     }
 
     @Test
     fun `should return debugBuild false when factory receives isDebug false`() {
-        val graph = createGraphFactory<IosApplicationGraph.Factory>().create(
-            isDebug = false,
-            remoteConfigBridge = FakeRemoteConfigBridge,
-        )
+        val graph = createGraph(isDebug = false)
 
         graph.debugConfig.isDebug shouldBe false
     }
 
     @Test
     fun `should return Platform IOS`() {
-        val graph = createGraphFactory<IosApplicationGraph.Factory>().create(
-            isDebug = false,
-            remoteConfigBridge = FakeRemoteConfigBridge,
-        )
+        val graph = createGraph(isDebug = false)
 
         graph.appMetadata.platform shouldBe Platform.IOS
     }
 
-    private object FakeRemoteConfigBridge : RemoteConfigBridge {
-        override fun setMinimumFetchIntervalSeconds(seconds: Long): Unit = Unit
-        override fun fetchAndActivate(onResult: (Boolean) -> Unit): Unit = onResult(false)
-        override fun getBoolean(key: String): Boolean = false
-        override fun setDefaults(defaults: Map<String, Boolean>): Unit = Unit
-        override fun addOnConfigUpdateListener(onUpdate: () -> Unit): Unit = Unit
+    private fun createGraph(isDebug: Boolean): IosApplicationGraph =
+        createGraphFactory<IosApplicationGraph.Factory>().create(
+            isDebug = isDebug,
+            remoteConfigBridge = FakeRemoteConfigBridge(),
+            widgetManager = FakeWidgetManager,
+            crashlyticsConfiguration = FakeCrashlyticsConfiguration(isConfigured = false),
+        )
+
+    private object FakeWidgetManager : WidgetManager {
+        override fun hasInstalledWidgets(onResult: (Boolean) -> Unit): Unit = onResult(false)
+        override fun containerPath(): String? = null
+        override fun reloadTimelines(): Unit = Unit
     }
 }


### PR DESCRIPTION
## Description
This PR fixes the iOS test binaries that stopped compiling and linking after the widget and telemetry pull requests, and gives each `DatastoreRepositoryTest` its own preferences file so test runs no longer share state.

## Changes
- Pass `widgetManager` and `crashlyticsConfiguration` in `IosApplicationGraphTest`, and `crashlyticsConfiguration` in `HomePresenterIosTest` and `DefaultRootPresenterIosTest`, using the shared fakes from `core/logger/testing` and `core/feature-flags/testing`.
- Add `-U` linker flags to the `ios-framework` test executables for the two Firebase symbols CrashKiOS resolves at load time, so a test binary that reaches `CrashKiosCrashlytics` links.
- Write each `DatastoreRepositoryTest` instance to a randomly named file and delete it afterwards, replacing the preference key cleanup list.
