### PR TITLE
fix: Fix Nightly emulator run

### DIFF
--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/BaseAppFlowTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/BaseAppFlowTest.kt
@@ -33,6 +33,7 @@ import com.thomaskioko.tvmaniac.app.test.compose.robot.StatisticsRobot
 import com.thomaskioko.tvmaniac.app.test.compose.robot.WatchDateSelectionRobot
 import com.thomaskioko.tvmaniac.app.test.compose.stubs.Scenarios
 import com.thomaskioko.tvmaniac.testing.integration.MockEngineHandler
+import com.thomaskioko.tvmaniac.testing.integration.ui.isRobolectricRuntime
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -55,7 +56,7 @@ internal abstract class BaseAppFlowTest {
         application.clearPersistentTestState()
 
         val testDispatcher = StandardTestDispatcher()
-        Dispatchers.setMain(testDispatcher)
+        if (isRobolectricRuntime) Dispatchers.setMain(testDispatcher)
         try {
             runAndroidComposeUiTest<TvManiacTestActivity>(effectContext = testDispatcher) {
                 val graph = application.graph
@@ -68,7 +69,7 @@ internal abstract class BaseAppFlowTest {
                 }
             }
         } finally {
-            Dispatchers.resetMain()
+            if (isRobolectricRuntime) Dispatchers.resetMain()
         }
     }
 }

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/TvManiacTestActivity.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/TvManiacTestActivity.kt
@@ -1,11 +1,19 @@
 package com.thomaskioko.tvmaniac.app.test.compose
 
+import android.app.Activity
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.LocalActivityResultRegistryOwner
 import androidx.activity.compose.setContent
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.ActivityResultRegistry
+import androidx.activity.result.ActivityResultRegistryOwner
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.core.app.ActivityOptionsCompat
 import com.thomaskioko.tvmaniac.app.di.ActivityGraph
 import com.thomaskioko.tvmaniac.app.test.TvManiacTestApplication
 import com.thomaskioko.tvmaniac.app.ui.di.AppRootContent
