### PR TITLE
fix: Add Page to Trakt list items and watchlist requests

### DIFF
--- a/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/TraktListRemoteDataSource.kt
+++ b/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/TraktListRemoteDataSource.kt
@@ -19,11 +19,18 @@ public interface TraktListRemoteDataSource {
     public suspend fun getListItems(
         userSlug: String,
         listId: Long,
+        page: Int = TRAKT_FIRST_PAGE,
+        limit: Int = TRAKT_PAGE_LIMIT,
     ): ApiResponse<List<TraktListItemResponse>>
 
     public suspend fun createList(userSlug: String, name: String): ApiResponse<TraktCreateListResponse>
 
-    public suspend fun getWatchList(sortBy: String, sortHow: String): ApiResponse<List<TraktFollowedShowResponse>>
+    public suspend fun getWatchList(
+        sortBy: String,
+        sortHow: String,
+        page: Int = TRAKT_FIRST_PAGE,
+        limit: Int = TRAKT_PAGE_LIMIT,
+    ): ApiResponse<List<TraktFollowedShowResponse>>
 
     public suspend fun addShowsToWatchList(shows: List<TraktShowIds>): ApiResponse<TraktAddShowToListResponse>
 

--- a/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/TraktPagination.kt
+++ b/api/trakt/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/api/TraktPagination.kt
@@ -1,0 +1,4 @@
+package com.thomaskioko.tvmaniac.trakt.api
+
+public const val TRAKT_FIRST_PAGE: Int = 1
+public const val TRAKT_PAGE_LIMIT: Int = 250

--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktListRemoteDataSource.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktListRemoteDataSource.kt
@@ -53,11 +53,15 @@ public class DefaultTraktListRemoteDataSource(
     override suspend fun getListItems(
         userSlug: String,
         listId: Long,
+        page: Int,
+        limit: Int,
     ): ApiResponse<List<TraktListItemResponse>> =
         httpClient.authSafeRequest {
             url {
                 method = HttpMethod.Get
                 path("users/$userSlug/lists/$listId/items")
+                parameter("page", page)
+                parameter("limit", limit)
             }
         }
 
@@ -71,12 +75,18 @@ public class DefaultTraktListRemoteDataSource(
             setBody(TraktCreateListRequest(name = name))
         }
 
-    override suspend fun getWatchList(sortBy: String, sortHow: String): ApiResponse<List<TraktFollowedShowResponse>> =
+    override suspend fun getWatchList(
+        sortBy: String,
+        sortHow: String,
+        page: Int,
+        limit: Int,
+    ): ApiResponse<List<TraktFollowedShowResponse>> =
         httpClient.authSafeRequest {
             url {
                 method = HttpMethod.Get
                 path("users/me/watchlist/shows")
-                parameter("limit", "10000")
+                parameter("page", page)
+                parameter("limit", limit)
             }
             headers.append("X-Sort-By", sortBy)
             headers.append("X-Sort-How", sortHow)

--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktLibraryRemoteDataSource.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktLibraryRemoteDataSource.kt
@@ -1,12 +1,14 @@
 package com.thomaskioko.trakt.service.implementation.sync
 
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
+import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.fetchPages
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.map
 import com.thomaskioko.tvmaniac.data.library.LibraryRemoteDataSource
 import com.thomaskioko.tvmaniac.data.library.model.RemoteFollowedShow
 import com.thomaskioko.tvmaniac.data.library.model.WatchlistShowIds
 import com.thomaskioko.tvmaniac.data.library.model.WatchlistSyncResult
+import com.thomaskioko.tvmaniac.trakt.api.TRAKT_PAGE_LIMIT
 import com.thomaskioko.tvmaniac.trakt.api.TraktListRemoteDataSource
 import com.thomaskioko.tvmaniac.trakt.api.model.TraktFollowedShowResponse
 import com.thomaskioko.tvmaniac.trakt.api.model.TraktShowIds
@@ -24,8 +26,9 @@ public class TraktLibraryRemoteDataSource(
     override val provider: SyncProviderSource = SyncProviderSource.TRAKT
 
     override suspend fun getWatchlist(): ApiResponse<List<RemoteFollowedShow>> =
-        remoteDataSource.getWatchList(sortBy = SORT_BY, sortHow = SORT_HOW)
-            .map { shows -> shows.map { it.toRemoteFollowedShow() } }
+        fetchPages(limit = TRAKT_PAGE_LIMIT) { page, limit ->
+            remoteDataSource.getWatchList(sortBy = SORT_BY, sortHow = SORT_HOW, page = page, limit = limit)
+        }.map { shows -> shows.map { it.toRemoteFollowedShow() } }
 
     override suspend fun addToWatchlist(shows: List<WatchlistShowIds>): ApiResponse<WatchlistSyncResult> =
         remoteDataSource.addShowsToWatchList(shows.map { it.toTraktShowIds() })

--- a/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktStartWatchingRemoteDataSource.kt
+++ b/api/trakt/implementation/src/commonMain/kotlin/com/thomaskioko/trakt/service/implementation/sync/TraktStartWatchingRemoteDataSource.kt
@@ -1,10 +1,12 @@
 package com.thomaskioko.trakt.service.implementation.sync
 
 import com.thomaskioko.tvmaniac.accountmanager.api.SyncProviderSource
+import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.fetchPages
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.map
 import com.thomaskioko.tvmaniac.startwatching.api.RemotePlanToWatchShow
 import com.thomaskioko.tvmaniac.startwatching.api.StartWatchingRemoteDataSource
+import com.thomaskioko.tvmaniac.trakt.api.TRAKT_PAGE_LIMIT
 import com.thomaskioko.tvmaniac.trakt.api.TraktListRemoteDataSource
 import com.thomaskioko.tvmaniac.trakt.api.model.TraktFollowedShowResponse
 import dev.zacsweers.metro.AppScope
@@ -21,8 +23,9 @@ public class TraktStartWatchingRemoteDataSource(
     override val provider: SyncProviderSource = SyncProviderSource.TRAKT
 
     override suspend fun getPlanToWatch(): ApiResponse<List<RemotePlanToWatchShow>> =
-        remoteDataSource.getWatchList(sortBy = SORT_BY, sortHow = SORT_HOW)
-            .map { shows -> shows.map { it.toRemotePlanToWatchShow() } }
+        fetchPages(limit = TRAKT_PAGE_LIMIT) { page, limit ->
+            remoteDataSource.getWatchList(sortBy = SORT_BY, sortHow = SORT_HOW, page = page, limit = limit)
+        }.map { shows -> shows.map { it.toRemotePlanToWatchShow() } }
 
     private companion object {
         private const val SORT_BY = "added"

--- a/api/trakt/implementation/src/jvmTest/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktListRemoteDataSourceTest.kt
+++ b/api/trakt/implementation/src/jvmTest/kotlin/com/thomaskioko/trakt/service/implementation/api/DefaultTraktListRemoteDataSourceTest.kt
@@ -110,10 +110,14 @@ class DefaultTraktListRemoteDataSourceTest {
     fun `should use GET and correct path given getListItems is called`() = runTest {
         var capturedMethod: HttpMethod? = null
         var capturedPath: String? = null
+        var capturedPage: String? = null
+        var capturedLimit: String? = null
 
         val engine = MockEngine { request ->
             capturedMethod = request.method
             capturedPath = request.url.encodedPath
+            capturedPage = request.url.parameters["page"]
+            capturedLimit = request.url.parameters["limit"]
             respond(
                 content = """[]""",
                 status = HttpStatusCode.OK,
@@ -126,6 +130,61 @@ class DefaultTraktListRemoteDataSourceTest {
 
         capturedMethod shouldBe HttpMethod.Get
         capturedPath shouldBe "/users/sean/lists/42/items"
+        capturedPage shouldBe "1"
+        capturedLimit shouldBe "250"
+    }
+
+    @Test
+    fun `should send the given page and limit given getListItems is called with them`() = runTest {
+        var capturedPage: String? = null
+        var capturedLimit: String? = null
+
+        val engine = MockEngine { request ->
+            capturedPage = request.url.parameters["page"]
+            capturedLimit = request.url.parameters["limit"]
+            respond(
+                content = """[]""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        dataSource.getListItems(userSlug = "sean", listId = 42L, page = 3, limit = 50)
+
+        capturedPage shouldBe "3"
+        capturedLimit shouldBe "50"
+    }
+
+    @Test
+    fun `should send page, limit and sort headers given getWatchList is called`() = runTest {
+        var capturedPath: String? = null
+        var capturedPage: String? = null
+        var capturedLimit: String? = null
+        var capturedSortBy: String? = null
+        var capturedSortHow: String? = null
+
+        val engine = MockEngine { request ->
+            capturedPath = request.url.encodedPath
+            capturedPage = request.url.parameters["page"]
+            capturedLimit = request.url.parameters["limit"]
+            capturedSortBy = request.headers["X-Sort-By"]
+            capturedSortHow = request.headers["X-Sort-How"]
+            respond(
+                content = """[]""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val dataSource = createDataSource(engine)
+
+        dataSource.getWatchList(sortBy = "added", sortHow = "desc")
+
+        capturedPath shouldBe "/users/me/watchlist/shows"
+        capturedPage shouldBe "1"
+        capturedLimit shouldBe "250"
+        capturedSortBy shouldBe "added"
+        capturedSortHow shouldBe "desc"
     }
 
     @Test

--- a/api/trakt/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/testing/FakeTraktListRemoteDataSource.kt
+++ b/api/trakt/testing/src/commonMain/kotlin/com/thomaskioko/tvmaniac/trakt/testing/FakeTraktListRemoteDataSource.kt
@@ -39,6 +39,8 @@ public class FakeTraktListRemoteDataSource : TraktListRemoteDataSource {
     override suspend fun getWatchList(
         sortBy: String,
         sortHow: String,
+        page: Int,
+        limit: Int,
     ): ApiResponse<List<TraktFollowedShowResponse>> = watchListResponse
 
     override suspend fun addShowsToWatchList(
@@ -64,6 +66,8 @@ public class FakeTraktListRemoteDataSource : TraktListRemoteDataSource {
     override suspend fun getListItems(
         userSlug: String,
         listId: Long,
+        page: Int,
+        limit: Int,
     ): ApiResponse<List<TraktListItemResponse>> =
         error("FakeTraktListRemoteDataSource: getListItems not configured")
 

--- a/core/network-util/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/networkutil/api/extensions/PagingExtensions.kt
+++ b/core/network-util/api/src/commonMain/kotlin/com/thomaskioko/tvmaniac/core/networkutil/api/extensions/PagingExtensions.kt
@@ -1,0 +1,19 @@
+package com.thomaskioko.tvmaniac.core.networkutil.api.extensions
+
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+
+public suspend fun <T> fetchPages(
+    limit: Int,
+    firstPage: Int = 1,
+    request: suspend (page: Int, limit: Int) -> ApiResponse<List<T>>,
+): ApiResponse<List<T>> {
+    val items = mutableListOf<T>()
+    var page = firstPage
+    while (true) {
+        val response = request(page, limit)
+        if (response !is ApiResponse.Success) return response
+        items += response.body
+        if (response.body.size < limit) return ApiResponse.Success(items)
+        page++
+    }
+}

--- a/core/network-util/api/src/commonTest/kotlin/com/thomaskioko/tvmaniac/core/networkutil/api/extensions/PagingExtensionsTest.kt
+++ b/core/network-util/api/src/commonTest/kotlin/com/thomaskioko/tvmaniac/core/networkutil/api/extensions/PagingExtensionsTest.kt
@@ -1,0 +1,62 @@
+package com.thomaskioko.tvmaniac.core.networkutil.api.extensions
+
+import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class PagingExtensionsTest {
+
+    @Test
+    fun `should request every page until a short page`() = runTest {
+        val requestedPages = mutableListOf<Int>()
+
+        val result = fetchPages(limit = 3) { page, limit ->
+            requestedPages += page
+            val count = if (page < 3) limit else 1
+            ApiResponse.Success(List(count) { "page$page-$it" })
+        }
+
+        requestedPages shouldBe listOf(1, 2, 3)
+        result.shouldBeInstanceOf<ApiResponse.Success<List<String>>>().body.size shouldBe 7
+    }
+
+    @Test
+    fun `should stop after one request given the first page is short`() = runTest {
+        var requests = 0
+
+        val result = fetchPages(limit = 3) { _, _ ->
+            requests++
+            ApiResponse.Success(listOf("a"))
+        }
+
+        requests shouldBe 1
+        result.shouldBeInstanceOf<ApiResponse.Success<List<String>>>().body shouldBe listOf("a")
+    }
+
+    @Test
+    fun `should return the failure given a later page fails`() = runTest {
+        val result = fetchPages(limit = 2) { page, limit ->
+            if (page == 1) {
+                ApiResponse.Success(List(limit) { "item$it" })
+            } else {
+                ApiResponse.Error.HttpError(code = 429, errorBody = null, errorMessage = null)
+            }
+        }
+
+        result.shouldBeInstanceOf<ApiResponse.Error.HttpError<*>>().code shouldBe 429
+    }
+
+    @Test
+    fun `should start from the given first page`() = runTest {
+        val requestedPages = mutableListOf<Int>()
+
+        fetchPages(limit = 2, firstPage = 4) { page, _ ->
+            requestedPages += page
+            ApiResponse.Success(emptyList<String>())
+        }
+
+        requestedPages shouldBe listOf(4)
+    }
+}

--- a/data/traktlists/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/TraktListItemsStore.kt
+++ b/data/traktlists/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/TraktListItemsStore.kt
@@ -2,12 +2,14 @@ package com.thomaskioko.tvmaniac.traktlists.implementation
 
 import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.apiFetcher
+import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.fetchPages
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.storeBuilder
 import com.thomaskioko.tvmaniac.core.networkutil.api.extensions.usingDispatchers
 import com.thomaskioko.tvmaniac.core.networkutil.api.model.ApiResponse
 import com.thomaskioko.tvmaniac.db.DatabaseTransactionRunner
 import com.thomaskioko.tvmaniac.resourcemanager.api.RequestManagerRepository
 import com.thomaskioko.tvmaniac.resourcemanager.api.RequestTypeConfig.TRAKT_LIST_ITEMS_SYNC
+import com.thomaskioko.tvmaniac.trakt.api.TRAKT_PAGE_LIMIT
 import com.thomaskioko.tvmaniac.trakt.api.TraktListRemoteDataSource
 import com.thomaskioko.tvmaniac.trakt.api.model.TraktListItemResponse
 import com.thomaskioko.tvmaniac.traktlists.api.TraktListShowDao
@@ -35,7 +37,9 @@ public class TraktListItemsStore(
     private val dispatchers: AppCoroutineDispatchers,
 ) : Store<TraktListItemsKey, TraktListItemsKey> by storeBuilder(
     fetcher = apiFetcher { key: TraktListItemsKey ->
-        val response = traktListRemoteDataSource.getListItems(userSlug = key.userSlug, listId = key.listId)
+        val response = fetchPages(limit = TRAKT_PAGE_LIMIT) { page, limit ->
+            traktListRemoteDataSource.getListItems(userSlug = key.userSlug, listId = key.listId, page = page, limit = limit)
+        }
         if (response is ApiResponse.Error.HttpError && response.code == 404) {
             ApiResponse.Success(emptyList())
         } else {

--- a/data/traktlists/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/DefaultTraktListRepositoryTest.kt
+++ b/data/traktlists/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/traktlists/implementation/DefaultTraktListRepositoryTest.kt
@@ -427,6 +427,8 @@ private class FakeRemoteDataSource : TraktListRemoteDataSource {
     override suspend fun getListItems(
         userSlug: String,
         listId: Long,
+        page: Int,
+        limit: Int,
     ): ApiResponse<List<TraktListItemResponse>> {
         itemsCalls += userSlug to listId
         itemsErrorByListId[listId]?.let { return it }
@@ -441,6 +443,8 @@ private class FakeRemoteDataSource : TraktListRemoteDataSource {
     override suspend fun getWatchList(
         sortBy: String,
         sortHow: String,
+        page: Int,
+        limit: Int,
     ): ApiResponse<List<TraktFollowedShowResponse>> = error("not used")
 
     override suspend fun addShowsToWatchList(


### PR DESCRIPTION
## Description
This PR fetches Trakt personal list items and the watchlist in 250-item pages instead of a single request. Trakt now returns 100 items when no page is requested and caps `limit` at 250, so longer lists were cut off in the app.

