### PR TITLE
feat: Load restored show details on reconnect

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1138,6 +1138,7 @@ graph TB
   :domain:account-switcher --> :domain:library
   :domain:account-switcher --> :domain:user
   :domain:backup --> :core:base
+  :domain:backup --> :core:connectivity:api
   :domain:backup --> :core:logger:api
   :domain:backup --> :core:network-util:api
   :domain:backup --> :core:tasks:api

--- a/core/integration/infra/README.md
+++ b/core/integration/infra/README.md
@@ -704,6 +704,7 @@ graph TB
   :domain:account-switcher --> :domain:library
   :domain:account-switcher --> :domain:user
   :domain:backup --> :core:base
+  :domain:backup --> :core:connectivity:api
   :domain:backup --> :core:logger:api
   :domain:backup --> :core:network-util:api
   :domain:backup --> :core:tasks:api

--- a/domain/backup/README.md
+++ b/domain/backup/README.md
@@ -130,6 +130,7 @@ graph TB
   :data:trailers:api --> :data:database:sqldelight
   :data:watchproviders:api --> :data:database:sqldelight
   :domain:backup --> :core:base
+  :domain:backup --> :core:connectivity:api
   :domain:backup --> :core:logger:api
   :domain:backup --> :core:network-util:api
   :domain:backup --> :core:tasks:api