@@ -24,11 +32,44 @@ internal class TvManiacTestActivity : ComponentActivity() {
             .asContribution<ActivityGraph.Factory>()
             .createGraph(this)
 
+        val resultRegistryOwner = DocumentPickerCancellingRegistryOwner(this)
         setContent {
             val appUiState by activityGraph.rootPresenter.appUiState.collectAsState()
             TvManiacTheme(appTheme = appUiState.appTheme) {
-                CompositionLocalProvider(LocalAutoAdvanceEnabled provides false) {
+                CompositionLocalProvider(
+                    LocalAutoAdvanceEnabled provides false,
+                    LocalActivityResultRegistryOwner provides resultRegistryOwner,
+                ) {
                     activityGraph.AppRootContent()
+                }
+            }
+        }
+    }
+}
+
+private class DocumentPickerCancellingRegistryOwner(
+    private val activity: ComponentActivity,
+) : ActivityResultRegistryOwner {
+
+    override val activityResultRegistry: ActivityResultRegistry = object : ActivityResultRegistry() {
+        override fun <I, O> onLaunch(
+            requestCode: Int,
+            contract: ActivityResultContract<I, O>,
+            input: I,
+            options: ActivityOptionsCompat?,
+        ) {
+            when (contract) {
+                is ActivityResultContracts.OpenDocument,
+                is ActivityResultContracts.OpenDocumentTree,
+                -> dispatchResult(requestCode, Activity.RESULT_CANCELED, null)
+
+                else -> {
+                    var launcher: ActivityResultLauncher<I>? = null
+                    launcher = activity.activityResultRegistry.register("forwarded-$requestCode", contract) { result ->
+                        dispatchResult(requestCode, result)
+                        launcher?.unregister()
+                    }
+                    launcher.launch(input, options)
                 }
             }
         }

--- a/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/deeplink/DeepLinkToShowDetailsFlowTest.kt
+++ b/app/src/sharedTest/kotlin/com/thomaskioko/tvmaniac/app/test/compose/flows/deeplink/DeepLinkToShowDetailsFlowTest.kt
@@ -13,7 +13,7 @@ internal class DeepLinkToShowDetailsFlowTest : BaseAppFlowTest() {
 
         discoverRobot.assertFeaturedPagerDisplayed()
 
-        activityGraph.rootPresenter.onDeepLinkUrl("tvmaniac://show/$breakingBadTmdbId")
+        composeUi.runOnUiThread { activityGraph.rootPresenter.onDeepLinkUrl("tvmaniac://show/$breakingBadTmdbId") }
 
         showDetailsRobot
             .waitForIdle()
@@ -26,7 +26,7 @@ internal class DeepLinkToShowDetailsFlowTest : BaseAppFlowTest() {
 
         discoverRobot.assertFeaturedPagerDisplayed()
 
-        activityGraph.rootPresenter.onDeepLinkUrl("tvmaniac://show/not-a-number")
+        composeUi.runOnUiThread { activityGraph.rootPresenter.onDeepLinkUrl("tvmaniac://show/not-a-number") }
 
         discoverRobot
             .waitForIdle()

--- a/core/integration/infra/src/androidMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/bindings/TestLoggerBindingContainer.kt
+++ b/core/integration/infra/src/androidMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/bindings/TestLoggerBindingContainer.kt
@@ -8,7 +8,6 @@ import com.thomaskioko.tvmaniac.core.logger.KermitLogger
 import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.core.logger.LoggingInitializerModule
 import com.thomaskioko.tvmaniac.core.logger.fixture.FakeCrashReporter
-import com.thomaskioko.tvmaniac.core.logger.fixture.FakeLogger
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
@@ -30,7 +29,7 @@ public object TestLoggerBindingContainer {
 
     @Provides
     @SingleIn(AppScope::class)
-    public fun provideLogger(): Logger = FakeLogger()
+    public fun provideLogger(): Logger = KermitLogger().apply { setup(debugMode = true) }
 
     @Provides
     @SingleIn(AppScope::class)

--- a/core/integration/ui/src/androidMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/ui/BaseRobot.kt
+++ b/core/integration/ui/src/androidMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/ui/BaseRobot.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsMatcher
@@ -19,6 +20,7 @@ import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.filter
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.performClick
@@ -28,6 +30,7 @@ import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.printToLog
 import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.test.swipeRight
 import androidx.compose.ui.test.swipeUp
@@ -39,6 +42,7 @@ import androidx.compose.ui.test.hasContentDescription as composeHasContentDescri
 public const val TIMEOUT_MILLIS: Long = 10_000
 
 private const val CLOCK_CATCH_UP_MILLIS: Long = 200
+private const val SEMANTICS_TREE_LOG_TAG: String = "SemanticsTree"
 
 /**
  * Base robot for integration tests.
@@ -95,11 +99,16 @@ public abstract class BaseRobot<T : BaseRobot<T>>(protected val composeUi: Compo
     // virtual time advances. waitUntil advances one frame per poll while counting its timeout in
     // real milliseconds, so on a loaded machine a pending delay outlives the timeout.
     private fun awaitCondition(timeoutMillis: Long, condition: () -> Boolean) {
-        composeUi.waitUntil(timeoutMillis = timeoutMillis) {
-            condition() || run {
-                composeUi.mainClock.advanceTimeBy(CLOCK_CATCH_UP_MILLIS)
-                condition()
+        try {
+            composeUi.waitUntil(timeoutMillis = timeoutMillis) {
+                condition() || run {
+                    composeUi.mainClock.advanceTimeBy(CLOCK_CATCH_UP_MILLIS)
+                    condition()
+                }
             }
+        } catch (e: ComposeTimeoutException) {
+            composeUi.onAllNodes(isRoot(), useUnmergedTree = true).printToLog(SEMANTICS_TREE_LOG_TAG)
+            throw e
         }
     }
 

--- a/core/integration/ui/src/androidMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/ui/RobolectricRuntime.kt
+++ b/core/integration/ui/src/androidMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/ui/RobolectricRuntime.kt
@@ -1,0 +1,6 @@
+package com.thomaskioko.tvmaniac.testing.integration.ui
+
+import android.os.Build
+
+public val isRobolectricRuntime: Boolean
+    get() = Build.FINGERPRINT.startsWith("robolectric", ignoreCase = true)

--- a/core/integration/ui/src/androidMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/ui/SystemDialogUtil.kt
+++ b/core/integration/ui/src/androidMain/kotlin/com/thomaskioko/tvmaniac/testing/integration/ui/SystemDialogUtil.kt
@@ -68,7 +68,7 @@ public fun dismissSystemDialog(
     appearTimeoutMillis: Long = 3_000,
     dismissTimeoutMillis: Long = 5_000,
 ) {
-    if (Build.FINGERPRINT.startsWith("robolectric", ignoreCase = true)) return
+    if (isRobolectricRuntime) return
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
 
     val instrumentation = InstrumentationRegistry.getInstrumentation()

--- a/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/User.sq
+++ b/data/database/sqldelight/src/commonMain/sqldelight/com/thomaskioko/tvmaniac/db/User.sq
@@ -36,6 +36,11 @@ FROM
 WHERE
     is_me != 0;
 
+clearCurrentUserExcept:
+UPDATE user
+SET is_me = 0
+WHERE is_me != 0 AND slug != ?;
+
 delete:
 DELETE FROM
     user

--- a/data/user/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/DefaultUserDao.kt
+++ b/data/user/implementation/src/commonMain/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/DefaultUserDao.kt
@@ -126,6 +126,7 @@ public class DefaultUserDao(
         isMe: Boolean,
     ) {
         database.transaction {
+            if (isMe) database.userQueries.clearCurrentUserExcept(slug)
             database.userQueries.insertOrReplace(
                 slug = slug,
                 user_name = userName,

--- a/data/user/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/DefaultUserDaoTest.kt
+++ b/data/user/implementation/src/commonTest/kotlin/com/thomaskioko/tvmaniac/data/user/implementation/DefaultUserDaoTest.kt
@@ -164,6 +164,33 @@ internal class DefaultUserDaoTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun `should keep a single current user given another slug is stored as me`() = runTest {
+        userDao.upsertUser(
+            slug = "trakt-user",
+            userName = "trakt",
+            fullName = null,
+            profilePicture = null,
+            backgroundUrl = null,
+            isMe = true,
+        )
+
+        userDao.upsertUser(
+            slug = "12345678",
+            userName = "simkl",
+            fullName = null,
+            profilePicture = null,
+            backgroundUrl = null,
+            isMe = true,
+        )
+
+        userDao.observeCurrentUser().test {
+            awaitItem()?.slug shouldBe "12345678"
+            cancelAndConsumeRemainingEvents()
+        }
+        database.userQueries.userBySlug("trakt-user").executeAsOneOrNull()?.is_me shouldBe false
+    }
+
+    @Test
     fun `should update when stats change`() = runTest {
         insertTestUser()
         userStatsDao.upsertStats(


### PR DESCRIPTION
## Description
This PR returns the nightly emulator run to green by keeping the real main dispatcher on a device in the app flow tests, and makes a provider switch keep a single current user.

## Bug Fixes
- Clear the current-user flag on other rows when a provider stores its profile, so switching from Trakt to Simkl leaves one current user and the Profile screen loads.