--- a/domain/backup/build.gradle.kts
+++ b/domain/backup/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
             dependencies {
                 api(projects.core.base)
                 api(projects.core.view)
+                api(projects.core.connectivity.api)
                 api(projects.core.logger.api)
                 api(projects.core.networkUtil.api)
                 api(projects.core.tasks.api)
@@ -25,6 +26,7 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(libs.bundles.unittest)
+                implementation(projects.core.connectivity.testing)
                 implementation(projects.core.logger.testing)
                 implementation(projects.core.tasks.testing)
                 implementation(projects.core.util.testing)

--- a/domain/backup/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/backup/AutoBackupTasksInitializer.kt
+++ b/domain/backup/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/backup/AutoBackupTasksInitializer.kt
@@ -1,21 +1,28 @@
 package com.thomaskioko.tvmaniac.domain.backup
 
 import com.thomaskioko.tvmaniac.core.base.IoCoroutineScope
+import com.thomaskioko.tvmaniac.core.base.interactor.executeSync
+import com.thomaskioko.tvmaniac.core.connectivity.api.InternetConnectionChecker
 import com.thomaskioko.tvmaniac.core.logger.Logger
 import com.thomaskioko.tvmaniac.core.tasks.api.BackgroundTaskScheduler
 import com.thomaskioko.tvmaniac.data.backup.api.BackupDestination
 import com.thomaskioko.tvmaniac.datastore.api.DatastoreRepository
 import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Inject
 public class AutoBackupTasksInitializer(
     private val scheduler: BackgroundTaskScheduler,
     private val backupDestination: Lazy<BackupDestination>,
     private val datastoreRepository: Lazy<DatastoreRepository>,
+    private val internetConnectionChecker: InternetConnectionChecker,
+    private val syncRestoredShowsInteractor: Lazy<SyncRestoredShowsInteractor>,
     private val logger: Logger,
     @IoCoroutineScope private val coroutineScope: CoroutineScope,
 ) {
@@ -41,6 +48,24 @@ public class AutoBackupTasksInitializer(
                         scheduler.cancel(AutoBackupWorker.WORKER_NAME)
                     }
                 }
+        }
+
+        coroutineScope.launch {
+            internetConnectionChecker.observeReconnection().collect {
+                withContext(NonCancellable) {
+                    runReconnectMetadataRefill()
+                }
+            }
+        }
+    }
+
+    private suspend fun runReconnectMetadataRefill() {
+        try {
+            syncRestoredShowsInteractor.value.executeSync()
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (throwable: Throwable) {
+            logger.warning(TAG, "Reconnect metadata refill failed", throwable)
         }
     }
 

--- a/domain/backup/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/backup/SyncRestoredShowsInteractor.kt
+++ b/domain/backup/src/commonMain/kotlin/com/thomaskioko/tvmaniac/domain/backup/SyncRestoredShowsInteractor.kt
@@ -9,13 +9,18 @@ import com.thomaskioko.tvmaniac.data.backup.api.BackupRepository
 import com.thomaskioko.tvmaniac.data.backup.api.ShowRefillReporter
 import com.thomaskioko.tvmaniac.domain.showdetails.SyncShowMetadataInteractor
 import com.thomaskioko.tvmaniac.shows.api.ShowTraktIdResolver
+import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 @Inject
+@SingleIn(AppScope::class)
 public class SyncRestoredShowsInteractor(
     private val backupRepository: BackupRepository,
     private val syncShowMetadataInteractor: SyncShowMetadataInteractor,
@@ -25,7 +30,11 @@ public class SyncRestoredShowsInteractor(
     private val logger: Logger,
 ) : Interactor<Unit>() {
 
-    override suspend fun doWork(params: Unit) {
+    private val refillMutex = Mutex()
+
+    override suspend fun doWork(params: Unit): Unit = refillMutex.withLock { refill() }
+
+    private suspend fun refill() {
         val showIds = backupRepository.showsNeedingMetadata()
         if (showIds.isEmpty()) {
             logger.debug(TAG, "No restored shows need metadata")

--- a/domain/backup/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/backup/AutoBackupTasksInitializerTest.kt
+++ b/domain/backup/src/commonTest/kotlin/com/thomaskioko/tvmaniac/domain/backup/AutoBackupTasksInitializerTest.kt
@@ -1,16 +1,26 @@
 package com.thomaskioko.tvmaniac.domain.backup
 
+import com.thomaskioko.tvmaniac.core.base.model.AppCoroutineDispatchers
+import com.thomaskioko.tvmaniac.core.connectivity.testing.FakeInternetConnectionChecker
 import com.thomaskioko.tvmaniac.core.logger.fixture.FakeLogger
 import com.thomaskioko.tvmaniac.core.tasks.testing.FakeBackgroundTaskScheduler
 import com.thomaskioko.tvmaniac.data.backup.testing.FakeBackupDestination
+import com.thomaskioko.tvmaniac.data.backup.testing.FakeBackupRepository
+import com.thomaskioko.tvmaniac.data.backup.testing.FakeShowRefillReporter
+import com.thomaskioko.tvmaniac.data.showdetails.testing.FakeShowDetailsRepository
+import com.thomaskioko.tvmaniac.data.watchproviders.testing.FakeWatchProviderRepository
 import com.thomaskioko.tvmaniac.datastore.api.AutoBackupInterval
 import com.thomaskioko.tvmaniac.datastore.testing.FakeDatastoreRepository
+import com.thomaskioko.tvmaniac.domain.showdetails.SyncShowMetadataInteractor
+import com.thomaskioko.tvmaniac.seasondetails.testing.FakeSeasonDetailsRepository
+import com.thomaskioko.tvmaniac.shows.testing.FakeShowTraktIdResolver
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -22,6 +32,29 @@ internal class AutoBackupTasksInitializerTest {
     private val scheduler = FakeBackgroundTaskScheduler()
     private val datastoreRepository = FakeDatastoreRepository()
     private val backupDestination = FakeBackupDestination()
+    private val internetConnectionChecker = FakeInternetConnectionChecker()
+    private val backupRepository = FakeBackupRepository()
+    private val showDetailsRepository = FakeShowDetailsRepository()
+    private val dispatchers = AppCoroutineDispatchers(
+        main = testDispatcher,
+        io = testDispatcher,
+        computation = testDispatcher,
+        databaseWrite = testDispatcher,
+        databaseRead = testDispatcher,
+    )
+    private val syncRestoredShowsInteractor = SyncRestoredShowsInteractor(
+        backupRepository = backupRepository,
+        syncShowMetadataInteractor = SyncShowMetadataInteractor(
+            showDetailsRepository = showDetailsRepository,
+            seasonDetailsRepository = FakeSeasonDetailsRepository(),
+            watchProviderRepository = FakeWatchProviderRepository(),
+            dispatchers = dispatchers,
+        ),
+        traktIdResolver = FakeShowTraktIdResolver(),
+        refillReporter = FakeShowRefillReporter(),
+        dispatchers = dispatchers,
+        logger = FakeLogger(),
+    )
 
     @AfterTest
     fun tearDown() {
@@ -33,9 +66,17 @@ internal class AutoBackupTasksInitializerTest {
             scheduler = scheduler,
             backupDestination = lazyOf(backupDestination),
             datastoreRepository = lazyOf(datastoreRepository),
+            internetConnectionChecker = internetConnectionChecker,
+            syncRestoredShowsInteractor = lazyOf(syncRestoredShowsInteractor),
             logger = FakeLogger(),
             coroutineScope = initializerScope,
         ).init()
+    }
+
+    private fun TestScope.reconnect() {
+        internetConnectionChecker.setConnected(false)
+        internetConnectionChecker.setConnected(true)
+        testScheduler.runCurrent()
     }
 
     @Test
@@ -164,9 +205,57 @@ internal class AutoBackupTasksInitializerTest {
         scheduler.getCancelledIds() shouldBe listOf(AutoBackupWorker.WORKER_NAME)
     }
 
+    @Test
+    fun `should run the metadata refill given a reconnect`() = runTest(testDispatcher) {
+        backupRepository.setShowsNeedingMetadata(listOf(SHOW_ID))
+
+        startInitializer()
+        testScheduler.advanceUntilIdle()
+        reconnect()
+
+        showDetailsRepository.fetchInvocations().map { it.id } shouldBe listOf(SHOW_ID)
+    }
+
+    @Test
+    fun `should run the metadata refill on reconnect given Sync and Update is off`() = runTest(testDispatcher) {
+        datastoreRepository.setBackgroundSyncEnabled(false)
+        backupRepository.setShowsNeedingMetadata(listOf(SHOW_ID))
+
+        startInitializer()
+        testScheduler.advanceUntilIdle()
+        reconnect()
+
+        showDetailsRepository.fetchInvocations().map { it.id } shouldBe listOf(SHOW_ID)
+    }
+
+    @Test
+    fun `should make no request on reconnect given no restored show needs metadata`() = runTest(testDispatcher) {
+        startInitializer()
+        testScheduler.advanceUntilIdle()
+        reconnect()
+
+        showDetailsRepository.fetchInvocations().shouldBeEmpty()
+    }
+
+    @Test
+    fun `should keep collecting reconnects given a show refill fails`() = runTest(testDispatcher) {
+        backupRepository.setShowsNeedingMetadata(listOf(SHOW_ID))
+        showDetailsRepository.setFetchError(RuntimeException("Boom"))
+
+        startInitializer()
+        testScheduler.advanceUntilIdle()
+        reconnect()
+
+        showDetailsRepository.setFetchError(null)
+        reconnect()
+
+        showDetailsRepository.fetchInvocations().map { it.id } shouldBe listOf(SHOW_ID, SHOW_ID)
+    }
+
     private companion object {
         private const val LOCATION = "content://downloads/tree"
         private const val DEFAULT_FOLDER = "/Documents"
+        private const val SHOW_ID = 7L
         private const val ONE_DAY_MS = 24L * 60 * 60 * 1000
         private const val SEVEN_DAYS_MS = 7 * ONE_DAY_MS
         private const val THIRTY_DAYS_MS = 30 * ONE_DAY_MS

--- a/features/root/presenter/README.md
+++ b/features/root/presenter/README.md
@@ -266,6 +266,7 @@ graph TB
   :domain:account-switcher --> :domain:library
   :domain:account-switcher --> :domain:user
   :domain:backup --> :core:base
+  :domain:backup --> :core:connectivity:api
   :domain:backup --> :core:logger:api
   :domain:backup --> :core:network-util:api
   :domain:backup --> :core:tasks:api

--- a/features/root/ui/README.md
+++ b/features/root/ui/README.md
@@ -274,6 +274,7 @@ graph TB
   :domain:account-switcher --> :domain:library
   :domain:account-switcher --> :domain:user
   :domain:backup --> :core:base
+  :domain:backup --> :core:connectivity:api
   :domain:backup --> :core:logger:api
   :domain:backup --> :core:network-util:api
   :domain:backup --> :core:tasks:api

--- a/features/settings/presenter/README.md
+++ b/features/settings/presenter/README.md
@@ -220,6 +220,7 @@ graph TB
   :domain:account-switcher --> :domain:library
   :domain:account-switcher --> :domain:user
   :domain:backup --> :core:base
+  :domain:backup --> :core:connectivity:api
   :domain:backup --> :core:logger:api
   :domain:backup --> :core:network-util:api
   :domain:backup --> :core:tasks:api

--- a/features/settings/ui/README.md
+++ b/features/settings/ui/README.md
@@ -227,6 +227,7 @@ graph TB
   :domain:account-switcher --> :domain:library
   :domain:account-switcher --> :domain:user
   :domain:backup --> :core:base
+  :domain:backup --> :core:connectivity:api
   :domain:backup --> :core:logger:api
   :domain:backup --> :core:network-util:api
   :domain:backup --> :core:tasks:api

--- a/ios-framework/README.md
+++ b/ios-framework/README.md
@@ -922,6 +922,7 @@ graph TB
   :domain:account-switcher --> :domain:library
   :domain:account-switcher --> :domain:user
   :domain:backup --> :core:base
+  :domain:backup --> :core:connectivity:api
   :domain:backup --> :core:logger:api
   :domain:backup --> :core:network-util:api
   :domain:backup --> :core:tasks:api


### PR DESCRIPTION
## Description
This PR fetches the details of restored shows when the device comes back online. A backup restore that loses the network part way through no longer waits up to twelve hours for the scheduled worker; the remaining shows get their details on the next reconnect, whether or not an account is connected.
